### PR TITLE
feat(geotiff): Support multi-tile fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.superpowers
 *.wkt
 *.xml
 

--- a/packages/geotiff/src/assemble.ts
+++ b/packages/geotiff/src/assemble.ts
@@ -1,0 +1,334 @@
+import type { RasterArray, RasterTypedArray } from "./array.js";
+import type { Tile } from "./tile.js";
+
+/**
+ * Options for {@link assembleTiles}.
+ */
+export interface AssembleTilesOptions {
+  /** Total output width in pixels. */
+  width: number;
+  /** Total output height in pixels. */
+  height: number;
+  /** Tile width in pixels (all tiles must share this). */
+  tileWidth: number;
+  /** Tile height in pixels (all tiles must share this). */
+  tileHeight: number;
+  /** Column index of the leftmost tile in the grid. */
+  minCol: number;
+  /** Row index of the topmost tile in the grid. */
+  minRow: number;
+}
+
+/**
+ * Assemble multiple fetched tiles into a single {@link RasterArray}.
+ *
+ * Handles both pixel-interleaved and band-separate layouts, preserving the
+ * original typed array type (e.g. `Float32Array`, `Uint16Array`). Masks are
+ * assembled alongside data when present.
+ *
+ * The output array's `transform`, `crs`, and `nodata` are taken from the
+ * top-left tile (the tile at `(minCol, minRow)`).
+ *
+ * @param tiles - Fetched tiles to assemble. Must form a contiguous rectangular
+ *   grid and all share the same layout, band count, and typed array type.
+ * @param opts - Describes the output grid dimensions and tile positions.
+ * @returns A single {@link RasterArray} containing the assembled data.
+ *
+ * @see {@link AssembleTilesOptions}
+ */
+export function assembleTiles(
+  tiles: Tile[],
+  opts: AssembleTilesOptions,
+): RasterArray {
+  validateContiguousGrid(tiles, opts);
+
+  const { width, height, tileWidth, tileHeight, minCol, minRow } = opts;
+  const firstArray = tiles[0]!.array;
+  const { count, crs, nodata } = firstArray;
+
+  // Find the top-left tile for transform reference
+  const topLeftTile =
+    tiles.find((t) => t.x === minCol && t.y === minRow) ?? tiles[0]!;
+
+  // Determine if any tile has a mask
+  const hasMask = tiles.some((t) => t.array.mask !== null);
+
+  // Assemble mask if needed
+  let outputMask: Uint8Array | null = null;
+  if (hasMask) {
+    outputMask = new Uint8Array(width * height);
+    for (const tile of tiles) {
+      const colOffset = (tile.x - minCol) * tileWidth;
+      const rowOffset = (tile.y - minRow) * tileHeight;
+      const srcMask = tile.array.mask;
+      if (srcMask === null) {
+        // No mask on this tile — fill with 255 (all valid)
+        fillRows(outputMask, {
+          dstWidth: width,
+          colOffset,
+          rowOffset,
+          fillWidth: tile.array.width,
+          fillHeight: tile.array.height,
+          value: 255,
+        });
+      } else {
+        copyRows(srcMask, outputMask, {
+          srcWidth: tile.array.width,
+          dstWidth: width,
+          colOffset,
+          rowOffset,
+          copyWidth: tile.array.width,
+          copyHeight: tile.array.height,
+          samplesPerPixel: 1,
+        });
+      }
+    }
+  }
+
+  const arrayMeta = {
+    count,
+    transform: topLeftTile.array.transform,
+    crs,
+    nodata,
+    mask: outputMask,
+  };
+
+  if (firstArray.layout === "pixel-interleaved") {
+    return assemblePixelInterleaved(tiles, opts, arrayMeta);
+  }
+
+  return assembleBandSeparate(tiles, opts, arrayMeta);
+}
+
+/** Metadata carried from the source tiles into the assembled output. */
+interface ArrayMeta {
+  count: number;
+  transform: RasterArray["transform"];
+  crs: RasterArray["crs"];
+  nodata: RasterArray["nodata"];
+  mask: Uint8Array | null;
+}
+
+/**
+ * Assemble pixel-interleaved tiles into a single pixel-interleaved
+ * {@link RasterArray}.
+ */
+function assemblePixelInterleaved(
+  tiles: Tile[],
+  opts: AssembleTilesOptions,
+  meta: ArrayMeta,
+): RasterArray {
+  const { width, height, tileWidth, tileHeight, minCol, minRow } = opts;
+  const { count, transform, crs, nodata, mask } = meta;
+  const firstArray = tiles[0]!.array;
+
+  if (firstArray.layout !== "pixel-interleaved") {
+    throw new Error("Expected pixel-interleaved layout");
+  }
+
+  // Allocate output with the same typed array type as the input
+  const Ctor = firstArray.data.constructor as new (
+    length: number,
+  ) => RasterTypedArray;
+  const outputData = new Ctor(width * height * count);
+
+  for (const tile of tiles) {
+    const { array } = tile;
+    if (array.layout !== "pixel-interleaved") {
+      throw new Error(
+        "All tiles must have the same layout; expected pixel-interleaved",
+      );
+    }
+
+    const colOffset = (tile.x - minCol) * tileWidth;
+    const rowOffset = (tile.y - minRow) * tileHeight;
+
+    copyRows(array.data, outputData, {
+      srcWidth: array.width,
+      dstWidth: width,
+      colOffset,
+      rowOffset,
+      copyWidth: array.width,
+      copyHeight: array.height,
+      samplesPerPixel: count,
+    });
+  }
+
+  return {
+    layout: "pixel-interleaved",
+    data: outputData,
+    count,
+    width,
+    height,
+    mask,
+    transform,
+    crs,
+    nodata,
+  };
+}
+
+/**
+ * Assemble band-separate tiles into a single band-separate
+ * {@link RasterArray}.
+ */
+function assembleBandSeparate(
+  tiles: Tile[],
+  opts: AssembleTilesOptions,
+  meta: ArrayMeta,
+): RasterArray {
+  const { width, height, tileWidth, tileHeight, minCol, minRow } = opts;
+  const { count, transform, crs, nodata, mask } = meta;
+  const firstArray = tiles[0]!.array;
+
+  if (firstArray.layout !== "band-separate") {
+    throw new Error("Expected band-separate layout");
+  }
+
+  // Allocate output bands with the same typed array type as the input
+  const Ctor = firstArray.bands[0]!.constructor as new (
+    length: number,
+  ) => RasterTypedArray;
+  const outputBands: RasterTypedArray[] = [];
+  for (let b = 0; b < count; b++) {
+    outputBands.push(new Ctor(width * height));
+  }
+
+  for (const tile of tiles) {
+    const { array } = tile;
+    if (array.layout !== "band-separate") {
+      throw new Error("All tiles must have the same layout");
+    }
+
+    const colOffset = (tile.x - minCol) * tileWidth;
+    const rowOffset = (tile.y - minRow) * tileHeight;
+
+    for (let b = 0; b < count; b++) {
+      copyRows(array.bands[b]!, outputBands[b]!, {
+        srcWidth: array.width,
+        dstWidth: width,
+        colOffset,
+        rowOffset,
+        copyWidth: array.width,
+        copyHeight: array.height,
+        samplesPerPixel: 1,
+      });
+    }
+  }
+
+  return {
+    layout: "band-separate",
+    bands: outputBands,
+    count,
+    width,
+    height,
+    mask,
+    transform,
+    crs,
+    nodata,
+  };
+}
+
+/**
+ * Copy rows from a source typed array into a destination typed array,
+ * accounting for the stride difference between source and destination widths.
+ *
+ * For pixel-interleaved data, `samplesPerPixel` must be the band count so
+ * that each pixel's samples are copied together.
+ */
+function copyRows(
+  src: RasterTypedArray,
+  dst: RasterTypedArray,
+  opts: {
+    srcWidth: number;
+    dstWidth: number;
+    colOffset: number;
+    rowOffset: number;
+    copyWidth: number;
+    copyHeight: number;
+    samplesPerPixel: number;
+  },
+): void {
+  const {
+    srcWidth,
+    dstWidth,
+    colOffset,
+    rowOffset,
+    copyWidth,
+    copyHeight,
+    samplesPerPixel,
+  } = opts;
+  const srcStride = srcWidth * samplesPerPixel;
+  const dstStride = dstWidth * samplesPerPixel;
+  const copyStride = copyWidth * samplesPerPixel;
+
+  for (let row = 0; row < copyHeight; row++) {
+    const srcStart = row * srcStride;
+    const dstStart =
+      (rowOffset + row) * dstStride + colOffset * samplesPerPixel;
+    dst.set(src.subarray(srcStart, srcStart + copyStride), dstStart);
+  }
+}
+
+/**
+ * Validate that the tiles form a contiguous rectangular grid matching the
+ * expected dimensions. Throws if tiles are missing, duplicated, or outside
+ * the expected range.
+ */
+function validateContiguousGrid(
+  tiles: Tile[],
+  opts: AssembleTilesOptions,
+): void {
+  if (tiles.length === 0) {
+    throw new Error("At least one tile is required");
+  }
+
+  const { width, height, tileWidth, tileHeight, minCol, minRow } = opts;
+  const numCols = width / tileWidth;
+  const numRows = height / tileHeight;
+  const expectedCount = numCols * numRows;
+
+  if (tiles.length !== expectedCount) {
+    throw new Error(
+      `Expected ${expectedCount} tiles for a ${numCols}x${numRows} grid, got ${tiles.length}`,
+    );
+  }
+
+  const seen = new Set<string>();
+  for (const tile of tiles) {
+    const col = tile.x - minCol;
+    const row = tile.y - minRow;
+    if (col < 0 || col >= numCols || row < 0 || row >= numRows) {
+      throw new Error(
+        `Tile (${tile.x}, ${tile.y}) is outside the expected grid range ` +
+          `[${minCol}..${minCol + numCols - 1}] x [${minRow}..${minRow + numRows - 1}]`,
+      );
+    }
+    const key = `${tile.x},${tile.y}`;
+    if (seen.has(key)) {
+      throw new Error(`Duplicate tile at (${tile.x}, ${tile.y})`);
+    }
+    seen.add(key);
+  }
+}
+
+/**
+ * Fill rows in a destination array with a constant value. Used when a tile
+ * has no mask but other tiles in the assembly do.
+ */
+function fillRows(
+  dst: Uint8Array,
+  opts: {
+    dstWidth: number;
+    colOffset: number;
+    rowOffset: number;
+    fillWidth: number;
+    fillHeight: number;
+    value: number;
+  },
+): void {
+  const { dstWidth, colOffset, rowOffset, fillWidth, fillHeight, value } = opts;
+  for (let row = 0; row < fillHeight; row++) {
+    const dstStart = (rowOffset + row) * dstWidth + colOffset;
+    dst.fill(value, dstStart, dstStart + fillWidth);
+  }
+}

