### PR TITLE
feat: Print tile xyz index in COG Layer debug mode

### DIFF
--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -405,7 +405,6 @@ export class COGLayer<
       _offset: number;
       tile: Tile2DHeader<GetTileDataResult<DataT>>;
     },
-    tms: TileMatrixSet,
     forwardTo4326: ReprojectionFns["forwardReproject"],
     inverseFrom4326: ReprojectionFns["inverseReproject"],
     forwardTo3857: ReprojectionFns["forwardReproject"],
@@ -512,45 +511,12 @@ export class COGLayer<
 
     if (debug) {
       const { projectedCorners } = tile;
-
-      if (!projectedCorners || !tms) {
-        return [];
-      }
-
-      // Create a closed path in WGS84 projection around the tile bounds
-      //
-      // The tile has a `bbox` field which is already the bounding box in WGS84,
-      // but that uses `transformBounds` and densifies edges. So the corners of
-      // the bounding boxes don't line up with each other.
-      //
-      // In this case in the debug mode, it looks better if we ignore the actual
-      // non-linearities of the edges and just draw a box connecting the
-      // reprojected corners. In any case, the _image itself_ will be densified
-      // on the edges as a feature of the mesh generation.
-      const { topLeft, topRight, bottomRight, bottomLeft } = projectedCorners;
-      const topLeftWgs84 = forwardTo4326(topLeft[0], topLeft[1]);
-      const topRightWgs84 = forwardTo4326(topRight[0], topRight[1]);
-      const bottomRightWgs84 = forwardTo4326(bottomRight[0], bottomRight[1]);
-      const bottomLeftWgs84 = forwardTo4326(bottomLeft[0], bottomLeft[1]);
-
-      const path = [
-        topLeftWgs84,
-        topRightWgs84,
-        bottomRightWgs84,
-        bottomLeftWgs84,
-        topLeftWgs84,
-      ];
-
       layers.push(
-        new PathLayer({
-          id: `${this.id}-${tile.id}-bounds`,
-          data: [path],
-          getPath: (d) => d,
-          getColor: [255, 0, 0, 255], // Red
-          getWidth: 2,
-          widthUnits: "pixels",
-          pickable: false,
-        }),
+        this.renderDebugTileOutline(
+          `${this.id}-${tile.id}-bounds`,
+          projectedCorners,
+          forwardTo4326,
+        ),
       );
     }
 
@@ -591,7 +557,6 @@ export class COGLayer<
       renderSubLayers: (props) =>
         this._renderSubLayers(
           props,
-          tms,
           forwardTo4326,
           inverseFrom4326,
           forwardTo3857,
@@ -637,5 +602,45 @@ export class COGLayer<
       inverseFrom3857,
       geotiff,
     );
+  }
+
+  renderDebugTileOutline(
+    id: string,
+    projectedCorners: TileMetadata["projectedCorners"],
+    forwardTo4326: ReprojectionFns["forwardReproject"],
+  ) {
+    // Create a closed path in WGS84 projection around the tile bounds
+    //
+    // The tile has a `bbox` field which is already the bounding box in WGS84,
+    // but that uses `transformBounds` and densifies edges. So the corners of
+    // the bounding boxes don't line up with each other.
+    //
+    // In this case in the debug mode, it looks better if we ignore the actual
+    // non-linearities of the edges and just draw a box connecting the
+    // reprojected corners. In any case, the _image itself_ will be densified
+    // on the edges as a feature of the mesh generation.
+    const { topLeft, topRight, bottomRight, bottomLeft } = projectedCorners;
+    const topLeftWgs84 = forwardTo4326(topLeft[0], topLeft[1]);
+    const topRightWgs84 = forwardTo4326(topRight[0], topRight[1]);
+    const bottomRightWgs84 = forwardTo4326(bottomRight[0], bottomRight[1]);
+    const bottomLeftWgs84 = forwardTo4326(bottomLeft[0], bottomLeft[1]);
+
+    const path = [
+      topLeftWgs84,
+      topRightWgs84,
+      bottomRightWgs84,
+      bottomLeftWgs84,
+      topLeftWgs84,
+    ];
+
+    return new PathLayer({
+      id,
+      data: [path],
+      getPath: (d) => d,
+      getColor: [255, 0, 0, 255], // Red
+      getWidth: 2,
+      widthUnits: "pixels",
+      pickable: false,
+    });
   }
 }

--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -13,7 +13,7 @@ import type {
   _Tileset2DProps as Tileset2DProps,
 } from "@deck.gl/geo-layers";
 import { TileLayer } from "@deck.gl/geo-layers";
-import { PathLayer } from "@deck.gl/layers";
+import { PathLayer, TextLayer } from "@deck.gl/layers";
 import type {
   RenderTileResult,
   TileMetadata,
@@ -510,11 +510,10 @@ export class COGLayer<
     }
 
     if (debug) {
-      const { projectedCorners } = tile;
       layers.push(
-        this.renderDebugTileOutline(
+        ...this.renderDebugTileOutline(
           `${this.id}-${tile.id}-bounds`,
-          projectedCorners,
+          tile,
           forwardTo4326,
         ),
       );
@@ -606,9 +605,11 @@ export class COGLayer<
 
   renderDebugTileOutline(
     id: string,
-    projectedCorners: TileMetadata["projectedCorners"],
+    tile: Tile2DHeader<GetTileDataResult<DataT>> & TileMetadata,
     forwardTo4326: ReprojectionFns["forwardReproject"],
   ) {
+    const { projectedCorners } = tile;
+
     // Create a closed path in WGS84 projection around the tile bounds
     //
     // The tile has a `bbox` field which is already the bounding box in WGS84,
@@ -633,7 +634,27 @@ export class COGLayer<
       topLeftWgs84,
     ];
 
-    return new PathLayer({
+    const center = [
+      (topLeftWgs84[0] + bottomRightWgs84[0]) / 2,
+      (topLeftWgs84[1] + bottomRightWgs84[1]) / 2,
+    ];
+    const labelLayer = new TextLayer({
+      id: `${id}-label`,
+      data: [
+        {
+          position: center,
+          text: `x=${tile.index.x} y=${tile.index.y} z=${tile.index.z}`,
+        },
+      ],
+      getColor: [255, 255, 255, 255],
+      getSize: 24,
+      sizeUnits: "pixels",
+      outlineWidth: 3,
+      outlineColor: [0, 0, 0, 255],
+      fontSettings: { sdf: true },
+    });
+
+    const outlineLayer = new PathLayer({
       id,
       data: [path],
       getPath: (d) => d,
@@ -642,5 +663,7 @@ export class COGLayer<
       widthUnits: "pixels",
       pickable: false,
     });
+
+    return [outlineLayer, labelLayer];
   }
 }


### PR DESCRIPTION
This adds a text layer to add context for which tile is rendering where.

https://github.com/user-attachments/assets/8f4098b4-9fde-423e-9964-3dc6389fefd6

Closes https://github.com/developmentseed/deck.gl-raster/issues/107