### PR TITLE
fix: Use `MapboxOverlayProps` instead of `DeckProps` in example to fix type check

### DIFF
--- a/examples/cog-basic/src/App.tsx
+++ b/examples/cog-basic/src/App.tsx
@@ -1,4 +1,4 @@
-import type { DeckProps } from "@deck.gl/core";
+import type { MapboxOverlayProps } from "@deck.gl/mapbox";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import { COGLayer } from "@developmentseed/deck.gl-geotiff";
 import "maplibre-gl/dist/maplibre-gl.css";
@@ -7,7 +7,7 @@ import { useRef, useState } from "react";
 import type { MapRef } from "react-map-gl/maplibre";
 import { Map as MaplibreMap, useControl } from "react-map-gl/maplibre";
 
-function DeckGLOverlay(props: DeckProps) {
+function DeckGLOverlay(props: MapboxOverlayProps) {
   const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));
   overlay.setProps(props);
   return null;

--- a/examples/land-cover/src/App.tsx
+++ b/examples/land-cover/src/App.tsx
@@ -1,4 +1,4 @@
-import type { DeckProps } from "@deck.gl/core";
+import type { MapboxOverlayProps } from "@deck.gl/mapbox";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import { COGLayer } from "@developmentseed/deck.gl-geotiff";
 import "maplibre-gl/dist/maplibre-gl.css";
@@ -11,7 +11,7 @@ import { Map as MaplibreMap, useControl } from "react-map-gl/maplibre";
 import { InfoPanel } from "./components/InfoPanel";
 import { UIOverlay } from "./components/UIOverlay";
 
-function DeckGLOverlay(props: DeckProps) {
+function DeckGLOverlay(props: MapboxOverlayProps) {
   const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));
   overlay.setProps(props);
   return null;

--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -1,4 +1,4 @@
-import type { DeckProps } from "@deck.gl/core";
+import type { MapboxOverlayProps } from "@deck.gl/mapbox";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import { COGLayer, MosaicLayer } from "@developmentseed/deck.gl-geotiff";
 import type {
@@ -27,7 +27,7 @@ import { epsgResolver } from "./proj";
 /** Bounding box query passed to Microsoft Planetary Computer STAC API */
 const STAC_BBOX = [-106.6059, 38.7455, -104.5917, 40.4223];
 
-function DeckGLOverlay(props: DeckProps) {
+function DeckGLOverlay(props: MapboxOverlayProps) {
   const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));
   overlay.setProps(props);
   return null;


### PR DESCRIPTION
This means that the `interleaved` prop now type checks