--- a/packages/geotiff/src/fetch.ts
+++ b/packages/geotiff/src/fetch.ts
@@ -112,6 +112,40 @@ export async function fetchTile(
   };
 }
 
+/**
+ * Fetch multiple tiles from a GeoTIFF or Overview in parallel.
+ *
+ * The benefit of using this over multiple calls to {@link fetchTile} is that
+ * a future implementation can coalesce requests for tiles stored contiguously
+ * on disk, reducing the number of HTTP range requests. For now, this simply
+ * calls {@link fetchTile} in parallel for each coordinate.
+ *
+ * @param self - The GeoTIFF or Overview to fetch tiles from.
+ * @param xy - Array of `[x, y]` tile coordinates.
+ * @param options - Optional parameters (same as {@link fetchTile}).
+ * @returns Array of {@link Tile} objects in the same order as `xy`.
+ *
+ * @see {@link fetchTile} for single-tile fetching.
+ */
+export async function fetchTiles(
+  self: HasTiffReference,
+  xy: Array<[number, number]>,
+  {
+    boundless = true,
+    pool,
+    signal,
+  }: {
+    boundless?: boolean;
+    pool?: DecoderPool;
+    signal?: AbortSignal;
+  } = {},
+): Promise<Tile[]> {
+  // TODO: coalesce contiguous byte ranges for fewer HTTP requests
+  return Promise.all(
+    xy.map(([x, y]) => fetchTile(self, x, y, { boundless, pool, signal })),
+  );
+}
+
 type GetBytesResponse = { bytes: ArrayBuffer; compression: Compression };
 type ByteRange = Awaited<ReturnType<TiffImage["getTileSize"]>>;
 

