### PR TITLE
ci: Remove pnpm version from publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This failed because I also have the pnpm version saved in package.json:

https://github.com/developmentseed/deck.gl-raster/actions/runs/20351997654/job/58478667252
```
  Error: Multiple versions of pnpm specified:
    - version 10 in the GitHub Action config with the key "version"
    - version pnpm@10.25.0 in the package.json with the key "packageManager"
```