### PR TITLE
chore: Pin luma.gl in overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,14 @@
     "tsup": "^8.3.5",
     "typescript": "^5.7.2"
   },
+  "pnpm": {
+    "overrides": {
+      "deck.gl": "9.2.5",
+      "@deck.gl/*": "9.2.5",
+      "luma.gl": "9.2.5",
+      "@luma.gl/*": "9.2.5"
+    }
+  },
   "packageManager": "pnpm@10.25.0",
   "volta": {
     "node": "24.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  deck.gl: 9.2.5
+  '@deck.gl/*': 9.2.5
+  luma.gl: 9.2.5
+  '@luma.gl/*': 9.2.5
+
 importers:
 
   .:


### PR DESCRIPTION
As seen in the failing test here: https://github.com/developmentseed/deck.gl-raster/pull/99

If we have different versions of luma.gl, it'll error

> `luma.gl: Found luma.gl 9.2.4 while initialzing 9.2.5`
> `Error: luma.gl - multiple versions detected: see console log`