--- a/packages/geotiff/src/geotiff.ts
+++ b/packages/geotiff/src/geotiff.ts
@@ -7,7 +7,7 @@ import { Photometric, SubFileType, Tiff, TiffTag } from "@cogeotiff/core";
 import type { Affine } from "@developmentseed/affine";
 import type { ProjJson } from "@developmentseed/proj";
 import { crsFromGeoKeys } from "./crs.js";
-import { fetchTile } from "./fetch.js";
+import { fetchTile, fetchTiles } from "./fetch.js";
 import type { BandStatistics, GDALMetadata } from "./gdal-metadata.js";
 import { parseGDALMetadata } from "./gdal-metadata.js";
 import type { CachedTags, GeoKeyDirectory } from "./ifd.js";
@@ -386,6 +386,29 @@ export class GeoTIFF {
     } = {},
   ): Promise<Tile> {
     return await fetchTile(this, x, y, options);
+  }
+
+  /**
+   * Fetch multiple tiles in parallel.
+   *
+   * A future implementation may coalesce contiguous byte ranges to reduce
+   * the number of HTTP requests.
+   *
+   * @param xy - Array of `[x, y]` tile coordinates.
+   * @param options - Optional parameters (same as {@link fetchTile}).
+   * @returns Array of {@link Tile} objects in the same order as `xy`.
+   *
+   * @see {@link fetchTile} for single-tile fetching.
+   */
+  async fetchTiles(
+    xy: Array<[number, number]>,
+    options: {
+      boundless?: boolean;
+      pool?: DecoderPool;
+      signal?: AbortSignal;
+    } = {},
+  ): Promise<Tile[]> {
+    return await fetchTiles(this, xy, options);
   }
 
   // Transform mixin

