### PR TITLE
chore: add monorepo version

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  ".": "0.1.0",
   "packages/deck.gl-geotiff": "0.1.0",
   "packages/deck.gl-raster": "0.1.0",
   "packages/deck.gl-zarr": "0.1.0",


### PR DESCRIPTION
The first release PR put the monorepo at v1.0.0 b/c I forgot to add the version to the manifest: https://github.com/developmentseed/deck.gl-raster/pull/200.