### PR TITLE
feat: Offset transform by half pixel for pixel-is-point raster type

### DIFF
--- a/packages/geotiff/src/geotiff.ts
+++ b/packages/geotiff/src/geotiff.ts
@@ -15,7 +15,7 @@ import type { CachedTags, GeoKeyDirectory } from "./ifd.js";
 import { extractGeoKeyDirectory, prefetchTags } from "./ifd.js";
 import { Overview } from "./overview.js";
 import type { Tile } from "./tile.js";
-import { index, xy } from "./transform.js";
+import { createTransform, index, xy } from "./transform.js";
 
 /**
  * A higher-level GeoTIFF abstraction built on @cogeotiff/core.
@@ -245,32 +245,14 @@ export class GeoTIFF {
    * Return the dataset's georeferencing transformation matrix.
    */
   get transform(): Affine {
-    const origin = this.image.origin;
-    const resolution = this.image.resolution;
-
-    // Check for rotation via ModelTransformation.
-    // This tag is pre-fetched by @cogeotiff/core during initialization,
-    // so value() is safe to call synchronously.
-    const modelTransformation: number[] | null = this.image.value(
-      TiffTag.ModelTransformation,
-    );
-
-    let b = 0; // row rotation
-    let d = 0; // column rotation
-
-    if (modelTransformation != null && modelTransformation.length >= 16) {
-      b = modelTransformation[1]!;
-      d = modelTransformation[4]!;
-    }
-
-    return [
-      resolution[0], // a: pixel width (x per col)
-      b, // b: row rotation
-      origin[0], // c: x origin
-      d, // d: column rotation
-      resolution[1], // e: pixel height (negative = north-up)
-      origin[1], // f: y origin
-    ];
+    const { modelPixelScale, modelTiepoint, modelTransformation } =
+      this.cachedTags;
+    return createTransform({
+      modelTiepoint,
+      modelPixelScale,
+      modelTransformation,
+      rasterType: this.gkd.rasterType,
+    });
   }
 
   // Mixins

--- a/packages/geotiff/src/ifd.ts
+++ b/packages/geotiff/src/ifd.ts
@@ -6,6 +6,9 @@ export interface CachedTags {
   bitsPerSample: Uint16Array;
   colorMap?: Uint16Array; // TiffTagType[TiffTag.ColorMap];
   compression: TiffTagType[TiffTag.Compression];
+  modelTiepoint: TiffTagType[TiffTag.ModelTiePoint] | null;
+  modelPixelScale: TiffTagType[TiffTag.ModelPixelScale] | null;
+  modelTransformation: TiffTagType[TiffTag.ModelTransformation] | null;
   nodata: number | null;
   photometric: TiffTagType[TiffTag.Photometric];
   /** https://web.archive.org/web/20240329145322/https://www.awaresystems.be/imaging/tiff/tifftags/photometricinterpretation.html */
@@ -28,6 +31,9 @@ export async function prefetchTags(image: TiffImage): Promise<CachedTags> {
   const [
     bitsPerSample,
     colorMap,
+    modelTiepoint,
+    modelPixelScale,
+    modelTransformation,
     photometric,
     planarConfiguration,
     predictor,
@@ -36,6 +42,9 @@ export async function prefetchTags(image: TiffImage): Promise<CachedTags> {
   ] = await Promise.all([
     image.fetch(TiffTag.BitsPerSample),
     image.fetch(TiffTag.ColorMap),
+    image.fetch(TiffTag.ModelTiePoint),
+    image.fetch(TiffTag.ModelPixelScale),
+    image.fetch(TiffTag.ModelTransformation),
     image.fetch(TiffTag.Photometric),
     image.fetch(TiffTag.PlanarConfiguration),
     image.fetch(TiffTag.Predictor),
@@ -67,6 +76,9 @@ export async function prefetchTags(image: TiffImage): Promise<CachedTags> {
     bitsPerSample: new Uint16Array(bitsPerSample),
     colorMap: colorMap ? new Uint16Array(colorMap as number[]) : undefined,
     compression,
+    modelTiepoint,
+    modelPixelScale,
+    modelTransformation,
     nodata,
     photometric,
     planarConfiguration,

--- a/packages/geotiff/src/transform.ts
+++ b/packages/geotiff/src/transform.ts
@@ -1,5 +1,65 @@
+import { RasterTypeKey } from "@cogeotiff/core";
 import type { Affine } from "@developmentseed/affine";
-import { apply, invert } from "@developmentseed/affine";
+import { apply, compose, invert, translation } from "@developmentseed/affine";
+
+export function createTransform({
+  modelTiepoint,
+  modelPixelScale,
+  modelTransformation,
+  rasterType,
+}: {
+  modelTiepoint: number[] | null;
+  modelPixelScale: number[] | null;
+  modelTransformation: number[] | null;
+  rasterType: RasterTypeKey | null;
+}): Affine {
+  let transform: Affine;
+  if (modelTiepoint && modelPixelScale) {
+    transform = createFromModelTiepointAndPixelScale(
+      modelTiepoint,
+      modelPixelScale,
+    );
+  } else if (modelTransformation) {
+    transform = createFromModelTransformation(modelTransformation);
+  } else {
+    throw new Error("The image does not have an affine transformation.");
+  }
+
+  // Offset transform by half pixel for point-interpreted rasters.
+  if (rasterType === RasterTypeKey.PixelIsPoint) {
+    transform = compose(transform, translation(-0.5, -0.5));
+  }
+
+  return transform;
+}
+
+function createFromModelTiepointAndPixelScale(
+  modelTiepoint: number[],
+  modelPixelScale: number[],
+): Affine {
+  const xOrigin = modelTiepoint[3]!;
+  const yOrigin = modelTiepoint[4]!;
+  const xResolution = modelPixelScale[0]!;
+  const yResolution = -modelPixelScale[1]!;
+
+  return [xResolution, 0, xOrigin, 0, yResolution, yOrigin];
+}
+
+function createFromModelTransformation(modelTransformation: number[]): Affine {
+  // ModelTransformation is a 4x4 matrix in row-major order
+  // [0  1  2  3 ]   [a  b  0  c]
+  // [4  5  6  7 ] = [d  e  0  f]
+  // [8  9  10 11]   [0  0  1  0]
+  // [12 13 14 15]   [0  0  0  1]
+  const xOrigin = modelTransformation[3]!;
+  const yOrigin = modelTransformation[7]!;
+  const rowRotation = modelTransformation[1]!;
+  const colRotation = modelTransformation[4]!;
+  const xResolution = modelTransformation[0]!;
+  const yResolution = modelTransformation[5]!;
+
+  return [xResolution, rowRotation, xOrigin, colRotation, yResolution, yOrigin];
+}
 
 /**
  * Interface for objects that have an affine transform.


### PR DESCRIPTION
### Change list

- In line with https://github.com/developmentseed/async-geotiff/pull/107, this changes the calculation of the transform to offset by a half pixel for images where a pixel is considered a point, not an area.

Closes https://github.com/developmentseed/deck.gl-raster/issues/110