### PR TITLE
perf: Cache the result of bounding volume computation per RasterTileNode

### DIFF
--- a/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
@@ -146,6 +146,17 @@ export class RasterTileNode {
   private projectTo3857: ProjectionFunction;
   private projectTo4326: ProjectionFunction;
 
+  /**
+   * A cached bounding volume for this tile, used for frustum culling
+   *
+   * This stores the result of `getBoundingVolume`.
+   */
+  private _boundingVolume?: {
+    /** The zrange used to compute this bounding volume. */
+    zRange: ZRange;
+    result: { boundingVolume: OrientedBoundingBox; commonSpaceBounds: Bounds };
+  };
+
   constructor(
     x: number,
     y: number,
@@ -408,6 +419,15 @@ export class RasterTileNode {
     zRange: ZRange,
     project: ((xyz: number[]) => number[]) | null,
   ): { boundingVolume: OrientedBoundingBox; commonSpaceBounds: Bounds } {
+    const cached = this._boundingVolume;
+    if (
+      cached &&
+      cached.zRange[0] === zRange[0] &&
+      cached.zRange[1] === zRange[1]
+    ) {
+      return cached.result;
+    }
+
     // Case 1: Globe view - need to construct an oriented bounding box from
     // reprojected sample points, but also using the `project` param
     if (project) {
@@ -425,7 +445,9 @@ export class RasterTileNode {
 
     // Case 4: Generic case - sample reference points and reproject to
     // Web Mercator, then convert to deck.gl common space
-    return this._getGenericBoundingVolume(zRange);
+    const result = this._getGenericBoundingVolume(zRange);
+    this._boundingVolume = { zRange, result };
+    return result;
   }
 
   /**


### PR DESCRIPTION
Not 100% sure this is necessary, but from some performance tracing it looked like a large amount of time sometimes happened in this function. 

Actually, thinking more about it, I think the performance hit was from GC load. And GC overflow can happen anywhere. It just happened that the bounding volume computation hit that. 

Still I think it's worth caching this because it should never change after first creation (unless we start passing in zRange)