### PR TITLE
ci: Turn off git checks during pnpm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      # Explicitly check out the branch to pass pnpm's git branch check, which
-      # defaults to requiring being on master|main
-      - run: git checkout ${{ github.ref_name }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
       - run: pnpm build
@@ -29,7 +26,7 @@ jobs:
           # All packages are expected to have the same version
           VERSION=$(jq -r .version packages/deck.gl-raster/package.json)
           if [[ "$VERSION" == *alpha* || "$VERSION" == *beta* ]]; then
-            pnpm publish --recursive --tag beta
+            pnpm publish --recursive --no-git-checks --tag beta
           else
-            pnpm publish --recursive
+            pnpm publish --recursive --no-git-checks
           fi


### PR DESCRIPTION
Second try after https://github.com/developmentseed/deck.gl-raster/pull/74 to get past the error

```
 ERR_PNPM_GIT_UNKNOWN_BRANCH  The Git HEAD may not attached to any branch, but your "publish-branch" is set to "master|main".
If you want to disable Git checks on publish, set the "git-checks" setting to "false", or run again with "--no-git-checks".
```

when trying to publish