### PR TITLE
fix: Fix adding alpha channel to uint16 image

### DIFF
--- a/packages/deck.gl-geotiff/src/geotiff/geotiff.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/geotiff.ts
@@ -28,12 +28,16 @@ export function addAlphaChannel(rgbImage: RasterArray): RasterArray {
     // Need to add alpha channel
 
     const rgbaLength = (rgbImage.data.length / 3) * 4;
-    const rgbaArray = new Uint8ClampedArray(rgbaLength);
+    const isUint16 = rgbImage.data instanceof Uint16Array;
+    const rgbaArray = isUint16
+      ? new Uint16Array(rgbaLength)
+      : new Uint8ClampedArray(rgbaLength);
+    const maxAlpha = isUint16 ? 65535 : 255;
     for (let i = 0; i < rgbImage.data.length / 3; ++i) {
       rgbaArray[i * 4] = rgbImage.data[i * 3]!;
       rgbaArray[i * 4 + 1] = rgbImage.data[i * 3 + 1]!;
       rgbaArray[i * 4 + 2] = rgbImage.data[i * 3 + 2]!;
-      rgbaArray[i * 4 + 3] = 255;
+      rgbaArray[i * 4 + 3] = maxAlpha;
     }
 
     return {


### PR DESCRIPTION
Testing with this image:
```
https://data.source.coop/tabaqat/riyadh-sentinel-rgb/Sentinel-2_Satellite_RGB_Riyadh.tif
```
in `addAlphaChannel` we were unintentionally casting to uint8clampedarray.

<img width="701" height="801" alt="image" src="https://github.com/user-attachments/assets/6bc4be05-3a1f-4427-a8bd-9d78eea1ff2b" />

Now we're able to render the data, though we should probably default 3-band input to RGB, even if the photometric interpretation says grayscale.