### PR TITLE
feat: pass refinementStrategy prop down to deck.gl

### DIFF
--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -136,7 +136,11 @@ export type COGLayerProps<DataT extends MinimalDataT = DefaultDataT> =
   CompositeLayerProps &
     Pick<
       TileLayerProps,
-      "debounceTime" | "maxCacheSize" | "maxCacheByteSize" | "maxRequests"
+      | "debounceTime"
+      | "maxCacheSize"
+      | "maxCacheByteSize"
+      | "maxRequests"
+      | "refinementStrategy"
     > &
     COGLayerDataProps<DataT> & {
       /**
@@ -566,8 +570,13 @@ export class COGLayer<
       }
     }
 
-    const { maxRequests, maxCacheSize, maxCacheByteSize, debounceTime } =
-      this.props;
+    const {
+      maxRequests,
+      maxCacheSize,
+      maxCacheByteSize,
+      debounceTime,
+      refinementStrategy,
+    } = this.props;
 
     return new TileLayer<GetTileDataResult<DataT>>({
       id: `cog-tile-layer-${this.id}`,
@@ -582,10 +591,11 @@ export class COGLayer<
           forwardTo3857,
           inverseFrom3857,
         ),
-      maxRequests,
-      maxCacheSize,
-      maxCacheByteSize,
       debounceTime,
+      maxCacheByteSize,
+      maxCacheSize,
+      maxRequests,
+      refinementStrategy,
     });
   }
 


### PR DESCRIPTION
Simple follow up from https://github.com/developmentseed/deck.gl-raster/pull/333, now that we handle refinement strategies correctly. https://github.com/developmentseed/deck.gl-raster/pull/354