### PR TITLE
feat: Connect to geotiff.js web worker decoder Pool

### DIFF
--- a/examples/cog-basic/src/App.tsx
+++ b/examples/cog-basic/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from "react";
 import { Map, useControl, type MapRef } from "react-map-gl/maplibre";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import type { DeckProps } from "@deck.gl/core";
-import { fromUrl } from "geotiff";
+import { fromUrl, Pool } from "geotiff";
 import type { GeoTIFF } from "geotiff";
 import { COGLayer, GeoTIFFLayer } from "@developmentseed/deck.gl-cog";
 import proj4 from "proj4";
@@ -82,6 +82,7 @@ export default function App() {
   const [debug, setDebug] = useState(false);
   const [debugOpacity, setDebugOpacity] = useState(0.25);
   const [renderAsTiled, setRenderAsTiled] = useState(true);
+  const [pool] = useState<Pool>(new Pool());
 
   useEffect(() => {
     let mounted = true;
@@ -134,6 +135,7 @@ export default function App() {
           debug,
           debugOpacity,
           visible: renderAsTiled,
+          pool,
         }),
         new GeoTIFFLayer({
           id: "geotiff-layer",
@@ -142,6 +144,7 @@ export default function App() {
           debug,
           debugOpacity,
           visible: !renderAsTiled,
+          pool,
         }),
       ]
     : [];

--- a/packages/deck.gl-cog/src/cog-layer.ts
+++ b/packages/deck.gl-cog/src/cog-layer.ts
@@ -12,14 +12,14 @@ import {
   TileMatrixSet,
 } from "@developmentseed/deck.gl-raster";
 import type { ReprojectionFns } from "@developmentseed/raster-reproject";
-import type { GeoTIFF } from "geotiff";
+import type { GeoTIFF, Pool } from "geotiff";
 import proj4 from "proj4";
 import { parseCOGTileMatrixSet } from "./cog-tile-matrix-set.js";
 import {
   fromGeoTransform,
   getGeoTIFFProjection,
 } from "./geotiff-reprojection.js";
-import { loadRgbImage } from "./geotiff.js";
+import { defaultPool, loadRgbImage } from "./geotiff.js";
 
 // Workaround until upstream exposes props
 // https://github.com/visgl/deck.gl/pull/9917
@@ -29,6 +29,14 @@ const DEFAULT_MAX_ERROR = 0.125;
 
 export interface COGLayerProps extends CompositeLayerProps {
   geotiff: GeoTIFF;
+
+  /**
+   * GeoTIFF.js Pool for decoding image chunks.
+   *
+   * If none is provided, a default Pool will be created and shared between all
+   * COGLayer and GeoTIFFLayer instances.
+   */
+  pool?: Pool;
 
   /**
    * Maximum reprojection error in pixels for mesh refinement.
@@ -174,6 +182,7 @@ export class COGLayer extends CompositeLayer<COGLayerProps> {
 
         const { imageData, height, width } = await loadRgbImage(geotiffImage, {
           window,
+          pool: this.props.pool || defaultPool(),
         });
 
         return {

--- a/packages/deck.gl-cog/src/geotiff.ts
+++ b/packages/deck.gl-cog/src/geotiff.ts
@@ -1,6 +1,7 @@
 // Utilities for interacting with geotiff.js.
 
-import type { GeoTIFFImage, Pool, TypedArrayWithDimensions } from "geotiff";
+import type { GeoTIFFImage, TypedArrayWithDimensions } from "geotiff";
+import { Pool } from "geotiff";
 
 /**
  * Options that may be passed when reading image data from geotiff.js
@@ -15,6 +16,28 @@ type ReadRasterOptions = {
   /** An AbortSignal that may be signalled if the request is to be aborted */
   signal?: AbortSignal;
 };
+
+/**
+ * A default geotiff.js decoder pool instance.
+ *
+ * It will be created on first call of `defaultPool`.
+ */
+let DEFAULT_POOL: Pool | null = null;
+
+/**
+ * Retrieve the default geotiff.js decoder Pool.
+ *
+ * If a Pool has not yet been created, it will be created on first call.
+ *
+ * The Pool will be shared between all COGLayer and GeoTIFFLayer instances.
+ */
+export function defaultPool(): Pool {
+  if (DEFAULT_POOL === null) {
+    DEFAULT_POOL = new Pool();
+  }
+
+  return DEFAULT_POOL;
+}
 
 /**
  * Load an RGBA image from a GeoTIFFImage.


### PR DESCRIPTION
### Change list

- Add `pool` prop into `COGLayer` and `GeoTIFFLayer` to let users pass in a custom geotiff.js decoder pool, which decodes image chunks on a web worker instead of on the main thread.
- If a pool is not passed by a user, then we create a default worker pool in global scope and share it for all instances of these layers.
- In theory, we could allow something like `false` for the prop if the user explicitly didn't want to create web workers, but that can be for the future if anyone asks for it.

Closes https://github.com/developmentseed/deck.gl-raster/issues/53