### PR TITLE
wip: loaders.gl shim to allow passing input data via `data` prop

### DIFF
--- a/examples/land-cover/src/App.tsx
+++ b/examples/land-cover/src/App.tsx
@@ -254,7 +254,8 @@ export default function App() {
       ? [
           new COGLayer({
             id: "cog-layer",
-            geotiff,
+            data: COG_URL,
+            // geotiff,
             maxError: 0.125,
             debug,
             debugOpacity,

--- a/packages/deck.gl-geotiff/package.json
+++ b/packages/deck.gl-geotiff/package.json
@@ -42,6 +42,8 @@
     "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
   },
   "devDependencies": {
+    "@loaders.gl/core": "^4.3.4",
+    "@loaders.gl/loader-utils": "^4.3.4",
     "@types/node": "^25.0.1",
     "@typescript-eslint/eslint-plugin": "^8.16.0",
     "@typescript-eslint/parser": "^8.16.0",

--- a/packages/deck.gl-geotiff/src/loader.ts
+++ b/packages/deck.gl-geotiff/src/loader.ts
@@ -1,0 +1,71 @@
+/**
+ * Simple shim that implements the loaders.gl interface so that the user can
+ * pass a string into the data prop.
+ */
+import type { Loader, LoaderWithParser } from "@loaders.gl/core";
+import type { Source } from "@loaders.gl/loader-utils";
+import type { GeoTIFF } from "geotiff";
+
+/* ASCII I */
+const I = 0x49;
+
+/* ASCII M */
+const M = 0x4d;
+
+export const GeoTIFFLoader: LoaderWithParser<string> = {
+  id: "geotiff",
+  name: "GeoTIFF",
+  module: "geotiff",
+  version: "version",
+  worker: false,
+  extensions: ["tif", "tiff", "geotiff"],
+  mimeTypes: ["image/tiff", "image/geotiff"],
+  parse: async (arrayBuffer: ArrayBuffer): Promise<GeoTIFF> => {
+    console.log("parsing geotiff");
+    console.log(arrayBuffer);
+  },
+  // binary: false,
+  // text: true,
+  // tests: [testTIFFMagic],
+  // options: {
+  //   fetch: (input, info) => input,
+  //   geotiff: {
+  //     fetch: (input, init) => {
+  //       return input;
+  //     },
+  //   },
+  // },
+  // parseTextSync: (text: string) => text,
+};
+
+// function parseGeoTIFF(arrayBuffer: ArrayBuffer): Promise<GeoTIFF> {
+
+// }
+
+/**
+ * Test for TIFF magic bytes
+ *
+ * Magic bytes are either `II` or `MM` indicating little or big endian. Then the
+ * following bytes should be 42 for TIFF or 43 for BigTIFF.
+ */
+function testTIFFMagic(arrayBuffer: ArrayBuffer): boolean {
+  const byteArray = new Uint8Array(arrayBuffer);
+
+  const b0 = byteArray[0];
+  const b1 = byteArray[1];
+
+  // "II" = little endian, "MM" = big endian
+  const isLittleEndian = b0 === I && b1 === I;
+  const isBigEndian = b0 === M && b1 === M;
+
+  if (!isLittleEndian && !isBigEndian) {
+    return false;
+  }
+
+  const dataView = new DataView(arrayBuffer);
+
+  // 42 for classic TIFF, 43 for BigTIFF
+  const tiffVersion = dataView.getUint16(2, isLittleEndian);
+
+  return tiffVersion === 42 || tiffVersion === 43;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,12 @@ importers:
         specifier: ^2.20.2
         version: 2.20.2
     devDependencies:
+      '@loaders.gl/core':
+        specifier: ^4.3.4
+        version: 4.3.4
+      '@loaders.gl/loader-utils':
+        specifier: ^4.3.4
+        version: 4.3.4(@loaders.gl/core@4.3.4)
       '@types/node':
         specifier: ^25.0.1
         version: 25.0.1


### PR DESCRIPTION
Ideally we'd be able to use the `data` prop that most deck.gl layers use. However this doesn't seem possible because the data prop is explicitly tied to loaders.gl and loaders.gl loaders **always** attempt to load the full input URL. 

https://github.com/visgl/deck.gl/discussions/9931

Closes #131 