--- a/packages/geotiff/src/index.ts
+++ b/packages/geotiff/src/index.ts
@@ -5,6 +5,8 @@ export type {
   RasterArrayPixelInterleaved,
   RasterTypedArray,
 } from "./array.js";
+export type { AssembleTilesOptions } from "./assemble.js";
+export { assembleTiles } from "./assemble.js";
 export { parseColormap } from "./colormap.js";
 export type {
   DecodedBandSeparate,

--- a/packages/geotiff/src/overview.ts
+++ b/packages/geotiff/src/overview.ts
@@ -2,7 +2,7 @@ import type { Source, TiffImage, TiffImageTileCount } from "@cogeotiff/core";
 import type { Affine } from "@developmentseed/affine";
 import { compose, scale } from "@developmentseed/affine";
 import type { ProjJson } from "@developmentseed/proj";
-import { fetchTile } from "./fetch.js";
+import { fetchTile, fetchTiles } from "./fetch.js";
 import type { GeoTIFF } from "./geotiff.js";
 import type { CachedTags, GeoKeyDirectory } from "./ifd.js";
 import type { DecoderPool } from "./pool/pool.js";
@@ -119,6 +119,29 @@ export class Overview {
     } = {},
   ): Promise<Tile> {
     return await fetchTile(this, x, y, options);
+  }
+
+  /**
+   * Fetch multiple tiles in parallel.
+   *
+   * A future implementation may coalesce contiguous byte ranges to reduce
+   * the number of HTTP requests.
+   *
+   * @param xy - Array of `[x, y]` tile coordinates.
+   * @param options - Optional parameters (same as {@link fetchTile}).
+   * @returns Array of {@link Tile} objects in the same order as `xy`.
+   *
+   * @see {@link fetchTile} for single-tile fetching.
+   */
+  async fetchTiles(
+    xy: Array<[number, number]>,
+    options: {
+      boundless?: boolean;
+      pool?: DecoderPool;
+      signal?: AbortSignal;
+    } = {},
+  ): Promise<Tile[]> {
+    return await fetchTiles(this, xy, options);
   }
 
   // TiledMixin

