### PR TITLE
fix: Revert default behavior to send `cache: no-cache` header

### DIFF
--- a/packages/geotiff/src/geotiff.ts
+++ b/packages/geotiff/src/geotiff.ts
@@ -236,15 +236,7 @@ export class GeoTIFF {
       cacheSize = 1024 * 1024,
     }: { chunkSize?: number; cacheSize?: number } = {},
   ): Promise<GeoTIFF> {
-    // Bypass Chrome disk cache, which serializes multiple range requests to the
-    // same URL.
-    // https://www.chromium.org/developers/design-documents/network-stack/http-cache/
-    // > The cache implements a single writer - multiple reader lock so that
-    // > only one network request for the same resource is in flight at any
-    // > given time.
-    const source = new SourceHttp(url, {
-      cache: "public, no-store, s-maxage=86400",
-    });
+    const source = new SourceHttp(url, {});
 
     // Figure out optimal defaults in light of
     // https://github.com/blacha/cogeotiff/issues/1431


### PR DESCRIPTION
This change was originally made in https://github.com/developmentseed/deck.gl-raster/pull/341 as part of https://github.com/developmentseed/deck.gl-raster/issues/342, but I found that it broke handling of localhost urls, and found in https://github.com/developmentseed/deck.gl-raster/issues/342#issuecomment-4093456844 that some backends' CORS settings don't support this header.