### PR TITLE
fix: Fix passing general layer props down to RasterLayer

### DIFF
--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -389,21 +389,23 @@ export class COGLayer<
       }
 
       layers.push(
-        new RasterLayer({
-          id: `${props.id}-raster`,
-          width,
-          height,
-          renderPipeline,
-          maxError,
-          reprojectionFns: {
-            forwardTransform,
-            inverseTransform,
-            forwardReproject: forwardTo4326,
-            inverseReproject: inverseFrom4326,
-          },
-          debug,
-          debugOpacity,
-        }),
+        new RasterLayer(
+          this.getSubLayerProps({
+            id: `${props.id}-raster`,
+            width,
+            height,
+            renderPipeline,
+            maxError,
+            reprojectionFns: {
+              forwardTransform,
+              inverseTransform,
+              forwardReproject: forwardTo4326,
+              inverseReproject: inverseFrom4326,
+            },
+            debug,
+            debugOpacity,
+          }),
+        ),
       );
     }
 


### PR DESCRIPTION
Ensure we use `this.getSubLayerProps` so that props like `opacity` get passed down to the `RasterLayer`

Closes https://github.com/developmentseed/deck.gl-raster/issues/325, Closes https://github.com/developmentseed/deck.gl-raster/issues/324