### PR TITLE
feat: Initial, most basic GeoZarr example

### DIFF
--- a/examples/zarr-sentinel2-tci/README.md
+++ b/examples/zarr-sentinel2-tci/README.md
@@ -1,0 +1,21 @@
+# GeoZarr Sentinel-2 True Color Image
+
+## Setup
+
+1. Install dependencies from the repository root:
+   ```bash
+   pnpm install
+   ```
+
+2. Build the packages:
+   ```bash
+   pnpm build
+   ```
+
+3. Run the development server:
+   ```bash
+   cd examples/cog-basic
+   pnpm dev
+   ```
+
+4. Open your browser to http://localhost:3000

--- a/examples/zarr-sentinel2-tci/index.html
+++ b/examples/zarr-sentinel2-tci/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>COGLayer Example</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+      #root {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/zarr-sentinel2-tci/package.json
+++ b/examples/zarr-sentinel2-tci/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "deck.gl-zarr-sentinel2-tci",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "publish": "pnpm build && gh-pages -d dist -b gh-pages -e examples/zarr-sentinel2-tci"
+  },
+  "dependencies": {
+    "@deck.gl/core": "^9.2.10",
+    "@deck.gl/geo-layers": "^9.2.10",
+    "@deck.gl/layers": "^9.2.10",
+    "@deck.gl/mapbox": "^9.2.10",
+    "@deck.gl/mesh-layers": "^9.2.10",
+    "@developmentseed/deck.gl-zarr": "workspace:^",
+    "@luma.gl/core": "9.2.6",
+    "maplibre-gl": "^5.19.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-map-gl": "^8.1.0",
+    "zarrita": "^0.6.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
+    "gh-pages": "^6.3.0",
+    "vite": "^7.3.1"
+  }
+}

