### PR TITLE
feat: Call `onError` callback on GeoTIFF parsing errors

### DIFF
--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -212,7 +212,14 @@ export class COGLayer<
       Boolean(changeFlags.dataChanged) || props.geotiff !== oldProps.geotiff;
 
     if (needsUpdate) {
-      this._parseGeoTIFF();
+      try {
+        this._parseGeoTIFF();
+      } catch (error) {
+        if (error instanceof Error) {
+          this.props.onError?.(error);
+        }
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
Not exactly sure how I should be handling errors inside of the layer

Closes #205 

cc @gadomski just brainstorming