### PR TITLE
fix: Fix black flash when panning

### DIFF
--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -494,7 +494,11 @@ export class COGLayer<
             id: `${props.id}-raster`,
             width,
             height,
-            image,
+            // Only pass image if defined — passing `undefined` explicitly overrides
+            // the default null and causes isAsyncPropLoading to return true briefly,
+            // which hides the parent tile placeholder and causes a black flash.
+            // https://github.com/developmentseed/deck.gl-raster/issues/376
+            ...(image !== undefined && { image }),
             renderPipeline,
             maxError,
             reprojectionFns,

--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -21,7 +21,9 @@ const defaultProps: DefaultProps<
   }
 > = {
   ...SimpleMeshLayer.defaultProps,
-  image: { type: "image", value: null, async: true },
+  // Note: putting `image` in defaultProps causes Maplibre to fail to render
+  // labels in interleaved mode 🤷‍♂️
+  // image: { type: "image", value: null, async: true },
   renderPipeline: { type: "array", value: [], compare: true },
 };
 


### PR DESCRIPTION
Passing `image: undefined` explicitly overrides the default `null` value of `image` and causes `isAsyncPropLoading` to return true briefly. This hides the parent tile placeholder and causes a black flash.

Closes https://github.com/developmentseed/deck.gl-raster/issues/376