### PR TITLE
fix: Don't try to read pixels outside image bounds

### DIFF
--- a/packages/deck.gl-cog/src/cog-layer.ts
+++ b/packages/deck.gl-cog/src/cog-layer.ts
@@ -148,6 +148,8 @@ export class COGLayer extends CompositeLayer<COGLayerProps> {
         const imageCount = await geotiff.getImageCount();
         // Select overview image
         const geotiffImage = await geotiff.getImage(imageCount - 1 - z);
+        const imageHeight = geotiffImage.getHeight();
+        const imageWidth = geotiffImage.getWidth();
 
         const tileMatrix = metadata.tileMatrices[z]!;
         const { tileWidth, tileHeight } = tileMatrix;
@@ -176,8 +178,8 @@ export class COGLayer extends CompositeLayer<COGLayerProps> {
         const window: [number, number, number, number] = [
           x * tileWidth,
           y * tileHeight,
-          (x + 1) * tileWidth,
-          (y + 1) * tileHeight,
+          Math.min((x + 1) * tileWidth, imageWidth),
+          Math.min((y + 1) * tileHeight, imageHeight),
         ];
 
         const { imageData, height, width } = await loadRgbImage(geotiffImage, {


### PR DESCRIPTION
Simple fix: we shouldn't be attempting to read outside the bounds of the image. We can just clamp the window read as necessary.

Closes https://github.com/developmentseed/deck.gl-raster/issues/65