### PR TITLE
feat: Only load COGLayer at first in the example app

### DIFF
--- a/examples/cog-basic/src/App.tsx
+++ b/examples/cog-basic/src/App.tsx
@@ -128,24 +128,25 @@ export default function App() {
 
   const layers = geotiff
     ? [
-        new COGLayer({
-          id: "cog-layer",
-          geotiff,
-          maxError: 0.125,
-          debug,
-          debugOpacity,
-          visible: renderAsTiled,
-          pool,
-        }),
-        new GeoTIFFLayer({
-          id: "geotiff-layer",
-          geotiff,
-          maxError: 0.125,
-          debug,
-          debugOpacity,
-          visible: !renderAsTiled,
-          pool,
-        }),
+        renderAsTiled
+          ? new COGLayer({
+              id: "cog-layer",
+              geotiff,
+              maxError: 0.125,
+              debug,
+              debugOpacity,
+              visible: renderAsTiled,
+              pool,
+            })
+          : new GeoTIFFLayer({
+              id: "geotiff-layer",
+              geotiff,
+              maxError: 0.125,
+              debug,
+              debugOpacity,
+              visible: !renderAsTiled,
+              pool,
+            }),
       ]
     : [];
 


### PR DESCRIPTION
There's something about the GeoTIFFLayer that seems to block the main thread?