### PR TITLE
fix: fix setting default values for inherited props from TileLayer

### DIFF
--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -193,6 +193,7 @@ export type COGLayerProps<DataT extends MinimalDataT = DefaultDataT> =
     };
 
 const defaultProps: Partial<COGLayerProps> = {
+  ...TileLayer.defaultProps,
   epsgResolver,
   debug: false,
   debugOpacity: 0.5,


### PR DESCRIPTION
Follow up after https://github.com/developmentseed/deck.gl-raster/pull/333

If we don't set default props values ourselves, but we still pass down props into the `TileLayer`, then `undefined` will override the default value set in `TileLayer`