### PR TITLE
fix: Update release script to fetch submodules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          submodules: true
       - uses: pnpm/action-setup@v4
       - name: Use Node.js 20
         uses: actions/setup-node@v6


### PR DESCRIPTION
Otherwise, `pnpm build` fails to find the JSON spec files described in tsconfig.json