### PR TITLE
fix: skip inferRenderPipeline when user provides custom getTileData/renderTile

### DIFF
--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -249,8 +249,19 @@ export class COGLayer<
       });
     }
 
-    const { getTileData: defaultGetTileData, renderTile: defaultRenderTile } =
-      inferRenderPipeline(geotiff, this.context.device);
+    // inferRenderPipeline() throws for any SampleFormat other than Uint
+    // so only run if we need its output
+    let defaultGetTileData:
+      | COGLayerProps<TextureDataT>["getTileData"]
+      | undefined;
+    let defaultRenderTile:
+      | COGLayerProps<TextureDataT>["renderTile"]
+      | undefined;
+    if (!this.props.getTileData || !this.props.renderTile) {
+      const inferred = inferRenderPipeline(geotiff, this.context.device);
+      defaultGetTileData = inferred.getTileData;
+      defaultRenderTile = inferred.renderTile;
+    }
 
     this.setState({
       geotiff,


### PR DESCRIPTION
## Summary

- `COGLayer._parseGeoTIFF()` unconditionally calls `inferRenderPipeline()`, which throws for non-uint `SampleFormat` (e.g. Float32, Int), even when the user provides both `getTileData` and `renderTile` props
- This change skips the call when both custom callbacks are provided, since the inferred defaults are unused in that case

## Problem

When using `COGLayer` with a Float32 COG and custom `getTileData`/`renderTile`:

```
Inferring render pipeline for non-unsigned integers not yet supported. Found SampleFormat: 3,3,3,3,3
```

There's no workaround — the user has no way to use `COGLayer` with non-uint COGs, even with fully custom rendering.

## Fix

Guard `inferRenderPipeline()` behind a check for user-provided props. No behavior change for the default case (when either callback is missing, inference still runs as before).

Fixes #257