### PR TITLE
ci: Fix building examples as part of docs website generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,8 @@ jobs:
         run: |
           for dir in examples/*/; do
             example=$(basename "$dir")
-            pnpm --filter "$example" build
+            pkg_name=$(node -p "require('./$dir/package.json').name")
+            pnpm --filter "$pkg_name" build
             mkdir -p "docs/static/examples/$example"
             cp -r "$dir/dist/." "docs/static/examples/$example/"
           done


### PR DESCRIPTION
We have to pass package name to `pnpm --filter`, not directory name