### PR TITLE
fix: Fix declared luma.gl dependency

### DIFF
--- a/packages/deck.gl-geotiff/package.json
+++ b/packages/deck.gl-geotiff/package.json
@@ -61,7 +61,7 @@
     "@deck.gl/geo-layers": "^9.2.7",
     "@deck.gl/layers": "^9.2.7",
     "@deck.gl/mesh-layers": "^9.2.7",
-    "@luma.gl/core": "^9.2.7"
+    "@luma.gl/core": "^9.2.6"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/deck.gl-raster/package.json
+++ b/packages/deck.gl-raster/package.json
@@ -56,8 +56,8 @@
     "@deck.gl/geo-layers": "^9.2.7",
     "@deck.gl/layers": "^9.2.7",
     "@deck.gl/mesh-layers": "^9.2.7",
-    "@luma.gl/core": "^9.2.7",
-    "@luma.gl/shadertools": "^9.2.7"
+    "@luma.gl/core": "^9.2.6",
+    "@luma.gl/shadertools": "^9.2.6"
   },
   "dependencies": {
     "@developmentseed/affine": "workspace:^",


### PR DESCRIPTION
It's weird that pnpm didn't tell me I was depending on a version of luma.gl that didn't exist, but I guess when you set `overrides` it doesn't even check that it's consistent with the version declared in `package.json` 🤷‍♂️ 

Closes https://github.com/developmentseed/deck.gl-raster/issues/264