### PR TITLE
chore: don't include monorepo component in tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
   "prerelease": false,
   "packages": {
     ".": {
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false
     },
     "packages/deck.gl-geotiff": {
       "skip-changelog": true


### PR DESCRIPTION
We need monorepo tags for **release-please** to work correctly, so instead we'll just exclude the `monorepo` component from the tag.