### PR TITLE
ci: Fix docs publish; fetch submodules

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
 
       - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
Should hopefully fix action failure in https://github.com/developmentseed/deck.gl-raster/actions/runs/22975698287/job/66703596143