### PR TITLE
fix: Fix `TileMatrixSetTileset` projected bounds computation for each tile

### DIFF
--- a/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
@@ -124,17 +124,12 @@ export class TileMatrixSetTileset extends Tileset2D {
     const { tileHeight, tileWidth } = tileMatrix;
     const tileAffine = tileTransform(tileMatrix, { col: x, row: y });
 
-    // Calculate pixel coordinates for this tile's extent
-    const pixelMinCol = x * tileWidth;
-    const pixelMinRow = y * tileHeight;
-    const pixelMaxCol = (x + 1) * tileWidth;
-    const pixelMaxRow = (y + 1) * tileHeight;
-
-    // Calculate the four corners of the tile in geographic coordinates
-    const topLeft = affine.apply(tileAffine, pixelMinCol, pixelMinRow);
-    const topRight = affine.apply(tileAffine, pixelMaxCol, pixelMinRow);
-    const bottomLeft = affine.apply(tileAffine, pixelMinCol, pixelMaxRow);
-    const bottomRight = affine.apply(tileAffine, pixelMaxCol, pixelMaxRow);
+    // tileAffine maps pixel (0,0) → top-left corner of this tile, so use
+    // local pixel coordinates (0..tileWidth, 0..tileHeight).
+    const topLeft = affine.apply(tileAffine, 0, 0);
+    const topRight = affine.apply(tileAffine, tileWidth, 0);
+    const bottomLeft = affine.apply(tileAffine, 0, tileHeight);
+    const bottomRight = affine.apply(tileAffine, tileWidth, tileHeight);
 
     // Return the projected bounds as four corners
     // This preserves rotation/skew information


### PR DESCRIPTION
We were unintentionally doubling the affine translation because we were applying _image pixel coordinates_ to the **tile's transform**. It would've been correct if we were applying image pixel coordinates to the _matrix's transform_. But in the general case a TMS might not have a single transform for the entire matrix, so we prefer using the tile transform.

Before:

<img width="1016" height="809" alt="image" src="https://github.com/user-attachments/assets/e02f53a0-4c57-429f-b44d-38b89af38547" />


After:

<img width="1238" height="767" alt="image" src="https://github.com/user-attachments/assets/280024c0-eba0-45f9-a726-94a306e7d75f" />
