### PR TITLE
wip: image cutline/clamp UV bounds during mesh creation

### DIFF
--- a/packages/deck.gl-raster/src/raster-layer.ts
+++ b/packages/deck.gl-raster/src/raster-layer.ts
@@ -79,6 +79,22 @@ export interface RasterLayerProps extends CompositeLayerProps {
    */
   maxError?: number;
 
+  /**
+   * Minimum V (top edge) of the mesh in UV space [0, 1].
+   * Use to exclude rows at the top of the tile from meshing
+   * (e.g. when the tile touches lat +90° and the projection is undefined).
+   * @default 0
+   */
+  _vMin?: number;
+
+  /**
+   * Maximum V (bottom edge) of the mesh in UV space [0, 1].
+   * Use to exclude rows at the bottom of the tile from meshing
+   * (e.g. when the tile touches lat -90° and the projection is undefined).
+   * @default 1
+   */
+  _vMax?: number;
+
   /** If set, enables debug mode for visualizing the mesh and reprojection process. */
   debug?: boolean;
 
@@ -141,6 +157,8 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
       height,
       reprojectionFns,
       maxError = DEFAULT_MAX_ERROR,
+      _vMin,
+      _vMax,
     } = this.props;
 
     // The mesh is lined up with the upper and left edges of the raster. So if
@@ -154,6 +172,7 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
       reprojectionFns,
       width + 1,
       height + 1,
+      { _vMin, _vMax },
     );
     reprojector.run(maxError);
     const { indices, positions, texCoords } = reprojectorToMesh(reprojector);

--- a/packages/raster-reproject/src/delatin.ts
+++ b/packages/raster-reproject/src/delatin.ts
@@ -112,6 +112,7 @@ export class RasterReprojector {
     reprojectors: ReprojectionFns,
     width: number,
     height: number = width,
+    { _vMin = 0, _vMax = 1 }: { _vMin?: number; _vMax?: number } = {},
   ) {
     this.reprojectors = reprojectors;
     this.width = width;
@@ -131,12 +132,14 @@ export class RasterReprojector {
     this._pending = []; // triangles pending addition to queue
     this._pendingLen = 0;
 
-    // The two initial triangles cover the entire input texture in UV space, so
-    // they range from [0, 0] to [1, 1] in u and v.
+    // The two initial triangles cover the input texture UV space.
+    // _vMin/_vMax allow callers to exclude rows at the top/bottom edges
+    // (e.g. to avoid polar singularities when the tile touches lat ±90°).
     const u1 = 1;
-    const v1 = 1;
-    const p0 = this._addPoint(0, 0);
-    const p1 = this._addPoint(u1, 0);
+    const v0 = _vMin;
+    const v1 = _vMax;
+    const p0 = this._addPoint(0, v0);
+    const p1 = this._addPoint(u1, v0);
     const p2 = this._addPoint(0, v1);
     const p3 = this._addPoint(u1, v1);
 


### PR DESCRIPTION
Right now, our RasterReprojector always renders the entire input image. That is, the two initial triangles drawn span the entire bounds of the input image.

But sometimes this is not actually desired.

### rendering images near the poles in Web Mercator

For example, this branch started during exploration of #182. When rendering data from EPSG:4326 which, say it spans from (-180, -90, 180, 90). Well, -90 and +90 are outside of Web Mercator latitude bounds, which are ~ +-85.11. 

When we try to render such an image, we get very tall triangles near the poles, because essentially we never have enough triangles to accurately approximate the reprojection near the poles. The only reason why this renders at all is because we stop the delatin refinement after 10,000 iterations.

<img width="1258" height="862" alt="image" src="https://github.com/user-attachments/assets/f980d005-ca85-42b9-a1a0-b0bfea9413d4" />

Instead of using the full height of the image, we should probably just discard the image outside of 85.11, and not even try to render data there. 

### ~~Excluding parts of images that aren't intended to be rendered~~

Edit: This was implemented in a different way in https://github.com/developmentseed/deck.gl-raster/pull/424

I've considered this before but haven't written it down... I'd like to render [usgs-topo-tiler](https://github.com/kylebarron/usgs-topo-tiler) directly from the client. But those images have a "collar" that overlaps other adjacent images and isn't intended to be rendered. 

We can use this "cutline" to cut that out and not render it.

### What should the API be?

I want to think a bit more about this API before merging and making it public.

I think perhaps the RasterReprojector should support `uvBounds` which are allowed to be between 0 and 1. Not less than 0 and not greater than 1.

This assumes always a square cutline, but I think that's ok for now.

