### PR TITLE
feat: Stabler `renderPipeline` inference with props placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Fully client-side with direct image loading, no server required.
 ## Features
 
 - Client-side visualization with no server required.
-- Fast, GPU-enabled image processing:
+- GPU-based image processing:
     - Converting color spaces like CMYK, YCbCr, CIELAB to RGB.
     - Removing nodata values
     - Applying colormaps
+    - _Soon_: color correction, nodata masks, spectral band math, pixel filtering, etc.
+- Automatically-inferred render pipelines based on GeoTIFF metadata
+    - Or, customizable render pipelines with _no GPU knowledge required_.
 - GPU-based raster reprojection supports image sources from most projections [^1]
 - Intelligent COG rendering, only fetching the portions of the image required for the current view.
 
@@ -30,7 +33,7 @@ Fully client-side with direct image loading, no server required.
 This monorepo contains the following packages, each of which are published to NPM:
 
 - [`@developmentseed/deck.gl-geotiff`](#developmentseeddeckgl-geotiff)
-- [`@developmentseed/deck.gl-zarr`](#developmentseeddeckgl-zarr)
+- [`@developmentseed/deck.gl-zarr`](#developmentseeddeckgl-zarr) (_soon_)
 - [`@developmentseed/deck.gl-raster`](#developmentseeddeckgl-raster)
 - [`@developmentseed/raster-reproject`](#developmentseedraster-reproject)
 

--- a/packages/deck.gl-raster/src/gpu-modules/types.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/types.ts
@@ -1,7 +1,11 @@
+import type { Texture } from "@luma.gl/core";
 import type { ShaderModule } from "@luma.gl/shadertools";
 
 export type RasterModule<
-  PropsT extends Record<string, any> = Record<string, any>,
+  PropsT extends Record<string, number | Texture> = Record<
+    string,
+    number | Texture
+  >,
 > = {
   module: ShaderModule<PropsT>;
   props?: Partial<PropsT>;


### PR DESCRIPTION
Keeping a placeholder for how to handle the data to be later fetched by `getTileData` is a lot more elegant than just inserting a new module at the beginning.

Questions:

- Should we make a new type "UnresolvedRasterModule" that explicitly allows a function as the value as a prop?
- Can we be smart with these generics? Ensure that the type returned from `getTileData` must be the same as the type passed in to the raster module prop function?
- Can we improve the type hint of `RasterModule` to say that only numbers and textures are valid values of the properties object?

Closes https://github.com/developmentseed/deck.gl-raster/issues/141