### PR TITLE
feat: Add AbortSignal support to `GeoTIFF.fetchTile`

### DIFF
--- a/packages/deck.gl-geotiff/package.json
+++ b/packages/deck.gl-geotiff/package.json
@@ -46,7 +46,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@cogeotiff/core": "^9.1.2",
+    "@cogeotiff/core": "^9.2.0",
     "@developmentseed/affine": "workspace:^",
     "@developmentseed/deck.gl-raster": "workspace:^",
     "@developmentseed/geotiff": "workspace:^",

--- a/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
@@ -126,9 +126,8 @@ function createUnormPipeline(
     image: GeoTIFF | Overview,
     options: GetTileDataOptions,
   ) => {
-    const { device, x, y } = options;
-    // TODO: pass down signal
-    const tile = await image.fetchTile(x, y);
+    const { device, x, y, signal } = options;
+    const tile = await image.fetchTile(x, y, { signal });
     let { array } = tile;
 
     let numSamples = samplesPerPixel;

--- a/packages/geotiff/package.json
+++ b/packages/geotiff/package.json
@@ -50,7 +50,7 @@
     "@chunkd/source": "^11.1.0",
     "@chunkd/source-http": "^11.1.1",
     "@chunkd/source-memory": "^11.0.2",
-    "@cogeotiff/core": "^9.1.2",
+    "@cogeotiff/core": "^9.2.0",
     "@developmentseed/affine": "workspace:^",
     "@developmentseed/morecantile": "workspace:^",
     "uuid": "^13.0.0"

--- a/packages/geotiff/src/fetch.ts
+++ b/packages/geotiff/src/fetch.ts
@@ -27,18 +27,17 @@ interface HasTiffReference extends HasTransform {
   readonly nodata: number | null;
 }
 
-// TODO: add AbortSignal support.
-// https://github.com/blacha/cogeotiff/issues/1397
 export async function fetchTile(
   self: HasTiffReference,
   x: number,
   y: number,
+  options: { signal?: AbortSignal } = {},
 ): Promise<Tile> {
   if (self.maskImage != null) {
     throw new Error("Mask fetching not implemented yet");
   }
 
-  const tile = await self.image.getTile(x, y);
+  const tile = await self.image.getTile(x, y, options);
   if (tile === null) {
     throw new Error("Tile not found");
   }

--- a/packages/geotiff/src/geotiff.ts
+++ b/packages/geotiff/src/geotiff.ts
@@ -264,10 +264,12 @@ export class GeoTIFF {
   // Mixins
 
   /** Fetch a single tile from the full-resolution image. */
-  // TODO: support AbortSignal
-  // https://github.com/blacha/cogeotiff/issues/1397
-  async fetchTile(x: number, y: number): Promise<Tile> {
-    return await fetchTile(this, x, y);
+  async fetchTile(
+    x: number,
+    y: number,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<Tile> {
+    return await fetchTile(this, x, y, options);
   }
 
   // Transform mixin

--- a/packages/geotiff/src/overview.ts
+++ b/packages/geotiff/src/overview.ts
@@ -70,10 +70,12 @@ export class Overview {
   }
 
   /** Fetch a single tile from the full-resolution image. */
-  // TODO: support AbortSignal
-  // https://github.com/blacha/cogeotiff/issues/1397
-  async fetchTile(x: number, y: number): Promise<Tile> {
-    return await fetchTile(this, x, y);
+  async fetchTile(
+    x: number,
+    y: number,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<Tile> {
+    return await fetchTile(this, x, y, options);
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,8 +241,8 @@ importers:
   packages/deck.gl-geotiff:
     dependencies:
       '@cogeotiff/core':
-        specifier: ^9.1.2
-        version: 9.1.2
+        specifier: ^9.2.0
+        version: 9.2.0
       '@deck.gl/core':
         specifier: 9.2.7
         version: 9.2.7
@@ -391,8 +391,8 @@ importers:
         specifier: ^11.0.2
         version: 11.0.2
       '@cogeotiff/core':
-        specifier: ^9.1.2
-        version: 9.1.2
+        specifier: ^9.2.0
+        version: 9.2.0
       '@developmentseed/affine':
         specifier: workspace:^
         version: link:../affine
@@ -642,8 +642,8 @@ packages:
     resolution: {integrity: sha512-3BcrHK4XDm3t4vDx1OisgcOZ05+EarEqwaGVIL7IMHUmkXwN/Aprlnr7aVP3BYcltgcCcfMd1pXQicbSrP563g==}
     engines: {node: '>=16.0.0'}
 
-  '@cogeotiff/core@9.1.2':
-    resolution: {integrity: sha512-m1F9glmz8zxxfDyqVnOQibF/uIZciequ1576zy6FG1rCcXVtLhE3qERT1GcS79K/dKvf+B+imgEmV2qfl6TdJQ==}
+  '@cogeotiff/core@9.2.0':
+    resolution: {integrity: sha512-DEgX7dUgiuT+Zb7WUNH+BzRQoeDsK7QzqIE+8x9bWYoDbeC4FnRY1Fwgrdwve+T3EHHiw48esCk+mPV2jnuD4A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   '@csstools/color-helpers@5.1.0':
@@ -2826,7 +2826,7 @@ snapshots:
 
   '@chunkd/source@11.1.0': {}
 
-  '@cogeotiff/core@9.1.2': {}
+  '@cogeotiff/core@9.2.0': {}
 
   '@csstools/color-helpers@5.1.0': {}
 


### PR DESCRIPTION
Now that upstream has AbortSignal support (https://github.com/blacha/cogeotiff/releases/tag/core-v9.2.0) we can expose an `signal: AbortSignal` parameter to `fetchTile`

BEGIN_COMMIT_OVERRIDE
feat: feat: Add AbortSignal support to GeoTIFF.fetchTile

Release-As: 0.3.0-beta.2
END_COMMIT_OVERRIDE