### PR TITLE
feat: expose maxRequests on COGLayer

### DIFF
--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -41,12 +41,18 @@ import { epsgResolver } from "./proj.js";
  * Minimum interface that **must** be returned from getTileData.
  */
 export type MinimalDataT = {
+  /** The height of the tile in pixels. */
   height: number;
+  /** The width of the tile in pixels. */
   width: number;
+
+  /** Byte length of the data, used for cache eviction when `maxCacheByteSize` is set. */
+  byteLength?: number;
 };
 
 type DefaultDataT = MinimalDataT & {
   texture: Texture;
+  byteLength: number;
 };
 
 /** Options passed to `getTileData`. */
@@ -105,7 +111,10 @@ type COGLayerDataProps<DataT extends MinimalDataT> =
  */
 export type COGLayerProps<DataT extends MinimalDataT = DefaultDataT> =
   CompositeLayerProps &
-    Pick<TileLayerProps, "maxRequests"> &
+    Pick<
+      TileLayerProps,
+      "debounceTime" | "maxCacheSize" | "maxCacheByteSize" | "maxRequests"
+    > &
     COGLayerDataProps<DataT> & {
       /**
        * Cloud-optimized GeoTIFF input.
@@ -479,13 +488,19 @@ export class COGLayer<
       }
     }
 
+    const { maxRequests, maxCacheSize, maxCacheByteSize, debounceTime } =
+      this.props;
+
     return new TileLayer<GetTileDataResult<DataT>>({
       id: `cog-tile-layer-${this.id}`,
       TilesetClass: TileMatrixSetTilesetFactory,
       getTileData: async (tile) => this._getTileData(tile, geotiff, tms),
       renderSubLayers: (props) =>
         this._renderSubLayers(props, tms, forwardTo4326, inverseFrom4326),
-      maxRequests: this.props.maxRequests,
+      maxRequests,
+      maxCacheSize,
+      maxCacheByteSize,
+      debounceTime,
     });
   }
 

--- a/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
@@ -24,6 +24,7 @@ import { inferTextureFormat } from "./texture";
 export type TextureDataT = {
   height: number;
   width: number;
+  byteLength: number;
   texture: Texture;
   mask?: Texture;
 };
@@ -184,6 +185,7 @@ function createUnormPipeline(
       height,
       bytesPerPixel,
     });
+    let byteLength = textureData.byteLength;
     const texture = device.createTexture({
       data: textureData,
       format: textureFormat,
@@ -207,11 +209,13 @@ function createUnormPipeline(
         height,
         sampler: samplerOptions,
       });
+      byteLength += mask.byteLength;
     }
 
     return {
       texture,
       mask: maskTexture,
+      byteLength,
       height: array.height,
       width: array.width,
     };


### PR DESCRIPTION
This PR allows users to control concurrent tile fetch limits, matching the existing behavior in MosaicLayer.

Closes https://github.com/developmentseed/deck.gl-raster/issues/70