### PR TITLE
experiment: fast rendering of debug triangles using existing triangle mesh

### DIFF
--- a/packages/deck.gl-raster/src/raster-layer.ts
+++ b/packages/deck.gl-raster/src/raster-layer.ts
@@ -188,18 +188,6 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
     const positions = new Float64Array(reprojector.exactOutputPositions);
     const triangles = new Uint32Array(reprojector.triangles);
 
-    const getFillColor = new Uint8Array(numTriangles * 3 * 4);
-    for (let triangleIdx = 0; triangleIdx < numTriangles; triangleIdx++) {
-      const color = DEBUG_COLORS[triangleIdx % DEBUG_COLORS.length]!;
-      for (let colorIdx = 0; colorIdx < 3; colorIdx++) {
-        const i = triangleIdx * 4 + colorIdx;
-        getFillColor[i * 4] = color[0];
-        getFillColor[i * 4 + 1] = color[1];
-        getFillColor[i * 4 + 2] = color[2];
-        getFillColor[i * 4 + 3] = 255;
-      }
-    }
-
     const startIndices = new Uint32Array(numTriangles);
     for (let i = 0; i < numTriangles; i++) {
       startIndices[i] = i * 3;
@@ -211,14 +199,23 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
         _normalize: false,
         _windingOrder: "CCW",
         data: {
-          data: null,
           length: numTriangles,
           startIndices,
           attributes: {
             getPolygon: { value: positions, size: 2 },
             indices: { value: triangles, size: 1 },
-            getFillColor: { value: getFillColor, size: 4 },
           },
+        },
+        getFillColor: (
+          _: any,
+          { index, target }: { index: number; target: number[] },
+        ) => {
+          const color = DEBUG_COLORS[index % DEBUG_COLORS.length]!;
+          target[0] = color[0];
+          target[1] = color[1];
+          target[2] = color[2];
+          target[3] = 255;
+          return target;
         },
         opacity:
           debugOpacity !== undefined && Number.isFinite(debugOpacity)


### PR DESCRIPTION
All polygons in WebGL are rendered using a mesh. We're creating a mesh anyways for our raster rendering. Why create new polygons from scratch and then create new WebGL buffers when we could just reuse the triangle data we already have?

Well, that was my thought, but it doesn't look like it's working:

<img width="889" height="806" alt="image" src="https://github.com/user-attachments/assets/69e94923-a315-4762-8e14-5e704b86c942" />


I was trying to follow my existing work in deck.gl-layers: https://github.com/geoarrow/deck.gl-layers/blob/95d285014df2415cebddf6aafb442ed49117e5e6/packages/deck.gl-layers/src/layers/solid-polygon-layer.ts#L493-L512

