### PR TITLE
ci: Set branch name for pnpm in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      # Explicitly check out the branch to pass pnpm's git branch check, which
+      # defaults to requiring being on master|main
+      - run: git checkout ${{ github.ref_name }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
       - run: pnpm build


### PR DESCRIPTION
This is to get around the error:

```
 ERR_PNPM_GIT_UNKNOWN_BRANCH  The Git HEAD may not attached to any branch, but your "publish-branch" is set to "master|main".
If you want to disable Git checks on publish, set the "git-checks" setting to "false", or run again with "--no-git-checks".
```