### PR TITLE
fix: Move `lerc` to non-dev dependencies

### DIFF
--- a/packages/geotiff/package.json
+++ b/packages/geotiff/package.json
@@ -43,7 +43,6 @@
     "@developmentseed/geotiff": "workspace:^",
     "@types/node": "^25.3.3",
     "geotiff": "^3.0.4",
-    "lerc": "^4.0.4",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18",
     "wkt-parser": "^1.5.3"
@@ -61,6 +60,7 @@
     "@developmentseed/lzw-tiff-decoder": "^0.2.2",
     "@developmentseed/morecantile": "workspace:^",
     "fzstd": "^0.1.1",
+    "lerc": "^4.1.1",
     "uuid": "^13.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,6 +470,9 @@ importers:
       fzstd:
         specifier: ^0.1.1
         version: 0.1.1
+      lerc:
+        specifier: ^4.1.1
+        version: 4.1.1
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -486,9 +489,6 @@ importers:
       geotiff:
         specifier: ^3.0.4
         version: 3.0.4
-      lerc:
-        specifier: ^4.0.4
-        version: 4.0.4
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -5257,8 +5257,8 @@ packages:
   lerc@3.0.0:
     resolution: {integrity: sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==}
 
-  lerc@4.0.4:
-    resolution: {integrity: sha512-nHZH+ffiGPkgKUQtiZrljGUGV2GddvPcVTV5E345ZFncbKz+/rBIjDPrSxkiqW0EAtg1Jw7qAgRdaCwV+95Fow==}
+  lerc@4.1.1:
+    resolution: {integrity: sha512-rgMqdHK4+gIUnF80OkWyfRae2u1B96BT8ZAjbLB4xfxIdfCHQ9GOf17haZVCag+5X9WC+40hLNZPbwctFs2FPQ==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -13599,7 +13599,7 @@ snapshots:
 
   lerc@3.0.0: {}
 
-  lerc@4.0.4: {}
+  lerc@4.1.1: {}
 
   leven@3.1.0: {}
 


### PR DESCRIPTION


I had intended for lerc to be an "optional" dependency, but looks like just leaving it out of the dependency matrix doesn't work. https://github.com/developmentseed/stac-map/pull/366#discussion_r2982914674

This moves lerc to a main dependency, but still the dependency is loaded conditionally only when a LERC image is actually loaded.