### PR TITLE
chore: Update code for new upstream `SamplesPerPixel` typing

### DIFF
--- a/packages/geotiff/src/fetch.ts
+++ b/packages/geotiff/src/fetch.ts
@@ -55,9 +55,7 @@ export async function fetchTile(
     translation(x * self.tileWidth, y * self.tileHeight),
   );
 
-  // https://github.com/blacha/cogeotiff/pull/1394
-  const samplesPerPixel =
-    (self.image.value(TiffTag.SamplesPerPixel) as number) ?? 1;
+  const samplesPerPixel = self.image.value(TiffTag.SamplesPerPixel) ?? 1;
 
   const decodedPixels = await decode(bytes, compression, {
     sampleFormat,

--- a/packages/geotiff/src/geotiff.ts
+++ b/packages/geotiff/src/geotiff.ts
@@ -221,7 +221,7 @@ export class GeoTIFF {
 
   /** Number of bands (samples per pixel). */
   get count(): number {
-    return (this.image.value(TiffTag.SamplesPerPixel) as number) ?? 1;
+    return this.image.value(TiffTag.SamplesPerPixel) ?? 1;
   }
 
   /** Bounding box [minX, minY, maxX, maxY] in the CRS. */

--- a/packages/geotiff/src/ifd.ts
+++ b/packages/geotiff/src/ifd.ts
@@ -9,7 +9,7 @@ export interface CachedTags {
   nodata: number | null;
   photometric: TiffTagType[TiffTag.Photometric];
   sampleFormat: TiffTagType[TiffTag.SampleFormat];
-  samplesPerPixel: number; // TiffTagType[TiffTag.SamplesPerPixel];
+  samplesPerPixel: TiffTagType[TiffTag.SamplesPerPixel];
 }
 
 /** Pre-fetch TIFF tags for easier visualization. */
@@ -52,8 +52,7 @@ export async function prefetchTags(image: TiffImage): Promise<CachedTags> {
     // Uint is the default sample format according to the spec
     // https://web.archive.org/web/20240329145340/https://www.awaresystems.be/imaging/tiff/tifftags/sampleformat.html
     sampleFormat: sampleFormat ?? [SampleFormat.Uint],
-    // Waiting for release with https://github.com/blacha/cogeotiff/pull/1394
-    samplesPerPixel: samplesPerPixel as number,
+    samplesPerPixel,
   };
 }
 

--- a/packages/geotiff/tests/decode.test.ts
+++ b/packages/geotiff/tests/decode.test.ts
@@ -14,7 +14,7 @@ describe("decode", () => {
     const sampleFormat =
       (image.value(TiffTag.SampleFormat) as SampleFormat[] | null)?.[0] ??
       SampleFormat.Uint;
-    const samplesPerPixel = image.value(TiffTag.SamplesPerPixel) as number;
+    const samplesPerPixel = image.value(TiffTag.SamplesPerPixel) ?? 1;
 
     const result = await decode(tile!.bytes, tile!.compression, {
       sampleFormat,
@@ -43,7 +43,7 @@ describe("decode", () => {
     const sampleFormat =
       (image.value(TiffTag.SampleFormat) as SampleFormat[] | null)?.[0] ??
       SampleFormat.Uint;
-    const samplesPerPixel = image.value(TiffTag.SamplesPerPixel) as number;
+    const samplesPerPixel = image.value(TiffTag.SamplesPerPixel) ?? 1;
 
     const result = await decode(tile!.bytes, tile!.compression, {
       sampleFormat,


### PR DESCRIPTION
Code cleanups to reflect new `SamplesPerPixel` type from https://github.com/blacha/cogeotiff/issues/1394 released in https://github.com/blacha/cogeotiff/releases/tag/core-v9.2.0