### PR TITLE
chore: Remove unused deps from package.json

### DIFF
--- a/examples/cog-basic/package.json
+++ b/examples/cog-basic/package.json
@@ -14,13 +14,9 @@
     "@deck.gl/layers": "^9.2.7",
     "@deck.gl/mapbox": "^9.2.7",
     "@deck.gl/mesh-layers": "^9.2.7",
-    "@developmentseed/geotiff": "workspace:^",
     "@developmentseed/deck.gl-geotiff": "workspace:^",
-    "@developmentseed/deck.gl-raster": "workspace:^",
     "@luma.gl/core": "9.2.6",
-    "@luma.gl/shadertools": "9.2.6",
     "maplibre-gl": "^5.17.0",
-    "proj4": "^2.20.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-map-gl": "^8.1.0"

--- a/examples/land-cover/package.json
+++ b/examples/land-cover/package.json
@@ -15,13 +15,9 @@
     "@deck.gl/mapbox": "^9.2.7",
     "@deck.gl/mesh-layers": "^9.2.7",
     "@developmentseed/deck.gl-geotiff": "workspace:^",
-    "@developmentseed/deck.gl-raster": "workspace:^",
     "@luma.gl/core": "9.2.6",
-    "@luma.gl/shadertools": "9.2.6",
-    "geotiff": "^2.1.3",
     "geotiff-geokeys-to-proj4": "^2024.4.13",
     "maplibre-gl": "^5.17.0",
-    "proj4": "^2.20.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-map-gl": "^8.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,24 +58,12 @@ importers:
       '@developmentseed/deck.gl-geotiff':
         specifier: workspace:^
         version: link:../../packages/deck.gl-geotiff
-      '@developmentseed/deck.gl-raster':
-        specifier: workspace:^
-        version: link:../../packages/deck.gl-raster
-      '@developmentseed/geotiff':
-        specifier: workspace:^
-        version: link:../../packages/geotiff
       '@luma.gl/core':
         specifier: ^9.2.6
         version: 9.2.6
-      '@luma.gl/shadertools':
-        specifier: ^9.2.6
-        version: 9.2.6(@luma.gl/core@9.2.6)
       maplibre-gl:
         specifier: ^5.17.0
         version: 5.17.0
-      proj4:
-        specifier: ^2.20.2
-        version: 2.20.2
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -122,27 +110,15 @@ importers:
       '@developmentseed/deck.gl-geotiff':
         specifier: workspace:^
         version: link:../../packages/deck.gl-geotiff
-      '@developmentseed/deck.gl-raster':
-        specifier: workspace:^
-        version: link:../../packages/deck.gl-raster
       '@luma.gl/core':
         specifier: ^9.2.6
         version: 9.2.6
-      '@luma.gl/shadertools':
-        specifier: ^9.2.6
-        version: 9.2.6(@luma.gl/core@9.2.6)
-      geotiff:
-        specifier: ^2.1.3
-        version: 2.1.3
       geotiff-geokeys-to-proj4:
         specifier: ^2024.4.13
         version: 2024.4.13
       maplibre-gl:
         specifier: ^5.17.0
         version: 5.17.0
-      proj4:
-        specifier: ^2.20.2
-        version: 2.20.2
       react:
         specifier: ^19.2.4
         version: 19.2.4


### PR DESCRIPTION
I used `npx depcheck` to check if there were any extra deps in `package.json` that weren't actually used.

Closes https://github.com/developmentseed/deck.gl-raster/issues/283, closes https://github.com/developmentseed/deck.gl-raster/issues/282