### PR TITLE
fix: Ensure `loadTexture` returns `Texture`, not `TextureProps`

### DIFF
--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -13,7 +13,7 @@ import type {
 } from "@developmentseed/deck.gl-raster";
 import { RasterLayer, RasterTileset2D } from "@developmentseed/deck.gl-raster";
 import type { ReprojectionFns } from "@developmentseed/raster-reproject";
-import type { Device, TextureProps } from "@luma.gl/core";
+import type { Device, Texture } from "@luma.gl/core";
 import type { GeoTIFF, GeoTIFFImage, Pool } from "geotiff";
 import proj4 from "proj4";
 import { parseCOGTileMatrixSet } from "./cog-tile-matrix-set.js";
@@ -62,7 +62,7 @@ export interface COGLayerProps extends CompositeLayerProps {
    * The default implementation loads an RGBA image using geotiff.js's readRGB
    * method, returning an ImageData object.
    *
-   * For more customizability, you can also return a TextureProps object from
+   * For more customizability, you can also return a Texture object from
    * luma.gl, along with optional custom shaders for the RasterLayer.
    */
   loadTexture?: (
@@ -74,7 +74,7 @@ export interface COGLayerProps extends CompositeLayerProps {
       pool: Pool;
     },
   ) => Promise<{
-    texture: ImageData | TextureProps;
+    texture: ImageData | Texture;
     shaders?: RasterLayerProps["shaders"];
     height: number;
     width: number;
@@ -185,7 +185,7 @@ export class COGLayer extends CompositeLayer<COGLayerProps> {
       getTileData: async (
         tile,
       ): Promise<{
-        texture: ImageData | TextureProps;
+        texture: ImageData | Texture;
         shaders?: RasterLayerProps["shaders"];
         height: number;
         width: number;
@@ -245,7 +245,7 @@ export class COGLayer extends CompositeLayer<COGLayerProps> {
             pixelToInputCRS,
             inputCRSToPixel,
           }: {
-            texture: ImageData | TextureProps;
+            texture: ImageData | Texture;
             shaders?: RasterLayerProps["shaders"];
             height: number;
             width: number;


### PR DESCRIPTION
As discovered in https://github.com/developmentseed/deck.gl-raster/pull/102, I'm not sure why but passing in a `Texture` to `RasterLayer` works while passing down bare `TextureProps` _do not_. Because of this, we pass in `device` into the `loadTexture` so that the user callback can call `device.createTexture` and we change the type hint of the callback so it returns `Texture`.

Prep for https://github.com/developmentseed/deck.gl-raster/issues/109