### PR TITLE
fix: Ensure 4-byte alignment on texture buffers

### DIFF
--- a/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
@@ -148,8 +148,14 @@ function createUnormPipeline(
       bitsPerSample,
       sampleFormat,
     );
+    const bytesPerPixel = (bitsPerSample[0]! / 8) * numSamples;
     const texture = device.createTexture({
-      data: array.data,
+      data: padToAlignment(
+        array.data,
+        array.width,
+        array.height,
+        bytesPerPixel,
+      ),
       format: textureFormat,
       width: array.width,
       height: array.height,
@@ -245,4 +251,36 @@ function resolveModule<T>(m: UnresolvedRasterModule<T>, data: T): RasterModule {
   }
 
   return { module, props: resolvedProps };
+}
+
+/**
+ * WebGL's default `UNPACK_ALIGNMENT` is 4, meaning each row of pixel data must
+ * start on a 4-byte boundary.
+ *
+ * For textures with widths not divisible by 4, we need to pad each row to the
+ * next multiple of 4 bytes so WebGL doesn't reject the buffer as "too small".
+ *
+ * Returns the original array unchanged when no padding is needed.
+ */
+function padToAlignment(
+  data: ArrayBufferView,
+  width: number,
+  height: number,
+  bytesPerPixel: number,
+): Uint8Array {
+  const src = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  const rowBytes = width * bytesPerPixel;
+  const alignedRowBytes = Math.ceil(rowBytes / 4) * 4;
+  if (alignedRowBytes === rowBytes) {
+    return src;
+  }
+
+  const dst = new Uint8Array(alignedRowBytes * height);
+  for (let r = 0; r < height; r++) {
+    dst.set(
+      src.subarray(r * rowBytes, (r + 1) * rowBytes),
+      r * alignedRowBytes,
+    );
+  }
+  return dst;
 }


### PR DESCRIPTION


Closes https://github.com/developmentseed/deck.gl-raster/issues/237

With help from Claude:

----

Root cause: WebGL `UNPACK_ALIGNMENT=4`

WebGL's default pixel unpack alignment is 4 bytes. When uploading a texture, it expects each row of pixel data to start on a 4-byte boundary. For r8unorm (1 byte/pixel) — which is what palette images use — any tile whose width is not divisible by 4 will trigger the error.

Your image has tiles like:

- 459px wide (459 % 4 = 3) → WebGL expects rows padded to 460 bytes → needs 460×239 = 109,940 bytes, but we only provide 459×239 = 109,701 → "not big enough"
- 406px wide (406 % 4 = 2) → same problem
- 512px wide (512 % 4 = 0) → works fine, no error

Fix: `padToAlignment` in `render-pipeline.ts`

Before creating the texture, the pixel data is now padded so each row is rounded up to the next multiple of 4 bytes. For rows already on a 4-byte boundary (e.g. width=512 with 1bpp, or width=256 with 4bpp), it's a no-op — the original byte view is returned unchanged.

----

Updated rendering:

<img width="984" height="716" alt="image" src="https://github.com/user-attachments/assets/a8fbea5e-d645-4ae0-97a6-0ef2813c82c5" />
