### PR TITLE
feat: Pass AbortSignal from getTileData down to geotiff read fn

### DIFF
--- a/packages/deck.gl-cog/src/cog-layer.ts
+++ b/packages/deck.gl-cog/src/cog-layer.ts
@@ -153,6 +153,7 @@ export class COGLayer extends CompositeLayer<COGLayerProps> {
         pixelToInputCRS: ReprojectionFns["pixelToInputCRS"];
         inputCRSToPixel: ReprojectionFns["inputCRSToPixel"];
       }> => {
+        const { signal } = tile;
         const { x, y, z } = tile.index;
 
         // Select overview image
@@ -176,6 +177,7 @@ export class COGLayer extends CompositeLayer<COGLayerProps> {
 
         const { imageData, height, width } = await loadRgbImage(geotiffImage, {
           window,
+          signal,
           pool: this.props.pool || defaultPool(),
         });
 


### PR DESCRIPTION
When a user pans very quickly, deck.gl may make many requests for tiles. deck.gl will cancel the requests for tiles outside the current viewport that haven't finished. We should pass the signal on to the actual request being made in `geotiff.js` so that it will in turn cancel the request for us.

See upstream docs: https://deck.gl/docs/api-reference/geo-layers/tile-layer#gettiledata