### PR TITLE
feat: Allow user-defined texture loader in COGLayer

### DIFF
--- a/packages/deck.gl-geotiff/src/geotiff-layer.ts
+++ b/packages/deck.gl-geotiff/src/geotiff-layer.ts
@@ -101,13 +101,13 @@ export class GeoTIFFLayer extends CompositeLayer<GeoTIFFLayerProps> {
       this.props.geoKeysParser!,
     );
     const image = await geotiff.getImage();
-    const { imageData, height, width } = await loadRgbImage(image, {
+    const { texture, height, width } = await loadRgbImage(image, {
       pool: this.props.pool || defaultPool(),
     });
 
     this.setState({
       reprojectionFns,
-      imageData,
+      imageData: texture,
       height,
       width,
     });

--- a/packages/deck.gl-geotiff/src/geotiff-types.ts
+++ b/packages/deck.gl-geotiff/src/geotiff-types.ts
@@ -4,10 +4,10 @@ import { globals } from "geotiff";
 export type ImageFileDirectory = {
   ImageWidth: number;
   ImageLength: number;
-  BitsPerSample: number[];
+  BitsPerSample: Uint16Array;
   Compression: number;
   PhotometricInterpretation: typeof globals.photometricInterpretations;
   SamplesPerPixel: number;
-  SampleFormat: number[];
+  SampleFormat: Uint16Array;
   PlanarConfiguration: number;
 };

--- a/packages/deck.gl-geotiff/src/geotiff.ts
+++ b/packages/deck.gl-geotiff/src/geotiff.ts
@@ -45,7 +45,7 @@ export function defaultPool(): Pool {
 export async function loadRgbImage(
   image: GeoTIFFImage,
   options?: ReadRasterOptions,
-): Promise<{ imageData: ImageData; height: number; width: number }> {
+): Promise<{ texture: ImageData; height: number; width: number }> {
   const mergedOptions = {
     ...options,
     interleave: true,
@@ -60,7 +60,7 @@ export async function loadRgbImage(
   const imageData = addAlphaChannel(rgbImage);
 
   return {
-    imageData,
+    texture: imageData,
     height: rgbImage.height,
     width: rgbImage.width,
   };

--- a/packages/deck.gl-geotiff/src/index.ts
+++ b/packages/deck.gl-geotiff/src/index.ts
@@ -10,3 +10,4 @@ export {
 export { loadRgbImage } from "./geotiff.js";
 
 export * as proj from "./proj.js";
+export * as texture from "./texture.js";

--- a/packages/deck.gl-geotiff/src/texture.ts
+++ b/packages/deck.gl-geotiff/src/texture.ts
@@ -32,8 +32,8 @@ export function createTextureProps(
  */
 function inferTextureFormat(
   samplesPerPixel: number,
-  bitsPerSample: number[],
-  sampleFormat: number[],
+  bitsPerSample: Uint16Array,
+  sampleFormat: Uint16Array,
 ): TextureFormat {
   const channelCount = verifySamplesPerPixel(samplesPerPixel);
   const bitWidth = verifyIdenticalBitsPerSample(bitsPerSample);
@@ -70,7 +70,7 @@ function verifySamplesPerPixel(samplesPerPixel: number): ChannelCount {
   );
 }
 
-function verifyIdenticalBitsPerSample(bitsPerSample: number[]): BitWidth {
+function verifyIdenticalBitsPerSample(bitsPerSample: Uint16Array): BitWidth {
   // bitsPerSamples is non-empty
   const first = bitsPerSample[0]!;
 
@@ -94,7 +94,7 @@ function verifyIdenticalBitsPerSample(bitsPerSample: number[]): BitWidth {
 /**
  * Map the geotiff tag SampleFormat to known kinds of scalars
  */
-function inferScalarKind(sampleFormat: number[]): ScalarKind {
+function inferScalarKind(sampleFormat: Uint16Array): ScalarKind {
   // Only support identical SampleFormats for all samples
   const first = sampleFormat[0]!;
 


### PR DESCRIPTION
Closes https://github.com/developmentseed/deck.gl-raster/issues/88

Pass in standard arguments, `GeoTIFFImage`, `bbox`, `signal`, `pool`, and returns a texture object.

The default implementation will be to just call `readRGB`, but this allows external users to customize how to transform to RGB.