--- a/examples/zarr-sentinel2-tci/src/App.tsx
+++ b/examples/zarr-sentinel2-tci/src/App.tsx
@@ -25,10 +25,10 @@ export default function App() {
     debug,
     debugOpacity,
     onZarrLoad: () => {
-      // Bounds are [300000, 3990240, 409800, 4100040] in EPSG:32612 (UTM zone 12N)
-      // Center approx: lon=-111.5, lat=36.2 (Utah/Arizona area)
+      // Bounds are [499980, 4490220, 609780, 4600020] in EPSG:32618 (UTM zone 18N)
+      // Center approx: lon=-74, lat=40.7 (New York area)
       mapRef.current?.flyTo({
-        center: [-111.5, 36.2],
+        center: [-74, 41],
         zoom: 8,
         duration: 1000,
       });
@@ -40,9 +40,9 @@ export default function App() {
       <MaplibreMap
         ref={mapRef}
         initialViewState={{
-          longitude: -111.5,
-          latitude: 36.2,
-          zoom: 8,
+          longitude: -74,
+          latitude: 41,
+          zoom: 6,
         }}
         mapStyle="https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
       >

--- a/examples/zarr-sentinel2-tci/src/App.tsx
+++ b/examples/zarr-sentinel2-tci/src/App.tsx
@@ -12,6 +12,8 @@ function DeckGLOverlay(props: MapboxOverlayProps) {
   return null;
 }
 
+// Currently generated locally from
+// https://github.com/developmentseed/geozarr-examples/pull/36
 const ZARR_URL = "http://localhost:8080/TCI.zarr";
 
 export default function App() {

--- a/examples/zarr-sentinel2-tci/src/App.tsx
+++ b/examples/zarr-sentinel2-tci/src/App.tsx
@@ -1,51 +1,38 @@
-import type { DeckProps } from "@deck.gl/core";
+import type { MapboxOverlayProps } from "@deck.gl/mapbox";
 import { MapboxOverlay } from "@deck.gl/mapbox";
-import { COGLayer } from "@developmentseed/deck.gl-geotiff";
+import { ZarrLayer } from "@developmentseed/deck.gl-zarr";
 import "maplibre-gl/dist/maplibre-gl.css";
-import type { ReactNode } from "react";
 import { useRef, useState } from "react";
 import type { MapRef } from "react-map-gl/maplibre";
 import { Map as MaplibreMap, useControl } from "react-map-gl/maplibre";
 
-function DeckGLOverlay(props: DeckProps) {
+function DeckGLOverlay(props: MapboxOverlayProps) {
   const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));
   overlay.setProps(props);
   return null;
 }
 
-const COG_OPTIONS: { title: string; url: string; attribution?: ReactNode }[] = [
-  {
-    title: "Sentinel-2 TCI",
-    url: "http://localhost:8080/TCI.zarr/zarr.json",
-  },
-];
+const ZARR_URL = "http://localhost:8080/TCI.zarr";
 
 export default function App() {
   const mapRef = useRef<MapRef>(null);
   const [debug, setDebug] = useState(false);
   const [debugOpacity, setDebugOpacity] = useState(0.25);
-  const [selectedIndex, setSelectedIndex] = useState(0);
 
-  const cog_layer = new COGLayer({
-    id: "cog-layer",
-    geotiff: COG_OPTIONS[selectedIndex].url,
+  const zarrLayer = new ZarrLayer({
+    id: "zarr-layer",
+    source: ZARR_URL,
     debug,
     debugOpacity,
-    onGeoTIFFLoad: (tiff, options) => {
-      (window as any).tiff = tiff;
-      const { west, south, east, north } = options.geographicBounds;
-      mapRef.current?.fitBounds(
-        [
-          [west, south],
-          [east, north],
-        ],
-        {
-          padding: 40,
-          duration: 1000,
-        },
-      );
+    onZarrLoad: () => {
+      // Bounds are [300000, 3990240, 409800, 4100040] in EPSG:32612 (UTM zone 12N)
+      // Center approx: lon=-111.5, lat=36.2 (Utah/Arizona area)
+      mapRef.current?.flyTo({
+        center: [-111.5, 36.2],
+        zoom: 8,
+        duration: 1000,
+      });
     },
-    beforeId: "boundary_country_outline",
   });
 
   return (
@@ -53,18 +40,15 @@ export default function App() {
       <MaplibreMap
         ref={mapRef}
         initialViewState={{
-          longitude: 0,
-          latitude: 0,
-          zoom: 3,
-          pitch: 0,
-          bearing: 0,
+          longitude: -111.5,
+          latitude: 36.2,
+          zoom: 8,
         }}
         mapStyle="https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
       >
-        <DeckGLOverlay layers={[cog_layer]} interleaved />
+        <DeckGLOverlay layers={[zarrLayer]} interleaved />
       </MaplibreMap>
 
-      {/* UI Overlay Container */}
       <div
         style={{
           position: "absolute",
@@ -90,46 +74,17 @@ export default function App() {
           }}
         >
           <h3 style={{ margin: "0 0 8px 0", fontSize: "16px" }}>
-            COGLayer Example
+            ZarrLayer — Sentinel-2 TCI
           </h3>
-          <select
-            value={selectedIndex}
-            onChange={(e) => setSelectedIndex(Number(e.target.value))}
-            style={{
-              width: "100%",
-              padding: "4px",
-              cursor: "pointer",
-            }}
-          >
-            {COG_OPTIONS.map((opt, i) => (
-              <option key={opt.url} value={i}>
-                {opt.title}
-              </option>
-            ))}
-          </select>
-          {/* <p style={{ margin: "0 0 12px 0", fontSize: "14px", color: "#666" }}>
-            Displaying RGB imagery from New Zealand (NZTM2000 projection)
-          </p> */}
+          <p style={{ margin: "0 0 12px 0", fontSize: "12px", color: "#666" }}>
+            GeoZarr multiscale, EPSG:32612
+          </p>
 
-          {/* Attribution */}
-          {COG_OPTIONS[selectedIndex].attribution && (
-            <p
-              style={{
-                margin: "8px 0 0 0",
-                fontSize: "11px",
-                color: "#666",
-              }}
-            >
-              {COG_OPTIONS[selectedIndex].attribution}
-            </p>
-          )}
-
-          {/* Debug Controls */}
           <div
             style={{
               padding: "12px 0",
               borderTop: "1px solid #eee",
-              marginTop: "12px",
+              marginTop: "4px",
             }}
           >
             <label

--- a/examples/zarr-sentinel2-tci/src/App.tsx
+++ b/examples/zarr-sentinel2-tci/src/App.tsx
@@ -1,0 +1,184 @@
+import type { DeckProps } from "@deck.gl/core";
+import { MapboxOverlay } from "@deck.gl/mapbox";
+import { COGLayer } from "@developmentseed/deck.gl-geotiff";
+import "maplibre-gl/dist/maplibre-gl.css";
+import type { ReactNode } from "react";
+import { useRef, useState } from "react";
+import type { MapRef } from "react-map-gl/maplibre";
+import { Map as MaplibreMap, useControl } from "react-map-gl/maplibre";
+
+function DeckGLOverlay(props: DeckProps) {
+  const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));
+  overlay.setProps(props);
+  return null;
+}
+
+const COG_OPTIONS: { title: string; url: string; attribution?: ReactNode }[] = [
+  {
+    title: "Sentinel-2 TCI",
+    url: "http://localhost:8080/TCI.zarr/zarr.json",
+  },
+];
+
+export default function App() {
+  const mapRef = useRef<MapRef>(null);
+  const [debug, setDebug] = useState(false);
+  const [debugOpacity, setDebugOpacity] = useState(0.25);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const cog_layer = new COGLayer({
+    id: "cog-layer",
+    geotiff: COG_OPTIONS[selectedIndex].url,
+    debug,
+    debugOpacity,
+    onGeoTIFFLoad: (tiff, options) => {
+      (window as any).tiff = tiff;
+      const { west, south, east, north } = options.geographicBounds;
+      mapRef.current?.fitBounds(
+        [
+          [west, south],
+          [east, north],
+        ],
+        {
+          padding: 40,
+          duration: 1000,
+        },
+      );
+    },
+    beforeId: "boundary_country_outline",
+  });
+
+  return (
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <MaplibreMap
+        ref={mapRef}
+        initialViewState={{
+          longitude: 0,
+          latitude: 0,
+          zoom: 3,
+          pitch: 0,
+          bearing: 0,
+        }}
+        mapStyle="https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
+      >
+        <DeckGLOverlay layers={[cog_layer]} interleaved />
+      </MaplibreMap>
+
+      {/* UI Overlay Container */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          pointerEvents: "none",
+          zIndex: 1000,
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: "20px",
+            left: "20px",
+            background: "white",
+            padding: "16px",
+            borderRadius: "8px",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
+            maxWidth: "300px",
+            pointerEvents: "auto",
+          }}
+        >
+          <h3 style={{ margin: "0 0 8px 0", fontSize: "16px" }}>
+            COGLayer Example
+          </h3>
+          <select
+            value={selectedIndex}
+            onChange={(e) => setSelectedIndex(Number(e.target.value))}
+            style={{
+              width: "100%",
+              padding: "4px",
+              cursor: "pointer",
+            }}
+          >
+            {COG_OPTIONS.map((opt, i) => (
+              <option key={opt.url} value={i}>
+                {opt.title}
+              </option>
+            ))}
+          </select>
+          {/* <p style={{ margin: "0 0 12px 0", fontSize: "14px", color: "#666" }}>
+            Displaying RGB imagery from New Zealand (NZTM2000 projection)
+          </p> */}
+
+          {/* Attribution */}
+          {COG_OPTIONS[selectedIndex].attribution && (
+            <p
+              style={{
+                margin: "8px 0 0 0",
+                fontSize: "11px",
+                color: "#666",
+              }}
+            >
+              {COG_OPTIONS[selectedIndex].attribution}
+            </p>
+          )}
+
+          {/* Debug Controls */}
+          <div
+            style={{
+              padding: "12px 0",
+              borderTop: "1px solid #eee",
+              marginTop: "12px",
+            }}
+          >
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                fontSize: "14px",
+                cursor: "pointer",
+                marginBottom: "12px",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={debug}
+                onChange={(e) => setDebug(e.target.checked)}
+                style={{ cursor: "pointer" }}
+              />
+              <span>Show Debug Mesh</span>
+            </label>
+
+            {debug && (
+              <div style={{ marginTop: "8px" }}>
+                <label
+                  style={{
+                    display: "block",
+                    fontSize: "12px",
+                    color: "#666",
+                    marginBottom: "4px",
+                  }}
+                >
+                  Debug Opacity: {debugOpacity.toFixed(2)}
+                  <input
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.01"
+                    value={debugOpacity}
+                    onChange={(e) =>
+                      setDebugOpacity(parseFloat(e.target.value))
+                    }
+                    style={{ width: "100%", cursor: "pointer" }}
+                  />
+                </label>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/examples/zarr-sentinel2-tci/src/App.tsx
+++ b/examples/zarr-sentinel2-tci/src/App.tsx
@@ -24,15 +24,6 @@ export default function App() {
     source: ZARR_URL,
     debug,
     debugOpacity,
-    onZarrLoad: () => {
-      // Bounds are [499980, 4490220, 609780, 4600020] in EPSG:32618 (UTM zone 18N)
-      // Center approx: lon=-74, lat=40.7 (New York area)
-      mapRef.current?.flyTo({
-        center: [-74, 41],
-        zoom: 8,
-        duration: 1000,
-      });
-    },
   });
 
   return (
@@ -42,7 +33,7 @@ export default function App() {
         initialViewState={{
           longitude: -74,
           latitude: 41,
-          zoom: 6,
+          zoom: 8.5,
         }}
         mapStyle="https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
       >

--- a/examples/zarr-sentinel2-tci/src/main.tsx
+++ b/examples/zarr-sentinel2-tci/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/zarr-sentinel2-tci/tsconfig.json
+++ b/examples/zarr-sentinel2-tci/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/examples/zarr-sentinel2-tci/vite.config.ts
+++ b/examples/zarr-sentinel2-tci/vite.config.ts
@@ -1,0 +1,11 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  base: "/deck.gl-raster/examples/zarr-sentinel2-tci/",
+  worker: { format: "es" },
+  server: {
+    port: 3000,
+  },
+});

--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -13,7 +13,6 @@ import type {
   _Tileset2DProps as Tileset2DProps,
 } from "@deck.gl/geo-layers";
 import { TileLayer } from "@deck.gl/geo-layers";
-import { PathLayer, TextLayer } from "@deck.gl/layers";
 import type {
   RenderTileResult,
   TileMetadata,
@@ -21,6 +20,7 @@ import type {
 import {
   RasterLayer,
   RasterTileset2D,
+  _renderDebugTileOutline as renderDebugTileOutline,
   TileMatrixSetAdaptor,
 } from "@developmentseed/deck.gl-raster";
 import type { DecoderPool, GeoTIFF, Overview } from "@developmentseed/geotiff";
@@ -421,100 +421,10 @@ export class COGLayer<
     const tile = props.tile as Tile2DHeader<GetTileDataResult<DataT>> &
       TileMetadata;
 
-    if (!props.data) {
-      return null;
-    }
-
-    const { data, forwardTransform, inverseTransform } = props.data;
-
     const layers: Layer[] = [];
-
-    if (data) {
-      const { height, width } = data;
-
-      let tileResult: RenderTileResult;
-      if (this.props.getTileData) {
-        // In the case that the user passed in a custom `getTileData`, TS knows
-        // that `data` can be passed in to `renderTile`.
-        tileResult = this.props.renderTile(data);
-      } else {
-        // In the default case, `data` is `DefaultDataT` — cast required because
-        // TS can't prove that `DataT` (which defaults to `DefaultDataT`) is
-        // `DefaultDataT` at this point.
-        tileResult = this.state.defaultRenderTile!(
-          data as unknown as DefaultDataT,
-        );
-      }
-      const { image, renderPipeline } = tileResult;
-
-      // viewport.resolution is defined for GlobeView, undefined for WebMercatorViewport.
-      // For WebMercator we project the mesh to EPSG:3857 and use a model matrix
-      // to map from 3857 meters to deck.gl world space, matching the approach
-      // used by the MVTLayer. This avoids per-vertex WGS84→WebMercator linear
-      // interpolation errors that become visible at high latitudes.
-      const isGlobe = this.context.viewport.resolution !== undefined;
-      let reprojectionFns: ReprojectionFns;
-      let deckProjectionProps: Partial<LayerProps>;
-
-      if (isGlobe) {
-        reprojectionFns = {
-          forwardTransform,
-          inverseTransform,
-          forwardReproject: forwardTo4326,
-          inverseReproject: inverseFrom4326,
-        };
-        deckProjectionProps = {};
-      } else {
-        reprojectionFns = {
-          forwardTransform,
-          inverseTransform,
-          forwardReproject: forwardTo3857,
-          inverseReproject: inverseFrom3857,
-        };
-        // Scale 3857 meters → deck.gl world units (512×512).
-        //
-        // coordinateOrigin shifts the world-space origin to (256, 256) so that
-        // easting=0 / northing=0 maps to world center. Then the modelMatrix
-        //
-        // No Y-flip needed: CARTESIAN Y increases upward = northing.
-        deckProjectionProps = {
-          coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
-          coordinateOrigin: [TILE_SIZE / 2, TILE_SIZE / 2, 0],
-          // biome-ignore format: array
-          modelMatrix: [
-            WEB_MERCATOR_TO_WORLD_SCALE, 0, 0, 0,
-            0, WEB_MERCATOR_TO_WORLD_SCALE, 0, 0,
-            0, 0, 1, 0,
-            0, 0, 0, 1
-          ],
-        };
-      }
-
-      layers.push(
-        new RasterLayer(
-          this.getSubLayerProps({
-            id: `${props.id}-raster`,
-            width,
-            height,
-            // Only pass image if defined — passing `undefined` explicitly overrides
-            // the default null and causes isAsyncPropLoading to return true briefly,
-            // which hides the parent tile placeholder and causes a black flash.
-            // https://github.com/developmentseed/deck.gl-raster/issues/376
-            ...(image !== undefined && { image }),
-            renderPipeline,
-            maxError,
-            reprojectionFns,
-            debug,
-            debugOpacity,
-            ...deckProjectionProps,
-          }),
-        ),
-      );
-    }
-
     if (debug) {
       layers.push(
-        ...this.renderDebugTileOutline(
+        ...renderDebugTileOutline(
           `${this.id}-${tile.id}-bounds`,
           tile,
           forwardTo4326,
@@ -522,7 +432,91 @@ export class COGLayer<
       );
     }
 
-    return layers;
+    if (!props.data) {
+      return layers;
+    }
+
+    const { data, forwardTransform, inverseTransform } = props.data;
+
+    const { height, width } = data;
+
+    let tileResult: RenderTileResult;
+    if (this.props.getTileData) {
+      // In the case that the user passed in a custom `getTileData`, TS knows
+      // that `data` can be passed in to `renderTile`.
+      tileResult = this.props.renderTile(data);
+    } else {
+      // In the default case, `data` is `DefaultDataT` — cast required because
+      // TS can't prove that `DataT` (which defaults to `DefaultDataT`) is
+      // `DefaultDataT` at this point.
+      tileResult = this.state.defaultRenderTile!(
+        data as unknown as DefaultDataT,
+      );
+    }
+    const { image, renderPipeline } = tileResult;
+
+    // viewport.resolution is defined for GlobeView, undefined for WebMercatorViewport.
+    // For WebMercator we project the mesh to EPSG:3857 and use a model matrix
+    // to map from 3857 meters to deck.gl world space, matching the approach
+    // used by the MVTLayer. This avoids per-vertex WGS84→WebMercator linear
+    // interpolation errors that become visible at high latitudes.
+    const isGlobe = this.context.viewport.resolution !== undefined;
+    let reprojectionFns: ReprojectionFns;
+    let deckProjectionProps: Partial<LayerProps>;
+
+    if (isGlobe) {
+      reprojectionFns = {
+        forwardTransform,
+        inverseTransform,
+        forwardReproject: forwardTo4326,
+        inverseReproject: inverseFrom4326,
+      };
+      deckProjectionProps = {};
+    } else {
+      reprojectionFns = {
+        forwardTransform,
+        inverseTransform,
+        forwardReproject: forwardTo3857,
+        inverseReproject: inverseFrom3857,
+      };
+      // Scale 3857 meters → deck.gl world units (512×512).
+      //
+      // coordinateOrigin shifts the world-space origin to (256, 256) so that
+      // easting=0 / northing=0 maps to world center. Then the modelMatrix
+      //
+      // No Y-flip needed: CARTESIAN Y increases upward = northing.
+      deckProjectionProps = {
+        coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+        coordinateOrigin: [TILE_SIZE / 2, TILE_SIZE / 2, 0],
+        // biome-ignore format: array
+        modelMatrix: [
+            WEB_MERCATOR_TO_WORLD_SCALE, 0, 0, 0,
+            0, WEB_MERCATOR_TO_WORLD_SCALE, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1
+          ],
+      };
+    }
+
+    const rasterLayer = new RasterLayer(
+      this.getSubLayerProps({
+        id: `${props.id}-raster`,
+        width,
+        height,
+        // Only pass image if defined — passing `undefined` explicitly overrides
+        // the default null and causes isAsyncPropLoading to return true briefly,
+        // which hides the parent tile placeholder and causes a black flash.
+        // https://github.com/developmentseed/deck.gl-raster/issues/376
+        ...(image !== undefined && { image }),
+        renderPipeline,
+        maxError,
+        reprojectionFns,
+        debug,
+        debugOpacity,
+        ...deckProjectionProps,
+      }),
+    );
+    return [rasterLayer, ...layers];
   }
 
   /** Define the underlying deck.gl TileLayer. */
@@ -607,69 +601,5 @@ export class COGLayer<
       inverseFrom3857,
       geotiff,
     );
-  }
-
-  renderDebugTileOutline(
-    id: string,
-    tile: Tile2DHeader<GetTileDataResult<DataT>> & TileMetadata,
-    forwardTo4326: ReprojectionFns["forwardReproject"],
-  ) {
-    const { projectedCorners } = tile;
-
-    // Create a closed path in WGS84 projection around the tile bounds
-    //
-    // The tile has a `bbox` field which is already the bounding box in WGS84,
-    // but that uses `transformBounds` and densifies edges. So the corners of
-    // the bounding boxes don't line up with each other.
-    //
-    // In this case in the debug mode, it looks better if we ignore the actual
-    // non-linearities of the edges and just draw a box connecting the
-    // reprojected corners. In any case, the _image itself_ will be densified
-    // on the edges as a feature of the mesh generation.
-    const { topLeft, topRight, bottomRight, bottomLeft } = projectedCorners;
-    const topLeftWgs84 = forwardTo4326(topLeft[0], topLeft[1]);
-    const topRightWgs84 = forwardTo4326(topRight[0], topRight[1]);
-    const bottomRightWgs84 = forwardTo4326(bottomRight[0], bottomRight[1]);
-    const bottomLeftWgs84 = forwardTo4326(bottomLeft[0], bottomLeft[1]);
-
-    const path = [
-      topLeftWgs84,
-      topRightWgs84,
-      bottomRightWgs84,
-      bottomLeftWgs84,
-      topLeftWgs84,
-    ];
-
-    const center = [
-      (topLeftWgs84[0] + bottomRightWgs84[0]) / 2,
-      (topLeftWgs84[1] + bottomRightWgs84[1]) / 2,
-    ];
-    const labelLayer = new TextLayer({
-      id: `${id}-label`,
-      data: [
-        {
-          position: center,
-          text: `x=${tile.index.x} y=${tile.index.y} z=${tile.index.z}`,
-        },
-      ],
-      getColor: [255, 255, 255, 255],
-      getSize: 24,
-      sizeUnits: "pixels",
-      outlineWidth: 3,
-      outlineColor: [0, 0, 0, 255],
-      fontSettings: { sdf: true },
-    });
-
-    const outlineLayer = new PathLayer({
-      id,
-      data: [path],
-      getPath: (d) => d,
-      getColor: [255, 0, 0, 255], // Red
-      getWidth: 2,
-      widthUnits: "pixels",
-      pickable: false,
-    });
-
-    return [outlineLayer, labelLayer];
   }
 }

--- a/packages/deck.gl-raster/src/index.ts
+++ b/packages/deck.gl-raster/src/index.ts
@@ -1,4 +1,6 @@
 export type { RasterModule } from "./gpu-modules/types.js";
+// Not a public API; exported for use in COGLayer and ZarrLayer
+export { renderDebugTileOutline as _renderDebugTileOutline } from "./layer-utils.js";
 export type { RasterLayerProps, RenderTileResult } from "./raster-layer.js";
 export { RasterLayer } from "./raster-layer.js";
 export type {

--- a/packages/deck.gl-raster/src/layer-utils.ts
+++ b/packages/deck.gl-raster/src/layer-utils.ts
@@ -1,0 +1,68 @@
+import type { _Tile2DHeader as Tile2DHeader } from "@deck.gl/geo-layers";
+import { PathLayer, TextLayer } from "@deck.gl/layers";
+import type { ReprojectionFns } from "@developmentseed/raster-reproject";
+import type { TileMetadata } from "./raster-tileset";
+
+export function renderDebugTileOutline(
+  id: string,
+  tile: Tile2DHeader & TileMetadata,
+  forwardTo4326: ReprojectionFns["forwardReproject"],
+) {
+  const { projectedCorners } = tile;
+
+  // Create a closed path in WGS84 projection around the tile bounds
+  //
+  // The tile has a `bbox` field which is already the bounding box in WGS84,
+  // but that uses `transformBounds` and densifies edges. So the corners of
+  // the bounding boxes don't line up with each other.
+  //
+  // In this case in the debug mode, it looks better if we ignore the actual
+  // non-linearities of the edges and just draw a box connecting the
+  // reprojected corners. In any case, the _image itself_ will be densified
+  // on the edges as a feature of the mesh generation.
+  const { topLeft, topRight, bottomRight, bottomLeft } = projectedCorners;
+  const topLeftWgs84 = forwardTo4326(topLeft[0], topLeft[1]);
+  const topRightWgs84 = forwardTo4326(topRight[0], topRight[1]);
+  const bottomRightWgs84 = forwardTo4326(bottomRight[0], bottomRight[1]);
+  const bottomLeftWgs84 = forwardTo4326(bottomLeft[0], bottomLeft[1]);
+
+  const path = [
+    topLeftWgs84,
+    topRightWgs84,
+    bottomRightWgs84,
+    bottomLeftWgs84,
+    topLeftWgs84,
+  ];
+
+  const center = [
+    (topLeftWgs84[0] + bottomRightWgs84[0]) / 2,
+    (topLeftWgs84[1] + bottomRightWgs84[1]) / 2,
+  ];
+  const labelLayer = new TextLayer({
+    id: `${id}-label`,
+    data: [
+      {
+        position: center,
+        text: `x=${tile.index.x} y=${tile.index.y} z=${tile.index.z}`,
+      },
+    ],
+    getColor: [255, 255, 255, 255],
+    getSize: 24,
+    sizeUnits: "pixels",
+    outlineWidth: 3,
+    outlineColor: [0, 0, 0, 255],
+    fontSettings: { sdf: true },
+  });
+
+  const outlineLayer = new PathLayer({
+    id,
+    data: [path],
+    getPath: (d) => d,
+    getColor: [255, 0, 0, 255], // Red
+    getWidth: 2,
+    widthUnits: "pixels",
+    pickable: false,
+  });
+
+  return [outlineLayer, labelLayer];
+}

--- a/packages/deck.gl-zarr/src/index.ts
+++ b/packages/deck.gl-zarr/src/index.ts
@@ -1,2 +1,3 @@
-// Zarr visualization placeholder
-export {};
+export type { ZarrLayerProps } from "./zarr-layer.js";
+export { ZarrLayer } from "./zarr-layer.js";
+export { geoZarrToDescriptor } from "./zarr-tileset.js";

--- a/packages/deck.gl-zarr/src/index.ts
+++ b/packages/deck.gl-zarr/src/index.ts
@@ -1,3 +1,2 @@
 export type { ZarrLayerProps } from "./zarr-layer.js";
 export { ZarrLayer } from "./zarr-layer.js";
-export { geoZarrToDescriptor } from "./zarr-tileset.js";

--- a/packages/deck.gl-zarr/src/zarr-layer.ts
+++ b/packages/deck.gl-zarr/src/zarr-layer.ts
@@ -1,0 +1,524 @@
+import type {
+  CompositeLayerProps,
+  Layer,
+  LayerProps,
+  LayersList,
+  UpdateParameters,
+} from "@deck.gl/core";
+import { COORDINATE_SYSTEM, CompositeLayer } from "@deck.gl/core";
+import type {
+  _Tile2DHeader as Tile2DHeader,
+  TileLayerProps,
+  _TileLoadProps as TileLoadProps,
+  _Tileset2DProps as Tileset2DProps,
+} from "@deck.gl/geo-layers";
+import { TileLayer } from "@deck.gl/geo-layers";
+import * as affineLib from "@developmentseed/affine";
+import { RasterLayer, RasterTileset2D } from "@developmentseed/deck.gl-raster";
+import type { GeoZarrMetadata } from "@developmentseed/geozarr";
+import { parseGeoZarrMetadata } from "@developmentseed/geozarr";
+import type {
+  EpsgResolver,
+  ProjectionDefinition,
+  ProjJson,
+} from "@developmentseed/proj";
+import {
+  epsgResolver,
+  makeClampedForwardTo3857,
+  metersPerUnit,
+  parseWkt,
+} from "@developmentseed/proj";
+import type { ReprojectionFns } from "@developmentseed/raster-reproject";
+import proj4 from "proj4";
+import * as zarr from "zarrita";
+import { geoZarrToDescriptor } from "./zarr-tileset.js";
+
+/** Size of deck.gl's common coordinate space in world units. */
+const TILE_SIZE = 512;
+
+/** Size of the globe in web mercator meters. */
+const WEB_MERCATOR_METER_CIRCUMFERENCE = 40075016.686;
+
+/** Scale factor for converting EPSG:3857 meters into deck.gl world units. */
+const WEB_MERCATOR_TO_WORLD_SCALE =
+  TILE_SIZE / WEB_MERCATOR_METER_CIRCUMFERENCE;
+
+/**
+ * Props for the {@link ZarrLayer}.
+ */
+export type ZarrLayerProps = CompositeLayerProps &
+  Pick<
+    TileLayerProps,
+    | "debounceTime"
+    | "maxCacheSize"
+    | "maxCacheByteSize"
+    | "maxRequests"
+    | "refinementStrategy"
+  > & {
+    /** URL to the Zarr v3 store root. */
+    source: string | URL;
+
+    /**
+     * Optional path within the store to the variable group.
+     * If omitted, the root group is used.
+     */
+    variable?: string;
+
+    /**
+     * Index to use for non-spatial dimensions (e.g. `{ time: 0, band: 2 }`).
+     * Defaults to 0 for any unspecified dimension.
+     */
+    dimensionIndices?: Record<string, number>;
+
+    /**
+     * Resolver for authority:code CRS strings (e.g. "EPSG:4326").
+     * Defaults to fetching from epsg.io.
+     */
+    epsgResolver?: EpsgResolver;
+
+    /** Maximum reprojection error in pixels for mesh refinement. @default 0.125 */
+    maxError?: number;
+
+    /** Enable debug tile outline visualization. @default false */
+    debug?: boolean;
+
+    /** Opacity of the debug mesh overlay (0-1). @default 0.5 */
+    debugOpacity?: number;
+
+    /** Called when Zarr metadata has been loaded and parsed. */
+    onZarrLoad?: (meta: GeoZarrMetadata) => void;
+
+    /** User-provided AbortSignal to cancel loading. */
+    signal?: AbortSignal;
+  };
+
+const defaultProps: Partial<ZarrLayerProps> = {
+  ...TileLayer.defaultProps,
+  epsgResolver,
+  debug: false,
+  debugOpacity: 0.5,
+};
+
+type TileData = {
+  image: ImageData;
+  forwardTransform: ReprojectionFns["forwardTransform"];
+  inverseTransform: ReprojectionFns["inverseTransform"];
+  width: number;
+  height: number;
+};
+
+// Minimal interface for the data returned by zarrita.get
+type NDArrayLike = {
+  data: ArrayLike<number>;
+  shape: number[];
+};
+
+/**
+ * Convert a band-planar zarr result to an RGBA ImageData.
+ *
+ * Supports:
+ *  - shape [3, H, W]  → RGB  (alpha = 255)
+ *  - shape [1, H, W]  → grayscale (R=G=B, alpha = 255)
+ *  - shape [H, W]     → grayscale (R=G=B, alpha = 255)
+ */
+function toImageData(result: NDArrayLike, width: number, height: number): ImageData {
+  const { data, shape } = result;
+  const rgba = new Uint8ClampedArray(width * height * 4);
+  const numBands = shape.length >= 3 ? shape[shape.length - 3]! : 1;
+  const pixelCount = width * height;
+
+  if (numBands >= 3) {
+    // Band-planar RGB: [3, H, W]
+    const rOffset = 0;
+    const gOffset = pixelCount;
+    const bOffset = pixelCount * 2;
+    for (let i = 0; i < pixelCount; i++) {
+      rgba[i * 4 + 0] = (data as ArrayLike<number>)[rOffset + i] as number;
+      rgba[i * 4 + 1] = (data as ArrayLike<number>)[gOffset + i] as number;
+      rgba[i * 4 + 2] = (data as ArrayLike<number>)[bOffset + i] as number;
+      rgba[i * 4 + 3] = 255;
+    }
+  } else {
+    // Single band: [1, H, W] or [H, W]
+    const offset = shape.length >= 3 ? 0 : 0;
+    for (let i = 0; i < pixelCount; i++) {
+      const v = (data as ArrayLike<number>)[offset + i] as number;
+      rgba[i * 4 + 0] = v;
+      rgba[i * 4 + 1] = v;
+      rgba[i * 4 + 2] = v;
+      rgba[i * 4 + 3] = 255;
+    }
+  }
+
+  return new ImageData(rgba, width, height);
+}
+
+/**
+ * ZarrLayer renders a GeoZarr dataset using a tiled approach with reprojection.
+ */
+export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
+  static override layerName = "ZarrLayer";
+  static override defaultProps = defaultProps;
+
+  declare state: {
+    meta?: GeoZarrMetadata;
+    group?: zarr.Group<zarr.FetchStore>;
+    forwardTo4326?: ReprojectionFns["forwardReproject"];
+    inverseFrom4326?: ReprojectionFns["inverseReproject"];
+    forwardTo3857?: ReprojectionFns["forwardReproject"];
+    inverseFrom3857?: ReprojectionFns["inverseReproject"];
+    mpu?: number;
+    chunkSizes?: Array<{ width: number; height: number }>;
+  };
+
+  override initializeState(): void {
+    this.setState({});
+  }
+
+  override updateState(params: UpdateParameters<this>) {
+    super.updateState(params);
+    const { props, oldProps, changeFlags } = params;
+    const needsUpdate =
+      Boolean(changeFlags.dataChanged) ||
+      props.source !== oldProps.source ||
+      props.variable !== oldProps.variable;
+
+    if (needsUpdate) {
+      this._clearState();
+      void this._parseZarr();
+    }
+  }
+
+  _clearState() {
+    this.setState({
+      meta: undefined,
+      group: undefined,
+      forwardTo4326: undefined,
+      inverseFrom4326: undefined,
+      forwardTo3857: undefined,
+      inverseFrom3857: undefined,
+      mpu: undefined,
+      chunkSizes: undefined,
+    });
+  }
+
+  async _parseZarr(): Promise<void> {
+    const { source, variable } = this.props;
+
+    const store = new zarr.FetchStore(source.toString());
+    const rootGroup = await zarr.open(store, { kind: "group" });
+    const group = variable
+      ? await zarr.open(rootGroup.resolve(variable), { kind: "group" })
+      : rootGroup;
+
+    const meta = parseGeoZarrMetadata(group.attrs);
+
+    // Open each level array to get chunk sizes (shape is in attrs via spatial:shape)
+    const chunkSizes = await Promise.all(
+      meta.levels.map(async (level) => {
+        const arr = await zarr.open(group.resolve(level.path), {
+          kind: "array",
+        });
+        // chunks is [...otherDims, chunkHeight, chunkWidth]
+        const chunks = arr.chunks;
+        return {
+          width: chunks[chunks.length - 1]!,
+          height: chunks[chunks.length - 2]!,
+        };
+      }),
+    );
+
+    // Resolve CRS
+    const { crs } = meta;
+    let sourceProjection: ProjectionDefinition;
+
+    if (crs.code) {
+      const [authority, code] = crs.code.split(":");
+      if (authority !== "EPSG") {
+        throw new Error(
+          `Unsupported CRS authority "${authority}". Only "EPSG" is supported.`,
+        );
+      }
+      if (!code) {
+        throw new Error(
+          `Invalid CRS code "${crs.code}". Expected format "EPSG:XXXX".`,
+        );
+      }
+      sourceProjection = await this.props.epsgResolver!(
+        Number.parseInt(code, 10),
+      );
+    } else if (crs.wkt2) {
+      sourceProjection = parseWkt(crs.wkt2);
+    } else if (crs.projjson) {
+      sourceProjection = parseWkt(crs.projjson as unknown as ProjJson);
+    } else {
+      throw new Error("No CRS information found in GeoZarr metadata");
+    }
+
+    // Build proj4 converters
+    // @ts-expect-error - proj4 typings don't cover wkt-parser output
+    const converter4326 = proj4(sourceProjection, "EPSG:4326");
+    const forwardTo4326 = (x: number, y: number) =>
+      converter4326.forward<[number, number]>([x, y], false);
+    const inverseFrom4326 = (x: number, y: number) =>
+      converter4326.inverse<[number, number]>([x, y], false);
+
+    // @ts-expect-error - proj4 typings don't cover wkt-parser output
+    const converter3857 = proj4(sourceProjection, "EPSG:3857");
+    const forwardTo3857Raw = (x: number, y: number) =>
+      converter3857.forward<[number, number]>([x, y], false);
+    const forwardTo3857 = makeClampedForwardTo3857(
+      forwardTo3857Raw,
+      forwardTo4326,
+    );
+    const inverseFrom3857 = (x: number, y: number) =>
+      converter3857.inverse<[number, number]>([x, y], false);
+
+    // Compute meters-per-CRS-unit from the resolved projection
+    const units: string = sourceProjection.units ?? "m";
+    const semiMajorAxis: number | undefined =
+      sourceProjection.datum?.a ?? sourceProjection.a;
+    const mpu = metersPerUnit(units as Parameters<typeof metersPerUnit>[0], {
+      semiMajorAxis,
+    });
+
+    this.props.onZarrLoad?.(meta);
+
+    this.setState({
+      meta,
+      group,
+      forwardTo4326,
+      inverseFrom4326,
+      forwardTo3857,
+      inverseFrom3857,
+      mpu,
+      chunkSizes,
+    });
+  }
+
+  async _getTileData(
+    tile: TileLoadProps,
+    meta: GeoZarrMetadata,
+    group: zarr.Group<zarr.FetchStore>,
+    chunkSizes: Array<{ width: number; height: number }>,
+  ): Promise<TileData> {
+    const { x, y, z } = tile.index;
+    const { dimensionIndices = {} } = this.props;
+
+    // descriptor z=0 is coarsest; meta.levels is finest-first
+    // so descriptor level z maps to meta.levels[numLevels - 1 - z]
+    const zarrLevelIdx = meta.levels.length - 1 - z;
+    const level = meta.levels[zarrLevelIdx]!;
+    const chunk = chunkSizes[zarrLevelIdx]!;
+
+    const { tileWidth, tileHeight } = {
+      tileWidth: chunk.width,
+      tileHeight: chunk.height,
+    };
+
+    const arr = await zarr.open(group.resolve(level.path), { kind: "array" });
+
+    // Build slice spec for all dimensions
+    // The last two dims are y (height) and x (width); others use dimensionIndices
+    const rowStart = y * tileHeight;
+    const rowEnd = Math.min((y + 1) * tileHeight, level.arrayHeight);
+    const colStart = x * tileWidth;
+    const colEnd = Math.min((x + 1) * tileWidth, level.arrayWidth);
+
+    const actualHeight = rowEnd - rowStart;
+    const actualWidth = colEnd - colStart;
+
+    // Build slice for each dimension
+    const slices: (zarr.Slice | number)[] = arr.shape.map((_, dimIdx) => {
+      const numDims = arr.shape.length;
+      if (dimIdx === numDims - 2) {
+        // y dimension
+        return zarr.slice(rowStart, rowEnd);
+      }
+      if (dimIdx === numDims - 1) {
+        // x dimension
+        return zarr.slice(colStart, colEnd);
+      }
+      // Other dimensions: use dimensionIndices or 0
+      const dimName = meta.axes[dimIdx] ?? String(dimIdx);
+      return dimensionIndices[dimName] ?? 0;
+    });
+
+    const result = await zarr.get(arr, slices);
+
+    // Compute per-tile affine: compose level affine with pixel offset of this tile
+    const tileOffset = affineLib.translation(colStart, rowStart);
+    const tileAffine = affineLib.compose(level.affine, tileOffset);
+    const invTileAffine = affineLib.invert(tileAffine);
+
+    const forwardTransform = (px: number, py: number) =>
+      affineLib.apply(tileAffine, px, py);
+    const inverseTransform = (cx: number, cy: number) =>
+      affineLib.apply(invTileAffine, cx, cy);
+
+    const image = toImageData(result as NDArrayLike, actualWidth, actualHeight);
+
+    return {
+      image,
+      forwardTransform,
+      inverseTransform,
+      width: actualWidth,
+      height: actualHeight,
+    };
+  }
+
+  _renderSubLayers(
+    props: TileLayerProps<TileData> & {
+      id: string;
+      data?: TileData;
+      _offset: number;
+      tile: Tile2DHeader<TileData>;
+    },
+    forwardTo4326: ReprojectionFns["forwardReproject"],
+    inverseFrom4326: ReprojectionFns["inverseReproject"],
+    forwardTo3857: ReprojectionFns["forwardReproject"],
+    inverseFrom3857: ReprojectionFns["inverseReproject"],
+  ): Layer | LayersList | null {
+    const { maxError, debug, debugOpacity } = this.props;
+
+    if (!props.data) {
+      return null;
+    }
+
+    const { image, forwardTransform, inverseTransform, width, height } = props.data;
+
+    const isGlobe = this.context.viewport.resolution !== undefined;
+    let reprojectionFns: ReprojectionFns;
+    let deckProjectionProps: Partial<LayerProps>;
+
+    if (isGlobe) {
+      reprojectionFns = {
+        forwardTransform,
+        inverseTransform,
+        forwardReproject: forwardTo4326,
+        inverseReproject: inverseFrom4326,
+      };
+      deckProjectionProps = {};
+    } else {
+      reprojectionFns = {
+        forwardTransform,
+        inverseTransform,
+        forwardReproject: forwardTo3857,
+        inverseReproject: inverseFrom3857,
+      };
+      deckProjectionProps = {
+        coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+        coordinateOrigin: [TILE_SIZE / 2, TILE_SIZE / 2, 0],
+        // biome-ignore format: array
+        modelMatrix: [
+          WEB_MERCATOR_TO_WORLD_SCALE, 0, 0, 0,
+          0, WEB_MERCATOR_TO_WORLD_SCALE, 0, 0,
+          0, 0, 1, 0,
+          0, 0, 0, 1
+        ],
+      };
+    }
+
+    return new RasterLayer(
+      this.getSubLayerProps({
+        id: `${props.id}-raster`,
+        image,
+        width,
+        height,
+        maxError,
+        reprojectionFns,
+        debug,
+        debugOpacity,
+        ...deckProjectionProps,
+      }),
+    );
+  }
+
+  renderTileLayer(
+    meta: GeoZarrMetadata,
+    group: zarr.Group<zarr.FetchStore>,
+    chunkSizes: Array<{ width: number; height: number }>,
+    mpu: number,
+    forwardTo4326: ReprojectionFns["forwardReproject"],
+    inverseFrom4326: ReprojectionFns["inverseReproject"],
+    forwardTo3857: ReprojectionFns["forwardReproject"],
+    inverseFrom3857: ReprojectionFns["inverseReproject"],
+  ): TileLayer {
+    class ZarrTilesetFactory extends RasterTileset2D {
+      constructor(opts: Tileset2DProps) {
+        const descriptor = geoZarrToDescriptor(
+          meta,
+          forwardTo4326,
+          forwardTo3857,
+          chunkSizes,
+          mpu,
+        );
+        super(opts, descriptor, { projectTo4326: forwardTo4326 });
+      }
+    }
+
+    const {
+      maxRequests,
+      maxCacheSize,
+      maxCacheByteSize,
+      debounceTime,
+      refinementStrategy,
+    } = this.props;
+
+    return new TileLayer<TileData>({
+      id: `zarr-tile-layer-${this.id}`,
+      TilesetClass: ZarrTilesetFactory,
+      getTileData: (tile) => this._getTileData(tile, meta, group, chunkSizes),
+      renderSubLayers: (props) =>
+        this._renderSubLayers(
+          props,
+          forwardTo4326,
+          inverseFrom4326,
+          forwardTo3857,
+          inverseFrom3857,
+        ),
+      debounceTime,
+      maxCacheByteSize,
+      maxCacheSize,
+      maxRequests,
+      refinementStrategy,
+    });
+  }
+
+  override renderLayers() {
+    const {
+      meta,
+      group,
+      chunkSizes,
+      mpu,
+      forwardTo4326,
+      inverseFrom4326,
+      forwardTo3857,
+      inverseFrom3857,
+    } = this.state;
+
+    if (
+      !meta ||
+      !group ||
+      !chunkSizes ||
+      mpu === undefined ||
+      !forwardTo4326 ||
+      !inverseFrom4326 ||
+      !forwardTo3857 ||
+      !inverseFrom3857
+    ) {
+      return null;
+    }
+
+    return this.renderTileLayer(
+      meta,
+      group,
+      chunkSizes,
+      mpu,
+      forwardTo4326,
+      inverseFrom4326,
+      forwardTo3857,
+      inverseFrom3857,
+    );
+  }
+}

--- a/packages/deck.gl-zarr/src/zarr-layer.ts
+++ b/packages/deck.gl-zarr/src/zarr-layer.ts
@@ -193,32 +193,7 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
       ),
     );
 
-    // Resolve CRS
-    const { crs } = meta;
-    let sourceProjection: ProjectionDefinition;
-
-    if (crs.code) {
-      const [authority, code] = crs.code.split(":");
-      if (authority !== "EPSG") {
-        throw new Error(
-          `Unsupported CRS authority "${authority}". Only "EPSG" is supported.`,
-        );
-      }
-      if (!code) {
-        throw new Error(
-          `Invalid CRS code "${crs.code}". Expected format "EPSG:XXXX".`,
-        );
-      }
-      sourceProjection = await this.props.epsgResolver!(
-        Number.parseInt(code, 10),
-      );
-    } else if (crs.wkt2) {
-      sourceProjection = parseWkt(crs.wkt2);
-    } else if (crs.projjson) {
-      sourceProjection = parseWkt(crs.projjson as unknown as ProjJson);
-    } else {
-      throw new Error("No CRS information found in GeoZarr metadata");
-    }
+    const sourceProjection = await parseCrs(meta.crs, this.props.epsgResolver!);
 
     // Build proj4 converters
     // @ts-expect-error - proj4 typings don't cover wkt-parser output
@@ -230,17 +205,21 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
 
     // @ts-expect-error - proj4 typings don't cover wkt-parser output
     const converter3857 = proj4(sourceProjection, "EPSG:3857");
-    const forwardTo3857Raw = (x: number, y: number) =>
-      converter3857.forward<[number, number]>([x, y], false);
     const forwardTo3857 = makeClampedForwardTo3857(
-      forwardTo3857Raw,
+      (x: number, y: number) =>
+        converter3857.forward<[number, number]>([x, y], false),
       forwardTo4326,
     );
     const inverseFrom3857 = (x: number, y: number) =>
       converter3857.inverse<[number, number]>([x, y], false);
 
     // Compute meters-per-CRS-unit from the resolved projection
-    const units: string = sourceProjection.units ?? "m";
+    const units = sourceProjection.units;
+    if (!units) {
+      throw new Error(
+        "Source projection is missing 'units' property, cannot compute meters per unit",
+      );
+    }
     const semiMajorAxis: number | undefined =
       sourceProjection.datum?.a ?? sourceProjection.a;
     const mpu = metersPerUnit(units as Parameters<typeof metersPerUnit>[0], {
@@ -483,11 +462,31 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
   }
 }
 
-/** Minimal interface for the data returned by zarrita.get */
-type NDArrayLike = {
-  data: ArrayLike<number>;
-  shape: number[];
-};
+async function parseCrs(
+  crs: GeoZarrMetadata["crs"],
+  epsgResolver: EpsgResolver,
+): Promise<ProjectionDefinition> {
+  if (crs.code) {
+    const [authority, code] = crs.code.split(":");
+    if (authority !== "EPSG") {
+      throw new Error(
+        `Unsupported CRS authority "${authority}". Only "EPSG" is supported.`,
+      );
+    }
+    if (!code) {
+      throw new Error(
+        `Invalid CRS code "${crs.code}". Expected format "EPSG:XXXX".`,
+      );
+    }
+    return await epsgResolver(Number.parseInt(code, 10));
+  } else if (crs.wkt2) {
+    return parseWkt(crs.wkt2);
+  } else if (crs.projjson) {
+    return parseWkt(crs.projjson as unknown as ProjJson);
+  } else {
+    throw new Error("No CRS information found in GeoZarr metadata");
+  }
+}
 
 /**
  * Convert a band-planar zarr result to an RGBA ImageData.

--- a/packages/deck.gl-zarr/src/zarr-layer.ts
+++ b/packages/deck.gl-zarr/src/zarr-layer.ts
@@ -293,7 +293,7 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
     const inverseTransform = (cx: number, cy: number) =>
       affineLib.apply(invTileAffine, cx, cy);
 
-    const image = toImageData(result as NDArrayLike, actualWidth, actualHeight);
+    const image = toImageData(result, actualWidth, actualHeight);
 
     return {
       image,
@@ -497,7 +497,7 @@ async function parseCrs(
  *  - shape [H, W]     → grayscale (R=G=B, alpha = 255)
  */
 function toImageData(
-  result: NDArrayLike,
+  result: zarr.Chunk<zarr.NumberDataType>,
   width: number,
   height: number,
 ): ImageData {

--- a/packages/deck.gl-zarr/src/zarr-layer.ts
+++ b/packages/deck.gl-zarr/src/zarr-layer.ts
@@ -46,7 +46,10 @@ const WEB_MERCATOR_TO_WORLD_SCALE =
 /**
  * Props for the {@link ZarrLayer}.
  */
-export type ZarrLayerProps = CompositeLayerProps &
+export type ZarrLayerProps<
+  Store extends zarr.Readable = zarr.Readable,
+  Dtype extends zarr.DataType = zarr.DataType,
+> = CompositeLayerProps &
   Pick<
     TileLayerProps,
     | "debounceTime"
@@ -56,7 +59,7 @@ export type ZarrLayerProps = CompositeLayerProps &
     | "refinementStrategy"
   > & {
     /** URL to the Zarr v3 store root. */
-    source: string | URL;
+    source: string | URL | zarr.Array<Dtype, Store> | zarr.Group<Store>;
 
     /**
      * Optional path within the store to the variable group.
@@ -107,52 +110,6 @@ type TileData = {
   height: number;
 };
 
-// Minimal interface for the data returned by zarrita.get
-type NDArrayLike = {
-  data: ArrayLike<number>;
-  shape: number[];
-};
-
-/**
- * Convert a band-planar zarr result to an RGBA ImageData.
- *
- * Supports:
- *  - shape [3, H, W]  → RGB  (alpha = 255)
- *  - shape [1, H, W]  → grayscale (R=G=B, alpha = 255)
- *  - shape [H, W]     → grayscale (R=G=B, alpha = 255)
- */
-function toImageData(result: NDArrayLike, width: number, height: number): ImageData {
-  const { data, shape } = result;
-  const rgba = new Uint8ClampedArray(width * height * 4);
-  const numBands = shape.length >= 3 ? shape[shape.length - 3]! : 1;
-  const pixelCount = width * height;
-
-  if (numBands >= 3) {
-    // Band-planar RGB: [3, H, W]
-    const rOffset = 0;
-    const gOffset = pixelCount;
-    const bOffset = pixelCount * 2;
-    for (let i = 0; i < pixelCount; i++) {
-      rgba[i * 4 + 0] = (data as ArrayLike<number>)[rOffset + i] as number;
-      rgba[i * 4 + 1] = (data as ArrayLike<number>)[gOffset + i] as number;
-      rgba[i * 4 + 2] = (data as ArrayLike<number>)[bOffset + i] as number;
-      rgba[i * 4 + 3] = 255;
-    }
-  } else {
-    // Single band: [1, H, W] or [H, W]
-    const offset = shape.length >= 3 ? 0 : 0;
-    for (let i = 0; i < pixelCount; i++) {
-      const v = (data as ArrayLike<number>)[offset + i] as number;
-      rgba[i * 4 + 0] = v;
-      rgba[i * 4 + 1] = v;
-      rgba[i * 4 + 2] = v;
-      rgba[i * 4 + 3] = 255;
-    }
-  }
-
-  return new ImageData(rgba, width, height);
-}
-
 /**
  * ZarrLayer renders a GeoZarr dataset using a tiled approach with reprojection.
  */
@@ -162,13 +119,13 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
 
   declare state: {
     meta?: GeoZarrMetadata;
-    group?: zarr.Group<zarr.FetchStore>;
+    /** One opened array per level, finest-first (matches meta.levels order). */
+    arrays?: zarr.Array<zarr.DataType, zarr.Readable>[];
     forwardTo4326?: ReprojectionFns["forwardReproject"];
     inverseFrom4326?: ReprojectionFns["inverseReproject"];
     forwardTo3857?: ReprojectionFns["forwardReproject"];
     inverseFrom3857?: ReprojectionFns["inverseReproject"];
     mpu?: number;
-    chunkSizes?: Array<{ width: number; height: number }>;
   };
 
   override initializeState(): void {
@@ -177,13 +134,17 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
 
   override updateState(params: UpdateParameters<this>) {
     super.updateState(params);
+
     const { props, oldProps, changeFlags } = params;
+
     const needsUpdate =
       Boolean(changeFlags.dataChanged) ||
       props.source !== oldProps.source ||
       props.variable !== oldProps.variable;
 
     if (needsUpdate) {
+      // Clear stale state so renderLayers returns null until the new GeoTIFF is
+      // ready
       this._clearState();
       void this._parseZarr();
     }
@@ -192,13 +153,12 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
   _clearState() {
     this.setState({
       meta: undefined,
-      group: undefined,
+      arrays: undefined,
       forwardTo4326: undefined,
       inverseFrom4326: undefined,
       forwardTo3857: undefined,
       inverseFrom3857: undefined,
       mpu: undefined,
-      chunkSizes: undefined,
     });
   }
 
@@ -206,26 +166,29 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
     const { source, variable } = this.props;
 
     const store = new zarr.FetchStore(source.toString());
-    const rootGroup = await zarr.open(store, { kind: "group" });
+    // @ts-expect-error - for debugging
+    window.store = store;
+
+    const root = await zarr.open(store);
+    // @ts-expect-error - for debugging
+    window.root = root;
+
     const group = variable
-      ? await zarr.open(rootGroup.resolve(variable), { kind: "group" })
-      : rootGroup;
+      ? await zarr.open(root.resolve(variable), { kind: "group" })
+      : root;
+    // @ts-expect-error - for debugging
+    window.group = group;
 
     const meta = parseGeoZarrMetadata(group.attrs);
+    // @ts-expect-error - for debugging
+    window.meta = meta;
 
-    // Open each level array to get chunk sizes (shape is in attrs via spatial:shape)
-    const chunkSizes = await Promise.all(
-      meta.levels.map(async (level) => {
-        const arr = await zarr.open(group.resolve(level.path), {
-          kind: "array",
-        });
-        // chunks is [...otherDims, chunkHeight, chunkWidth]
-        const chunks = arr.chunks;
-        return {
-          width: chunks[chunks.length - 1]!,
-          height: chunks[chunks.length - 2]!,
-        };
-      }),
+    // Open each level's array once and keep the references in state.
+    // This avoids re-fetching array metadata on every tile request.
+    const arrays = await Promise.all(
+      meta.levels.map((level) =>
+        zarr.open(group.resolve(level.path), { kind: "array" }),
+      ),
     );
 
     // Resolve CRS
@@ -286,21 +249,19 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
 
     this.setState({
       meta,
-      group,
+      arrays,
       forwardTo4326,
       inverseFrom4326,
       forwardTo3857,
       inverseFrom3857,
       mpu,
-      chunkSizes,
     });
   }
 
   async _getTileData(
     tile: TileLoadProps,
     meta: GeoZarrMetadata,
-    group: zarr.Group<zarr.FetchStore>,
-    chunkSizes: Array<{ width: number; height: number }>,
+    arrays: zarr.Array<zarr.DataType, zarr.Readable>[],
   ): Promise<TileData> {
     const { x, y, z } = tile.index;
     const { dimensionIndices = {} } = this.props;
@@ -309,14 +270,11 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
     // so descriptor level z maps to meta.levels[numLevels - 1 - z]
     const zarrLevelIdx = meta.levels.length - 1 - z;
     const level = meta.levels[zarrLevelIdx]!;
-    const chunk = chunkSizes[zarrLevelIdx]!;
+    const arr = arrays[zarrLevelIdx]!;
 
-    const { tileWidth, tileHeight } = {
-      tileWidth: chunk.width,
-      tileHeight: chunk.height,
-    };
-
-    const arr = await zarr.open(group.resolve(level.path), { kind: "array" });
+    // chunks is [...otherDims, chunkHeight, chunkWidth]
+    const tileWidth = arr.chunks[arr.chunks.length - 1]!;
+    const tileHeight = arr.chunks[arr.chunks.length - 2]!;
 
     // Build slice spec for all dimensions
     // The last two dims are y (height) and x (width); others use dimensionIndices
@@ -385,7 +343,8 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
       return null;
     }
 
-    const { image, forwardTransform, inverseTransform, width, height } = props.data;
+    const { image, forwardTransform, inverseTransform, width, height } =
+      props.data;
 
     const isGlobe = this.context.viewport.resolution !== undefined;
     let reprojectionFns: ReprojectionFns;
@@ -436,14 +395,18 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
 
   renderTileLayer(
     meta: GeoZarrMetadata,
-    group: zarr.Group<zarr.FetchStore>,
-    chunkSizes: Array<{ width: number; height: number }>,
+    arrays: zarr.Array<zarr.DataType, zarr.Readable>[],
     mpu: number,
     forwardTo4326: ReprojectionFns["forwardReproject"],
     inverseFrom4326: ReprojectionFns["inverseReproject"],
     forwardTo3857: ReprojectionFns["forwardReproject"],
     inverseFrom3857: ReprojectionFns["inverseReproject"],
   ): TileLayer {
+    const chunkSizes = arrays.map((arr) => ({
+      width: arr.chunks[arr.chunks.length - 1]!,
+      height: arr.chunks[arr.chunks.length - 2]!,
+    }));
+
     class ZarrTilesetFactory extends RasterTileset2D {
       constructor(opts: Tileset2DProps) {
         const descriptor = geoZarrToDescriptor(
@@ -468,7 +431,7 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
     return new TileLayer<TileData>({
       id: `zarr-tile-layer-${this.id}`,
       TilesetClass: ZarrTilesetFactory,
-      getTileData: (tile) => this._getTileData(tile, meta, group, chunkSizes),
+      getTileData: (tile) => this._getTileData(tile, meta, arrays),
       renderSubLayers: (props) =>
         this._renderSubLayers(
           props,
@@ -488,8 +451,7 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
   override renderLayers() {
     const {
       meta,
-      group,
-      chunkSizes,
+      arrays,
       mpu,
       forwardTo4326,
       inverseFrom4326,
@@ -499,8 +461,7 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
 
     if (
       !meta ||
-      !group ||
-      !chunkSizes ||
+      !arrays ||
       mpu === undefined ||
       !forwardTo4326 ||
       !inverseFrom4326 ||
@@ -512,8 +473,7 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
 
     return this.renderTileLayer(
       meta,
-      group,
-      chunkSizes,
+      arrays,
       mpu,
       forwardTo4326,
       inverseFrom4326,
@@ -521,4 +481,53 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
       inverseFrom3857,
     );
   }
+}
+
+/** Minimal interface for the data returned by zarrita.get */
+type NDArrayLike = {
+  data: ArrayLike<number>;
+  shape: number[];
+};
+
+/**
+ * Convert a band-planar zarr result to an RGBA ImageData.
+ *
+ * Supports:
+ *  - shape [3, H, W]  → RGB  (alpha = 255)
+ *  - shape [1, H, W]  → grayscale (R=G=B, alpha = 255)
+ *  - shape [H, W]     → grayscale (R=G=B, alpha = 255)
+ */
+function toImageData(
+  result: NDArrayLike,
+  width: number,
+  height: number,
+): ImageData {
+  const { data, shape } = result;
+  const rgba = new Uint8ClampedArray(width * height * 4);
+  const numBands = shape.length >= 3 ? shape[shape.length - 3]! : 1;
+  const pixelCount = width * height;
+
+  if (numBands >= 3) {
+    // Band-planar RGB: [3, H, W]
+    const rOffset = 0;
+    const gOffset = pixelCount;
+    const bOffset = pixelCount * 2;
+    for (let i = 0; i < pixelCount; i++) {
+      rgba[i * 4 + 0] = data[rOffset + i]!;
+      rgba[i * 4 + 1] = data[gOffset + i]!;
+      rgba[i * 4 + 2] = data[bOffset + i]!;
+      rgba[i * 4 + 3] = 255;
+    }
+  } else {
+    // Single band: [1, H, W] or [H, W]
+    for (let i = 0; i < pixelCount; i++) {
+      const v = data[i]!;
+      rgba[i * 4 + 0] = v;
+      rgba[i * 4 + 1] = v;
+      rgba[i * 4 + 2] = v;
+      rgba[i * 4 + 3] = 255;
+    }
+  }
+
+  return new ImageData(rgba, width, height);
 }

--- a/packages/deck.gl-zarr/src/zarr-layer.ts
+++ b/packages/deck.gl-zarr/src/zarr-layer.ts
@@ -13,7 +13,7 @@ import type {
   _Tileset2DProps as Tileset2DProps,
 } from "@deck.gl/geo-layers";
 import { TileLayer } from "@deck.gl/geo-layers";
-import * as affineLib from "@developmentseed/affine";
+import * as affine from "@developmentseed/affine";
 import type { TileMetadata } from "@developmentseed/deck.gl-raster";
 import {
   RasterLayer,
@@ -126,6 +126,10 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
 
   declare state: {
     meta?: GeoZarrMetadata;
+
+    // TODO: arrays should be a named record, since the GeoZarr levels array
+    // isn't ordered. And we might need to support multiple separate arrays
+    // (different variables) in a single render
     /** One opened array per level, finest-first (matches meta.levels order). */
     arrays?: zarr.Array<zarr.DataType, zarr.Readable>[];
     forwardTo4326?: ReprojectionFns["forwardReproject"];
@@ -242,6 +246,8 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
     });
   }
 
+  // TODO: I need to go through _getTileData again and understand how slicing is
+  // fetched.
   async _getTileData(
     tile: TileLoadProps,
     meta: GeoZarrMetadata,
@@ -256,6 +262,8 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
     const level = meta.levels[zarrLevelIdx]!;
     const arr = arrays[zarrLevelIdx]!;
 
+    // TODO: don't hard-code y/x as the last two dims; look at spatial
+    // convention metadata
     // chunks is [...otherDims, chunkHeight, chunkWidth]
     const tileWidth = arr.chunks[arr.chunks.length - 1]!;
     const tileHeight = arr.chunks[arr.chunks.length - 2]!;
@@ -273,6 +281,8 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
     // Build slice for each dimension
     const slices: (zarr.Slice | number)[] = arr.shape.map((_, dimIdx) => {
       const numDims = arr.shape.length;
+      // TODO: don't hard-code y/x as the last two dims; look at spatial
+      // convention metadata
       if (dimIdx === numDims - 2) {
         // y dimension
         return zarr.slice(rowStart, rowEnd);
@@ -289,14 +299,14 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
     const result = await zarr.get(arr, slices);
 
     // Compute per-tile affine: compose level affine with pixel offset of this tile
-    const tileOffset = affineLib.translation(colStart, rowStart);
-    const tileAffine = affineLib.compose(level.affine, tileOffset);
-    const invTileAffine = affineLib.invert(tileAffine);
+    const tileOffset = affine.translation(colStart, rowStart);
+    const tileAffine = affine.compose(level.affine, tileOffset);
+    const invTileAffine = affine.invert(tileAffine);
 
     const forwardTransform = (px: number, py: number) =>
-      affineLib.apply(tileAffine, px, py);
+      affine.apply(tileAffine, px, py);
     const inverseTransform = (cx: number, cy: number) =>
-      affineLib.apply(invTileAffine, cx, cy);
+      affine.apply(invTileAffine, cx, cy);
 
     const image = toImageData(result, actualWidth, actualHeight);
 
@@ -403,6 +413,8 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
     forwardTo3857: ReprojectionFns["forwardReproject"],
     inverseFrom3857: ReprojectionFns["inverseReproject"],
   ): TileLayer {
+    // TODO: don't hard-code y/x as the last two dims; look at spatial
+    // convention metadata
     const chunkSizes = arrays.map((arr) => ({
       width: arr.chunks[arr.chunks.length - 1]!,
       height: arr.chunks[arr.chunks.length - 2]!,

--- a/packages/deck.gl-zarr/src/zarr-layer.ts
+++ b/packages/deck.gl-zarr/src/zarr-layer.ts
@@ -14,7 +14,12 @@ import type {
 } from "@deck.gl/geo-layers";
 import { TileLayer } from "@deck.gl/geo-layers";
 import * as affineLib from "@developmentseed/affine";
-import { RasterLayer, RasterTileset2D } from "@developmentseed/deck.gl-raster";
+import type { TileMetadata } from "@developmentseed/deck.gl-raster";
+import {
+  RasterLayer,
+  RasterTileset2D,
+  _renderDebugTileOutline as renderDebugTileOutline,
+} from "@developmentseed/deck.gl-raster";
 import type { GeoZarrMetadata } from "@developmentseed/geozarr";
 import { parseGeoZarrMetadata } from "@developmentseed/geozarr";
 import type {
@@ -318,8 +323,24 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
   ): Layer | LayersList | null {
     const { maxError, debug, debugOpacity } = this.props;
 
+    // Cast to include TileMetadata from raster-tileset's `getTileMetadata`
+    // method.
+    // TODO: implement generic handling of tile metadata upstream in TileLayer
+    const tile = props.tile as Tile2DHeader & TileMetadata;
+
+    const layers: Layer[] = [];
+    if (debug) {
+      layers.push(
+        ...renderDebugTileOutline(
+          `${this.id}-${tile.id}-bounds`,
+          tile,
+          forwardTo4326,
+        ),
+      );
+    }
+
     if (!props.data) {
-      return null;
+      return layers;
     }
 
     const { image, forwardTransform, inverseTransform, width, height } =
@@ -357,7 +378,7 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
       };
     }
 
-    return new RasterLayer(
+    const rasterLayer = new RasterLayer(
       this.getSubLayerProps({
         id: `${props.id}-raster`,
         image,
@@ -370,6 +391,7 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
         ...deckProjectionProps,
       }),
     );
+    return [rasterLayer, ...layers];
   }
 
   renderTileLayer(

--- a/packages/deck.gl-zarr/src/zarr-layer.ts
+++ b/packages/deck.gl-zarr/src/zarr-layer.ts
@@ -89,7 +89,9 @@ export type ZarrLayerProps<
     debugOpacity?: number;
 
     /** Called when Zarr metadata has been loaded and parsed. */
-    onZarrLoad?: (meta: GeoZarrMetadata) => void;
+    // TODO: restore onZarrLoad once we understand what metadata we should pass
+    // through it.
+    // onZarrLoad?: (meta: GeoZarrMetadata) => void;
 
     /** User-provided AbortSignal to cancel loading. */
     signal?: AbortSignal;
@@ -244,8 +246,6 @@ export class ZarrLayer extends CompositeLayer<ZarrLayerProps> {
     const mpu = metersPerUnit(units as Parameters<typeof metersPerUnit>[0], {
       semiMajorAxis,
     });
-
-    this.props.onZarrLoad?.(meta);
 
     this.setState({
       meta,

--- a/packages/geozarr/src/parse.ts
+++ b/packages/geozarr/src/parse.ts
@@ -36,7 +36,7 @@ export function parseGeoZarrMetadata(attrs: unknown): GeoZarrMetadata {
   } else if ("proj:wkt2" in geoProj) {
     crs.wkt2 = geoProj["proj:wkt2"];
   } else if ("proj:projjson" in geoProj) {
-    crs.projjson = geoProj["proj:projjson"] as Record<string, unknown>;
+    crs.projjson = geoProj["proj:projjson"];
   }
 
   // --- Axes ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,61 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  examples/zarr-sentinel2-tci:
+    dependencies:
+      '@deck.gl/core':
+        specifier: ^9.2.11
+        version: 9.2.11
+      '@deck.gl/geo-layers':
+        specifier: ^9.2.11
+        version: 9.2.11(@deck.gl/core@9.2.11)(@deck.gl/extensions@9.2.5(@deck.gl/core@9.2.11)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6))))(@deck.gl/layers@9.2.11(@deck.gl/core@9.2.11)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6))))(@deck.gl/mesh-layers@9.2.11(@deck.gl/core@9.2.11)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/gltf@9.2.6(@luma.gl/constants@9.2.6)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@loaders.gl/core@4.3.4)(@luma.gl/constants@9.2.6)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))
+      '@deck.gl/layers':
+        specifier: ^9.2.11
+        version: 9.2.11(@deck.gl/core@9.2.11)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))
+      '@deck.gl/mapbox':
+        specifier: ^9.2.11
+        version: 9.2.11(@deck.gl/core@9.2.11)(@luma.gl/constants@9.2.6)(@luma.gl/core@9.2.6)(@math.gl/web-mercator@4.1.0)
+      '@deck.gl/mesh-layers':
+        specifier: ^9.2.11
+        version: 9.2.11(@deck.gl/core@9.2.11)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/gltf@9.2.6(@luma.gl/constants@9.2.6)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6))
+      '@developmentseed/deck.gl-zarr':
+        specifier: workspace:^
+        version: link:../../packages/deck.gl-zarr
+      '@luma.gl/core':
+        specifier: ^9.2.6
+        version: 9.2.6
+      maplibre-gl:
+        specifier: ^5.19.0
+        version: 5.19.0
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      react-map-gl:
+        specifier: ^8.1.0
+        version: 8.1.0(maplibre-gl@5.19.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      zarrita:
+        specifier: ^0.6.1
+        version: 0.6.1
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.4
+        version: 5.1.4(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      gh-pages:
+        specifier: ^6.3.0
+        version: 6.3.0
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/affine:
     devDependencies:
       '@types/node':


### PR DESCRIPTION

Data is served locally right now, generated via https://github.com/developmentseed/geozarr-examples/pull/36


https://github.com/user-attachments/assets/cd5b6a06-2aca-4ba4-bca7-0e4cc2fcbbee


### Change list

- New `ZarrLayer` that roughly parallels the `COGLayer`, using `zarrita.js` and looking for GeoZarr metadata 
    - For now it hard-codes the expectation that the input is an RGB GeoZarr, but that will be refactored and expanded soon.
- New `zarr-sentinel2-tci` example that renders a Sentinel2 image converted to GeoZarr with https://github.com/developmentseed/geozarr-examples/pull/36
- `renderDebugTileOutline` was shared exactly between `COGLayer` and `ZarrLayer`, so it was moved into `deck.gl-raster` to be shared

I think in the future we'll have more things that move into `deck.gl-raster` as utilities that can be shared across both the `COGLayer` and the `ZarrLayer`.

