### PR TITLE
ci: Fix publish script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+
+      # Create test data in geotiff-test-data so that tests pass
+      - uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          pixi-version: v0.63.2
+          working-directory: ./fixtures/geotiff-test-data
+
+      # NPY fixtures are generated from the GeoTIFF fixtures on demand with
+      # rasterio
+      - name: Create npy fixtures
+        working-directory: ./fixtures/geotiff-test-data
+        run: pixi run generate-npy
+
       - uses: pnpm/action-setup@v4
       - name: Use Node.js 20
         uses: actions/setup-node@v6


### PR DESCRIPTION
Ensure we build npy files so that `pnpm test` in the publish script succeeds