--- a/packages/geotiff/tests/assemble.test.ts
+++ b/packages/geotiff/tests/assemble.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, it } from "vitest";
+import type { RasterArray } from "../src/array.js";
+import { assembleTiles } from "../src/assemble.js";
+import type { Tile } from "../src/tile.js";
+
+/** Helper: create a pixel-interleaved tile with sequential values. */
+function makeInterleavedTile(opts: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  count: number;
+  /** Starting value for sequential fill. */
+  startValue?: number;
+}): Tile {
+  const { x, y, width, height, count, startValue = 0 } = opts;
+  const data = new Uint8Array(width * height * count);
+  for (let i = 0; i < data.length; i++) {
+    data[i] = (startValue + i) % 256;
+  }
+  const identity = [1, 0, 0, 0, 1, 0] as [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+  ];
+  const array: RasterArray = {
+    layout: "pixel-interleaved",
+    data,
+    count,
+    width,
+    height,
+    mask: null,
+    transform: identity,
+    crs: 4326,
+    nodata: null,
+  };
+  return { x, y, array };
+}
+
+/** Helper: create a band-separate tile with sequential values per band. */
+function makeBandSeparateTile(opts: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  count: number;
+  startValue?: number;
+}): Tile {
+  const { x, y, width, height, count, startValue = 0 } = opts;
+  const bands = [];
+  for (let b = 0; b < count; b++) {
+    const band = new Uint8Array(width * height);
+    for (let i = 0; i < band.length; i++) {
+      band[i] = (startValue + b * 100 + i) % 256;
+    }
+    bands.push(band);
+  }
+  const identity = [1, 0, 0, 0, 1, 0] as [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+  ];
+  const array: RasterArray = {
+    layout: "band-separate",
+    bands,
+    count,
+    width,
+    height,
+    mask: null,
+    transform: identity,
+    crs: 4326,
+    nodata: null,
+  };
+  return { x, y, array };
+}
+
+describe("assembleTiles", () => {
+  describe("single tile (no stitching)", () => {
+    it("returns the tile's array directly for pixel-interleaved", () => {
+      const tile = makeInterleavedTile({
+        x: 0,
+        y: 0,
+        width: 4,
+        height: 4,
+        count: 1,
+      });
+      const result = assembleTiles([tile], {
+        width: 4,
+        height: 4,
+        tileWidth: 4,
+        tileHeight: 4,
+        minCol: 0,
+        minRow: 0,
+      });
+      expect(result.width).toBe(4);
+      expect(result.height).toBe(4);
+      expect(result.layout).toBe("pixel-interleaved");
+      expect(tile.array.layout).toBe("pixel-interleaved");
+      if (
+        result.layout === "pixel-interleaved" &&
+        tile.array.layout === "pixel-interleaved"
+      ) {
+        expect(result.data).toEqual(tile.array.data);
+      }
+    });
+  });
+
+  describe("pixel-interleaved stitching", () => {
+    it("stitches two tiles horizontally (single band)", () => {
+      // Two 2x2 tiles side by side → 4x2 output
+      const left = makeInterleavedTile({
+        x: 0,
+        y: 0,
+        width: 2,
+        height: 2,
+        count: 1,
+        startValue: 10,
+      });
+      const right = makeInterleavedTile({
+        x: 1,
+        y: 0,
+        width: 2,
+        height: 2,
+        count: 1,
+        startValue: 20,
+      });
+
+      const result = assembleTiles([left, right], {
+        width: 4,
+        height: 2,
+        tileWidth: 2,
+        tileHeight: 2,
+        minCol: 0,
+        minRow: 0,
+      });
+
+      expect(result.width).toBe(4);
+      expect(result.height).toBe(2);
+      expect(result.layout).toBe("pixel-interleaved");
+      if (result.layout === "pixel-interleaved") {
+        // Row 0: left[0,1], right[0,1] = [10, 11, 20, 21]
+        // Row 1: left[2,3], right[2,3] = [12, 13, 22, 23]
+        expect(Array.from(result.data)).toEqual([
+          10, 11, 20, 21, 12, 13, 22, 23,
+        ]);
+      }
+    });
+
+    it("stitches two tiles horizontally (multi-band)", () => {
+      // Two 2x2 tiles with 3 bands each → 4x2 output
+      const left = makeInterleavedTile({
+        x: 0,
+        y: 0,
+        width: 2,
+        height: 2,
+        count: 3,
+        startValue: 0,
+      });
+      const right = makeInterleavedTile({
+        x: 1,
+        y: 0,
+        width: 2,
+        height: 2,
+        count: 3,
+        startValue: 100,
+      });
+
+      const result = assembleTiles([left, right], {
+        width: 4,
+        height: 2,
+        tileWidth: 2,
+        tileHeight: 2,
+        minCol: 0,
+        minRow: 0,
+      });
+
+      expect(result.width).toBe(4);
+      expect(result.height).toBe(2);
+      expect(result.count).toBe(3);
+      if (result.layout === "pixel-interleaved") {
+        // Row 0: left pixel(0,0)[3 bands] + left pixel(1,0)[3 bands] +
+        //         right pixel(0,0)[3 bands] + right pixel(1,0)[3 bands]
+        // left data:  [0,1,2, 3,4,5, ...]
+        // right data: [100,101,102, 103,104,105, ...]
+        // Row 0 output: [0,1,2, 3,4,5, 100,101,102, 103,104,105]
+        const row0 = Array.from(result.data.subarray(0, 12));
+        expect(row0).toEqual([0, 1, 2, 3, 4, 5, 100, 101, 102, 103, 104, 105]);
+      }
+    });
+
+    it("stitches 2x2 grid of tiles", () => {
+      // Four 2x2 tiles in a 2x2 grid → 4x4 output
+      const tl = makeInterleavedTile({
+        x: 0,
+        y: 0,
+        width: 2,
+        height: 2,
+        count: 1,
+        startValue: 1,
+      });
+      const tr = makeInterleavedTile({
+        x: 1,
+        y: 0,
+        width: 2,
+        height: 2,
+        count: 1,
+        startValue: 5,
+      });
+      const bl = makeInterleavedTile({
+        x: 0,
+        y: 1,
+        width: 2,
+        height: 2,
+        count: 1,
+        startValue: 9,
+      });
+      const br = makeInterleavedTile({
+        x: 1,
+        y: 1,
+        width: 2,
+        height: 2,
+        count: 1,
+        startValue: 13,
+      });
+
+      const result = assembleTiles([tl, tr, bl, br], {
+        width: 4,
+        height: 4,
+        tileWidth: 2,
+        tileHeight: 2,
+        minCol: 0,
+        minRow: 0,
+      });
+
+      expect(result.width).toBe(4);
+      expect(result.height).toBe(4);
+      if (result.layout === "pixel-interleaved") {
+        // Row 0: tl row0 [1,2] + tr row0 [5,6]
+        // Row 1: tl row1 [3,4] + tr row1 [7,8]
+        // Row 2: bl row0 [9,10] + br row0 [13,14]
+        // Row 3: bl row1 [11,12] + br row1 [15,16]
+        expect(Array.from(result.data)).toEqual([
+          1, 2, 5, 6, 3, 4, 7, 8, 9, 10, 13, 14, 11, 12, 15, 16,
+        ]);
+      }
+    });
+
+    it("handles non-zero minCol/minRow offset", () => {
+      // A single tile at position (3, 5) with minCol=3, minRow=5
+      const tile = makeInterleavedTile({
+        x: 3,
+        y: 5,
+        width: 2,
+        height: 2,
+        count: 1,
+        startValue: 42,
+      });
+
+      const result = assembleTiles([tile], {
+        width: 2,
+        height: 2,
+        tileWidth: 2,
+        tileHeight: 2,
+        minCol: 3,
+        minRow: 5,
+      });
+
+      if (result.layout === "pixel-interleaved") {
+        expect(Array.from(result.data)).toEqual([42, 43, 44, 45]);
+      }
+    });
+  });
+
+  describe("band-separate stitching", () => {
+    it("stitches two tiles horizontally", () => {
+      const left = makeBandSeparateTile({
+        x: 0,
+        y: 0,
+        width: 2,
+        height: 2,
+        count: 2,
+        startValue: 0,
+      });
+      const right = makeBandSeparateTile({
+        x: 1,
+        y: 0,
+        width: 2,
+        height: 2,
+        count: 2,
+        startValue: 50,
+      });
+
+      const result = assembleTiles([left, right], {
+        width: 4,
+        height: 2,
+        tileWidth: 2,
+        tileHeight: 2,
+        minCol: 0,
+        minRow: 0,
+      });
+
+      expect(result.width).toBe(4);
+      expect(result.height).toBe(2);
+      expect(result.count).toBe(2);
+      expect(result.layout).toBe("band-separate");
+      if (result.layout === "band-separate") {
+        // Band 0: left startValue=0, right startValue=50
+        // Left band 0: [0,1,2,3] in 2x2 → row0=[0,1], row1=[2,3]
+        // Right band 0: [50,51,52,53] → row0=[50,51], row1=[52,53]
+        // Output band 0 (4x2): row0=[0,1,50,51], row1=[2,3,52,53]
+        expect(Array.from(result.bands[0]!)).toEqual([
+          0, 1, 50, 51, 2, 3, 52, 53,
+        ]);
+      }
+    });
+  });
+
+  describe("mask stitching", () => {
+    it("stitches masks alongside data", () => {
+      const identity = [1, 0, 0, 0, 1, 0] as [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+      ];
+      const left: Tile = {
+        x: 0,
+        y: 0,
+        array: {
+          layout: "pixel-interleaved",
+          data: new Uint8Array([1, 2, 3, 4]),
+          count: 1,
+          width: 2,
+          height: 2,
+          mask: new Uint8Array([255, 255, 0, 0]),
+          transform: identity,
+          crs: 4326,
+          nodata: null,
+        },
+      };
+      const right: Tile = {
+        x: 1,
+        y: 0,
+        array: {
+          layout: "pixel-interleaved",
+          data: new Uint8Array([5, 6, 7, 8]),
+          count: 1,
+          width: 2,
+          height: 2,
+          mask: new Uint8Array([0, 0, 255, 255]),
+          transform: identity,
+          crs: 4326,
+          nodata: null,
+        },
+      };
+
+      const result = assembleTiles([left, right], {
+        width: 4,
+        height: 2,
+        tileWidth: 2,
+        tileHeight: 2,
+        minCol: 0,
+        minRow: 0,
+      });
+
+      expect(result.mask).not.toBeNull();
+      // Row 0: left mask [255,255] + right mask [0,0]
+      // Row 1: left mask [0,0] + right mask [255,255]
+      expect(Array.from(result.mask!)).toEqual([
+        255, 255, 0, 0, 0, 0, 255, 255,
+      ]);
+    });
+  });
+
+  describe("typed array preservation", () => {
+    it("preserves Float32Array type", () => {
+      const identity = [1, 0, 0, 0, 1, 0] as [
+        number,
+        number,
+        number,
+        number,
+        number,
+        number,
+      ];
+      const tile: Tile = {
+        x: 0,
+        y: 0,
+        array: {
+          layout: "pixel-interleaved",
+          data: new Float32Array([1.5, 2.5, 3.5, 4.5]),
+          count: 1,
+          width: 2,
+          height: 2,
+          mask: null,
+          transform: identity,
+          crs: 4326,
+          nodata: null,
+        },
+      };
+
+      const result = assembleTiles([tile], {
+        width: 2,
+        height: 2,
+        tileWidth: 2,
+        tileHeight: 2,
+        minCol: 0,
+        minRow: 0,
+      });
+
+      if (result.layout === "pixel-interleaved") {
+        expect(result.data).toBeInstanceOf(Float32Array);
+        expect(Array.from(result.data)).toEqual([1.5, 2.5, 3.5, 4.5]);
+      }
+    });
+  });
+});


### PR DESCRIPTION
### Change list

- Adds new `GeoTIFF.fetchTiles` and `Overview.fetchTiles` to fetch multiple tiles at once from a GeoTIFF. For now this just makes multiple requests, but in the future we'll coalesce tile requests.
- Adds a new `assembleTiles` helper to stitch multiple contiguous tiles into a single `RasterArray`.
	- This will also form the basis of a future `read` helper: https://github.com/developmentseed/deck.gl-raster/issues/405
