### PR TITLE
chore: Make debug layer in RasterLayer non-pickable

### DIFF
--- a/packages/deck.gl-raster/src/raster-layer.ts
+++ b/packages/deck.gl-raster/src/raster-layer.ts
@@ -244,12 +244,13 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
             getFillColor: (d: ParsedTriangle) =>
               DEBUG_COLORS[d.idx % DEBUG_COLORS.length],
             getLineColor: [0, 0, 0],
-            getLineWidth: 0,
-            lineWidthMinPixels: 1,
+            getLineWidth: 1,
+            lineWidthUnits: "pixels",
             opacity:
               debugOpacity !== undefined && Number.isFinite(debugOpacity)
                 ? Math.max(0, Math.min(1, debugOpacity))
                 : 1,
+            pickable: false,
           }),
         );
         layers.push(debugLayer);


### PR DESCRIPTION
I was thinking this might help with the debug layer performance, but it doesn't seem to.

In any case it's a worthwhile edit for completeness.