### PR TITLE
fix: throw error when maxError is non-positive

### DIFF
--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -37,8 +37,6 @@ import { epsgIoGeoKeyParser } from "./proj.js";
 // https://github.com/visgl/deck.gl/pull/9917
 type Tileset2DProps = any;
 
-const DEFAULT_MAX_ERROR = 0.125;
-
 /**
  * Minimum interface that **must** be returned from getTileData.
  */
@@ -164,9 +162,10 @@ export interface COGLayerProps<DataT extends MinimalDataT = DefaultDataT>
 }
 
 const defaultProps: Partial<COGLayerProps> = {
-  maxError: DEFAULT_MAX_ERROR,
   geoKeysParser: epsgIoGeoKeyParser,
   getTileData: loadRgbImage,
+  debug: false,
+  debugOpacity: 0.5,
   renderTile: (data) => {
     return data.texture;
   },
@@ -304,7 +303,7 @@ export class COGLayer<
     forwardReproject: ReprojectionFns["forwardReproject"],
     inverseReproject: ReprojectionFns["inverseReproject"],
   ): Layer | LayersList | null {
-    const { maxError, debug = false, debugOpacity = 0.5 } = this.props;
+    const { maxError, debug, debugOpacity } = this.props;
     const { tile } = props;
     const { data, forwardTransform, inverseTransform } = props.data;
 

--- a/packages/deck.gl-geotiff/src/geotiff-layer.ts
+++ b/packages/deck.gl-geotiff/src/geotiff-layer.ts
@@ -14,8 +14,6 @@ import { extractGeotiffReprojectors } from "./geotiff-reprojection.js";
 import type { GeoKeysParser, ProjectionInfo } from "./proj.js";
 import { epsgIoGeoKeyParser } from "./proj.js";
 
-const DEFAULT_MAX_ERROR = 0.125;
-
 export interface GeoTIFFLayerProps extends CompositeLayerProps {
   /**
    * GeoTIFF input.
@@ -90,7 +88,6 @@ export interface GeoTIFFLayerProps extends CompositeLayerProps {
 }
 
 const defaultProps = {
-  maxError: DEFAULT_MAX_ERROR,
   geoKeysParser: epsgIoGeoKeyParser,
 };
 

--- a/packages/deck.gl-raster/src/raster-layer.ts
+++ b/packages/deck.gl-raster/src/raster-layer.ts
@@ -82,8 +82,8 @@ export interface RasterLayerProps extends CompositeLayerProps {
 }
 
 const defaultProps = {
-  maxError: DEFAULT_MAX_ERROR,
   debug: false,
+  debugOpacity: 0.5,
 };
 
 /**

--- a/packages/raster-reproject/src/delatin.ts
+++ b/packages/raster-reproject/src/delatin.ts
@@ -27,6 +27,8 @@ const SAMPLE_POINTS: [number, number, number][] = [
   [0, 0.5, 0.5], // edge 1–2
 ];
 
+const DEFAULT_MAX_ERROR = 0.125;
+
 export interface ReprojectionFns {
   /**
    * Convert from UV coordinates to input CRS coordinates.
@@ -132,7 +134,11 @@ export class RasterReprojector {
   }
 
   // refine the mesh until its maximum error gets below the given one
-  run(maxError: number = 1): void {
+  run(maxError: number = DEFAULT_MAX_ERROR): void {
+    if (maxError <= 0) {
+      throw new Error("maxError must be positive");
+    }
+
     while (this.getMaxError() > maxError) {
       this.refine();
     }


### PR DESCRIPTION
- Throw error if maxError is <= 0. 
- Also ensure that we only define `DEFAULT_MAX_ERROR` in one place.

Closes #18 