### PR TITLE
feat: Initial work for `MultiCOGLayer`: cross-resolution tileset for sentinel/landsat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.superpowers
 *.wkt
 *.xml
 

--- a/dev-docs/gpu-modules.md
+++ b/dev-docs/gpu-modules.md
@@ -1,0 +1,99 @@
+# GPU Modules (luma.gl ShaderModule) Guide
+
+## Key Rules for Uniform Binding
+
+luma.gl's `ShaderModule` system has two distinct paths for binding values to shaders. Getting these wrong results in uniforms silently defaulting to 0.
+
+### Scalar Uniforms (numbers, vectors, matrices)
+
+Scalar uniforms **must** use all three of:
+
+1. **`fs:`** — A uniform block declaration string
+2. **`uniformTypes:`** — A mapping of uniform names to type strings
+3. **`getUniforms:`** — Returns the values keyed by uniform name
+
+The uniform block name must follow the pattern `<moduleName>Uniforms` and the instance name must match the module's `name` field. Access uniforms in GLSL as `<moduleName>.<uniformName>`.
+
+```ts
+const MODULE_NAME = "myModule";
+
+export const MyModule = {
+  name: MODULE_NAME,
+  fs: `\
+uniform ${MODULE_NAME}Uniforms {
+  float myValue;
+  vec4 myVector;
+} ${MODULE_NAME};
+`,
+  uniformTypes: {
+    myValue: "f32",
+    myVector: "vec4<f32>",
+  },
+  inject: {
+    "fs:DECKGL_FILTER_COLOR": `
+      color.rgb *= ${MODULE_NAME}.myValue;
+    `,
+  },
+  getUniforms: (props) => ({
+    myValue: props.myValue ?? 1.0,
+    myVector: props.myVector ?? [0, 0, 0, 0],
+  }),
+};
+```
+
+**Without `uniformTypes` and the `fs:` uniform block, scalar uniforms will silently be 0.**
+
+### Texture Bindings (sampler2D)
+
+Texture bindings use a different path:
+
+1. **`inject["fs:#decl"]:`** — Declare `uniform sampler2D <name>;`
+2. **`getUniforms:`** — Return the texture object keyed by the **same name** as the GLSL uniform
+
+Textures do NOT use `uniformTypes` or `fs:` uniform blocks.
+
+```ts
+export const MyTextureModule = {
+  name: "myTexture",
+  inject: {
+    "fs:#decl": `uniform sampler2D myTex;`,
+    "fs:DECKGL_FILTER_COLOR": `
+      color = texture(myTex, geometry.uv);
+    `,
+  },
+  getUniforms: (props) => ({
+    myTex: props.myTex,  // must match the GLSL uniform name exactly
+  }),
+};
+```
+
+**The prop key, `getUniforms` return key, and GLSL uniform name must all be identical.**
+
+### Mixing Textures and Scalars
+
+A single module can use both paths. Textures go through `inject` + `getUniforms`; scalars go through `fs:` uniform block + `uniformTypes` + `getUniforms`. The `getUniforms` function returns both textures and scalars together.
+
+See `CompositeBands` for a working example of this pattern.
+
+## How Props Flow
+
+1. `MeshTextureLayer.draw()` calls `model.shaderInputs.setProps({ [moduleName]: moduleProps })`
+2. luma.gl calls `module.getUniforms(moduleProps)` to get the combined uniforms + bindings
+3. Scalar values are matched against `uniformTypes` and written to the uniform buffer
+4. Texture values are matched by name against `uniform sampler2D` declarations and bound to texture units
+
+## Common Pitfalls
+
+- **Uniform is always 0**: Missing `uniformTypes` or `fs:` uniform block declaration
+- **Texture not bound / "Binding not found"**: Prop key doesn't match GLSL uniform name, or texture declared in uniform block instead of `inject`
+- **All textures sample the same value**: Textures declared but not actually bound — check that `getUniforms` returns them with matching keys
+
+## Existing Module Patterns
+
+| Module | Textures | Scalars | Pattern |
+|--------|----------|---------|---------|
+| `CreateTexture` | 1 (`textureName`) | none | inject only |
+| `MaskTexture` | 1 (`maskTexture`) | none | inject only |
+| `FilterNoDataVal` | none | 1 (`value`) | fs + uniformTypes |
+| `LinearRescale` | none | 2 (`rescaleMin`, `rescaleMax`) | fs + uniformTypes |
+| `CompositeBands` | 4 (`band0`–`band3`) | 5 (`uvTransform0`–`3`, `channelMap`) | both |

--- a/dev-docs/multi-resolution-status.md
+++ b/dev-docs/multi-resolution-status.md
@@ -1,0 +1,85 @@
+# Multi-Resolution Tileset — Current Status
+
+## What Works
+
+- **MultiTilesetDescriptor** (`deck.gl-raster`): Groups N tilesets at different resolutions, auto-selects finest as primary. Includes `selectSecondaryLevel` (with configurable strategy) and `tilesetLevelsEqual` for grid comparison.
+
+- **Secondary Tile Resolver** (`deck.gl-raster`): Computes which secondary tiles cover a primary tile and the UV transform to align them.
+
+- **CompositeBands GPU Module** (`deck.gl-raster`): Static shader module with 4 fixed band texture slots. Uses `channelMap` ivec4 to route bands to RGBA output. Works with the luma.gl uniform block pattern for scalars + inject pattern for textures (see `dev-docs/gpu-modules.md`).
+
+- **LinearRescale GPU Module** (`deck.gl-raster`): Linear `[min, max] -> [0, 1]` rescaling. Required for displaying uint16 data like Sentinel-2 reflectance.
+
+- **MultiCOGLayer** (`deck.gl-geotiff`): Opens multiple COGs in parallel, builds TilesetDescriptors, fetches tiles for all bands, creates GPU textures, and renders via CompositeBands + RasterLayer.
+
+- **Same-resolution rendering**: True color composite (B04 + B03 + B02, all 10m) renders correctly with distinct RGB channels and proper rescaling.
+
+- **fetchTiles + assembleTiles** (`geotiff`): Multi-tile fetch with proper typed-array-preserving stitching. Used by MultiCOGLayer for secondary tile assembly.
+
+- **Sentinel-2 example app** (`examples/sentinel-2`): Visual demo with preset band composites.
+
+## Known Issues
+
+### 1. Multi-resolution alignment (20m bands misaligned)
+
+**Status**: Not working correctly.
+
+When mixing 10m and 20m bands (e.g., SWIR composite with B12 at 20m), the 20m band tiles don't align with the 10m primary grid. The UV transforms from `resolveSecondaryTiles` may be incorrect, or there's an issue in how the stitched secondary texture maps to the primary tile's mesh.
+
+**Symptoms**: Visible tile-boundary artifacts — correct color in some tiles, wrong color (often solid blue or wrong hue) in others.
+
+**To debug**: Log the UV transforms computed by `resolveSecondaryTiles` and verify they match the expected geographic sub-region. Compare the CRS extents of primary tiles with their corresponding secondary tile coverage.
+
+### 2. Tile cache invalidation on preset switch
+
+**Status**: Not working.
+
+When switching between band composite presets, the `TileLayer` doesn't re-fetch tiles. Old cached tiles have band data for the previous preset, so `buildCompositeBandsProps` either crashes (band not found) or renders stale data. A guard returns `null` for stale tiles, but new data isn't fetched.
+
+**Fix needed**: Use `updateTriggers` on `getTileData` or change the `TileLayer` id/data when sources change to force a full reload.
+
+### 3. Texture format hardcoded
+
+**Status**: Works for uint8 and uint16 single-band, but limited.
+
+`createBandTexture` supports `r8unorm` (Uint8Array) and `r16unorm` (Uint16Array). Multi-band textures, float32, and other formats are not yet handled. Should eventually use `inferTextureFormat` from `texture.ts`.
+
+### 4. enforceAlignment for uint16
+
+**Status**: Works but may have edge cases.
+
+The `enforceAlignment`/`padToAlignment` function pads rows to 4-byte alignment for WebGL's `UNPACK_ALIGNMENT`. This works for most tile sizes but the interaction with odd-width clipped edge tiles and `Uint16Array` needs more testing.
+
+### 5. Band-separate layout not supported
+
+`createBandTexture` throws for band-separate raster layouts. Only pixel-interleaved is supported.
+
+## Architecture Decisions Made
+
+### luma.gl Shader Module Binding Rules
+
+Documented in `dev-docs/gpu-modules.md`. Key insight discovered during debugging:
+
+- **Scalar uniforms** (float, vec4, ivec4): Must use `fs:` uniform block + `uniformTypes` + `getUniforms`
+- **Texture bindings** (sampler2D): Must use `inject["fs:#decl"]` + `getUniforms` with matching key names
+- Without `uniformTypes`, scalar uniforms silently default to 0
+
+### Fixed Slot Design for CompositeBands
+
+Dynamic uniform names (per-band) don't work with luma.gl's binding system. Instead, 4 fixed slots (`band0`–`band3`) with an `ivec4 channelMap` that routes slots to RGBA output. `buildCompositeBandsProps` maps semantic band names to slot indices.
+
+## File Summary
+
+| File | Status |
+|------|--------|
+| `packages/deck.gl-raster/src/multi-raster-tileset/` | Complete |
+| `packages/deck.gl-raster/src/gpu-modules/composite-bands.ts` | Working (fixed slots) |
+| `packages/deck.gl-raster/src/gpu-modules/linear-rescale.ts` | Working |
+| `packages/deck.gl-raster/src/gpu-modules/types.ts` | Updated (wider prop types) |
+| `packages/deck.gl-geotiff/src/multi-cog-layer.ts` | Working for same-res, needs multi-res debugging |
+| `packages/geotiff/src/assemble.ts` | Complete |
+| `packages/geotiff/src/fetch.ts` | Complete (fetchTiles added) |
+| `examples/sentinel-2/` | Working demo |
+| `dev-docs/gpu-modules.md` | Reference doc for shader module patterns |
+| `dev-docs/specs/2026-04-09-multi-resolution-tileset-design.md` | Design spec |
+| `dev-docs/plans/2026-04-09-multi-resolution-tileset.md` | Implementation plan (partially executed) |

--- a/dev-docs/plans/2026-04-09-multi-resolution-tileset.md
+++ b/dev-docs/plans/2026-04-09-multi-resolution-tileset.md
@@ -1,0 +1,1775 @@
+# Multi-Resolution Tileset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable rendering multiple satellite bands at different spatial resolutions (10m, 20m, 60m) in a single shader pass, with GPU-side resampling via UV transforms.
+
+**Architecture:** A `MultiTilesetDescriptor` in `deck.gl-raster` describes the relationship between tile grids at different resolutions. A `MultiCOGLayer` in `deck.gl-geotiff` orchestrates fetching tiles from multiple COGs, stitching across tile boundaries, computing UV transforms, and passing named textures to the shader. The primary (highest-resolution) tileset drives tile traversal; secondary tilesets are consulted at fetch time.
+
+**Tech Stack:** TypeScript, deck.gl (CompositeLayer, TileLayer, Tileset2D), luma.gl (Texture, ShaderModule), geotiff.js, vitest, Biome
+
+**Spec:** `dev-docs/specs/2026-04-09-multi-resolution-tileset-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `packages/deck.gl-raster/src/raster-tileset/multi-tileset-descriptor.ts` | `MultiTilesetDescriptor` type + `createMultiTilesetDescriptor()` factory + `selectSecondaryLevel()` + `tilesetLevelsEqual()` |
+| `packages/deck.gl-raster/src/raster-tileset/secondary-tile-resolver.ts` | `resolveSecondaryTiles()` — computes covering tile ranges and UV transforms for a primary tile against a secondary tileset |
+| `packages/deck.gl-raster/src/gpu-modules/composite-bands.ts` | `CompositeBands` GPU module — samples named band textures with UV transforms, outputs `vec4` |
+| `packages/deck.gl-geotiff/src/multi-cog-layer.ts` | `MultiCOGLayer` — orchestrates multi-source COG loading, tile fetching, stitching, rendering |
+| `packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts` | Tests for `MultiTilesetDescriptor` creation and validation |
+| `packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts` | Tests for secondary tile resolution and UV transform computation |
+| `packages/deck.gl-raster/tests/composite-bands.test.ts` | Tests for `CompositeBands` module structure |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `packages/deck.gl-raster/src/raster-tileset/index.ts` | Export new types and functions |
+| `packages/deck.gl-raster/src/gpu-modules/index.ts` | Export `CompositeBands` |
+| `packages/deck.gl-raster/src/index.ts` | Export new public types |
+| `packages/deck.gl-geotiff/src/index.ts` | Export `MultiCOGLayer` |
+
+---
+
+## Task 1: MultiTilesetDescriptor Type and Factory
+
+**Files:**
+- Create: `packages/deck.gl-raster/src/raster-tileset/multi-tileset-descriptor.ts`
+- Test: `packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts`
+- Modify: `packages/deck.gl-raster/src/raster-tileset/index.ts`
+
+- [ ] **Step 1: Write tests for MultiTilesetDescriptor**
+
+Create test file with mock tilesets representing 10m and 20m grids:
+
+```ts
+// packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  createMultiTilesetDescriptor,
+  selectSecondaryLevel,
+  tilesetLevelsEqual,
+} from "../src/raster-tileset/multi-tileset-descriptor.js";
+import type {
+  TilesetDescriptor,
+  TilesetLevel,
+} from "../src/raster-tileset/tileset-interface.js";
+import type { Corners, Point } from "../src/raster-tileset/types.js";
+
+/** Helper: create a mock TilesetLevel */
+function mockLevel(opts: {
+  matrixWidth: number;
+  matrixHeight: number;
+  tileWidth: number;
+  tileHeight: number;
+  metersPerPixel: number;
+}): TilesetLevel {
+  return {
+    ...opts,
+    projectedTileCorners: (_col: number, _row: number): Corners => ({
+      topLeft: [0, 1] as Point,
+      topRight: [1, 1] as Point,
+      bottomLeft: [0, 0] as Point,
+      bottomRight: [1, 0] as Point,
+    }),
+    crsBoundsToTileRange: () => ({
+      minCol: 0,
+      maxCol: 0,
+      minRow: 0,
+      maxRow: 0,
+    }),
+  };
+}
+
+/** Helper: create a mock TilesetDescriptor */
+function mockDescriptor(levels: TilesetLevel[]): TilesetDescriptor {
+  const identity = (x: number, y: number): [number, number] => [x, y];
+  return {
+    levels,
+    projectTo3857: identity,
+    projectTo4326: identity,
+    projectedBounds: [600000, 7890000, 710000, 8000000],
+  };
+}
+
+describe("tilesetLevelsEqual", () => {
+  it("returns true for levels with same grid parameters", () => {
+    const a = mockLevel({
+      matrixWidth: 43,
+      matrixHeight: 43,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 10,
+    });
+    const b = mockLevel({
+      matrixWidth: 43,
+      matrixHeight: 43,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 10,
+    });
+    expect(tilesetLevelsEqual(a, b)).toBe(true);
+  });
+
+  it("returns false for levels with different grid parameters", () => {
+    const a = mockLevel({
+      matrixWidth: 43,
+      matrixHeight: 43,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 10,
+    });
+    const b = mockLevel({
+      matrixWidth: 22,
+      matrixHeight: 22,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 20,
+    });
+    expect(tilesetLevelsEqual(a, b)).toBe(false);
+  });
+});
+
+describe("createMultiTilesetDescriptor", () => {
+  it("selects the finest-resolution tileset as primary", () => {
+    const fine = mockDescriptor([
+      mockLevel({
+        matrixWidth: 1,
+        matrixHeight: 1,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 100,
+      }),
+      mockLevel({
+        matrixWidth: 43,
+        matrixHeight: 43,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 10,
+      }),
+    ]);
+    const coarse = mockDescriptor([
+      mockLevel({
+        matrixWidth: 1,
+        matrixHeight: 1,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 200,
+      }),
+      mockLevel({
+        matrixWidth: 22,
+        matrixHeight: 22,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 20,
+      }),
+    ]);
+
+    const multi = createMultiTilesetDescriptor(
+      new Map([
+        ["red", fine],
+        ["swir", coarse],
+      ]),
+    );
+
+    // Primary should be the 10m tileset (finest metersPerPixel at last level)
+    expect(multi.primary).toBe(fine);
+    expect(multi.secondaries.size).toBe(1);
+    expect(multi.secondaries.get("swir")).toBe(coarse);
+  });
+
+  it("does not include the primary key in secondaries", () => {
+    const fine = mockDescriptor([
+      mockLevel({
+        matrixWidth: 43,
+        matrixHeight: 43,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 10,
+      }),
+    ]);
+    const coarse = mockDescriptor([
+      mockLevel({
+        matrixWidth: 22,
+        matrixHeight: 22,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 20,
+      }),
+    ]);
+
+    const multi = createMultiTilesetDescriptor(
+      new Map([
+        ["red", fine],
+        ["swir", coarse],
+      ]),
+    );
+
+    expect(multi.secondaries.has("red")).toBe(false);
+  });
+});
+
+describe("selectSecondaryLevel", () => {
+  it("picks the finest level that is >= primary metersPerPixel", () => {
+    const levels = [
+      mockLevel({
+        matrixWidth: 1,
+        matrixHeight: 1,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 200,
+      }),
+      mockLevel({
+        matrixWidth: 5,
+        matrixHeight: 5,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 60,
+      }),
+      mockLevel({
+        matrixWidth: 22,
+        matrixHeight: 22,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 20,
+      }),
+    ];
+
+    // Primary at 10m — secondary's finest is 20m, which is the best available
+    const selected = selectSecondaryLevel(levels, 10);
+    expect(selected).toBe(levels[2]);
+  });
+
+  it("returns the finest level when all are coarser than primary", () => {
+    const levels = [
+      mockLevel({
+        matrixWidth: 1,
+        matrixHeight: 1,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 200,
+      }),
+      mockLevel({
+        matrixWidth: 3,
+        matrixHeight: 3,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 60,
+      }),
+    ];
+
+    // Primary at 10m — finest secondary is 60m, still the best we have
+    const selected = selectSecondaryLevel(levels, 10);
+    expect(selected).toBe(levels[1]);
+  });
+
+  it("selects a coarser level when primary is zoomed out", () => {
+    const levels = [
+      mockLevel({
+        matrixWidth: 1,
+        matrixHeight: 1,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 200,
+      }),
+      mockLevel({
+        matrixWidth: 5,
+        matrixHeight: 5,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 60,
+      }),
+      mockLevel({
+        matrixWidth: 22,
+        matrixHeight: 22,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 20,
+      }),
+    ];
+
+    // Primary at 100m (zoomed out) — 60m level is closest finer-or-equal
+    const selected = selectSecondaryLevel(levels, 100);
+    expect(selected).toBe(levels[1]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement MultiTilesetDescriptor**
+
+```ts
+// packages/deck.gl-raster/src/raster-tileset/multi-tileset-descriptor.ts
+import type { TilesetDescriptor, TilesetLevel } from "./tileset-interface.js";
+import type { Bounds, ProjectionFunction } from "./types.js";
+
+/**
+ * Groups N tilesets representing the same geographic extent at different
+ * native resolutions. The primary tileset (finest resolution) drives tile
+ * traversal; secondaries are consulted at fetch time.
+ */
+export interface MultiTilesetDescriptor {
+  /** Highest-resolution tileset — drives tile traversal. */
+  primary: TilesetDescriptor;
+
+  /** The key under which the primary was provided. */
+  primaryKey: string;
+
+  /** Lower-resolution tilesets, keyed by user-defined name. */
+  secondaries: Map<string, TilesetDescriptor>;
+
+  /** Shared CRS bounds (from primary). */
+  bounds: Bounds;
+
+  /** Shared projection: source CRS -> EPSG:3857. */
+  projectTo3857: ProjectionFunction;
+
+  /** Shared projection: source CRS -> EPSG:4326. */
+  projectTo4326: ProjectionFunction;
+}
+
+/**
+ * Create a MultiTilesetDescriptor from a map of named tilesets.
+ *
+ * Automatically selects the tileset with the finest `metersPerPixel` at its
+ * highest-resolution level as the primary. All others become secondaries.
+ */
+export function createMultiTilesetDescriptor(
+  tilesets: Map<string, TilesetDescriptor>,
+): MultiTilesetDescriptor {
+  if (tilesets.size === 0) {
+    throw new Error("At least one tileset is required");
+  }
+
+  // Find the tileset with the finest metersPerPixel at its last (finest) level
+  let primaryKey: string | null = null;
+  let finestMpp = Number.POSITIVE_INFINITY;
+
+  for (const [key, descriptor] of tilesets) {
+    const finestLevel = descriptor.levels[descriptor.levels.length - 1];
+    if (finestLevel && finestLevel.metersPerPixel < finestMpp) {
+      finestMpp = finestLevel.metersPerPixel;
+      primaryKey = key;
+    }
+  }
+
+  const primary = tilesets.get(primaryKey!)!;
+
+  const secondaries = new Map<string, TilesetDescriptor>();
+  for (const [key, descriptor] of tilesets) {
+    if (key !== primaryKey) {
+      secondaries.set(key, descriptor);
+    }
+  }
+
+  return {
+    primary,
+    primaryKey: primaryKey!,
+    secondaries,
+    bounds: primary.projectedBounds,
+    projectTo3857: primary.projectTo3857,
+    projectTo4326: primary.projectTo4326,
+  };
+}
+
+/**
+ * Select the best level from a secondary tileset for a given primary
+ * metersPerPixel.
+ *
+ * Picks the finest level whose `metersPerPixel` is <= the primary's. If all
+ * secondary levels are coarser, returns the finest available (last level).
+ *
+ * Levels are ordered coarsest-first (index 0 = coarsest).
+ */
+export function selectSecondaryLevel(
+  levels: TilesetLevel[],
+  primaryMetersPerPixel: number,
+): TilesetLevel {
+  // Walk from finest to coarsest, find the first level that is finer-or-equal
+  // to the primary's resolution
+  for (let i = levels.length - 1; i >= 0; i--) {
+    if (levels[i]!.metersPerPixel <= primaryMetersPerPixel) {
+      return levels[i]!;
+    }
+  }
+
+  // All levels are coarser — return the finest available
+  return levels[levels.length - 1]!;
+}
+
+/**
+ * Check if two tileset levels have the same grid parameters (same tile grid).
+ * Used to detect when sources share a tile grid and can skip UV transform
+ * computation.
+ */
+export function tilesetLevelsEqual(
+  a: TilesetLevel,
+  b: TilesetLevel,
+): boolean {
+  return (
+    a.matrixWidth === b.matrixWidth &&
+    a.matrixHeight === b.matrixHeight &&
+    a.tileWidth === b.tileWidth &&
+    a.tileHeight === b.tileHeight &&
+    a.metersPerPixel === b.metersPerPixel
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Add exports**
+
+In `packages/deck.gl-raster/src/raster-tileset/index.ts`, add:
+
+```ts
+export type { MultiTilesetDescriptor } from "./multi-tileset-descriptor.js";
+export {
+  createMultiTilesetDescriptor,
+  selectSecondaryLevel,
+  tilesetLevelsEqual,
+} from "./multi-tileset-descriptor.js";
+```
+
+In `packages/deck.gl-raster/src/index.ts`, add to the raster-tileset re-exports:
+
+```ts
+export type { MultiTilesetDescriptor } from "./raster-tileset/index.js";
+export {
+  createMultiTilesetDescriptor,
+  selectSecondaryLevel,
+  tilesetLevelsEqual,
+} from "./raster-tileset/index.js";
+```
+
+- [ ] **Step 6: Run full test suite and lint**
+
+Run: `npx vitest run packages/deck.gl-raster/`
+Run: `npx biome check packages/deck.gl-raster/src/raster-tileset/multi-tileset-descriptor.ts`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/deck.gl-raster/src/raster-tileset/multi-tileset-descriptor.ts \
+       packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts \
+       packages/deck.gl-raster/src/raster-tileset/index.ts \
+       packages/deck.gl-raster/src/index.ts
+git commit -m "feat: add MultiTilesetDescriptor type and factory"
+```
+
+---
+
+## Task 2: Secondary Tile Resolver
+
+Computes which secondary tiles cover a primary tile's extent, and the UV transform to map between them.
+
+**Files:**
+- Create: `packages/deck.gl-raster/src/raster-tileset/secondary-tile-resolver.ts`
+- Test: `packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts`
+- Modify: `packages/deck.gl-raster/src/raster-tileset/index.ts`
+
+- [ ] **Step 1: Write tests for secondary tile resolution**
+
+```ts
+// packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts
+import { describe, expect, it } from "vitest";
+import { resolveSecondaryTiles } from "../src/raster-tileset/secondary-tile-resolver.js";
+import type { TilesetLevel } from "../src/raster-tileset/tileset-interface.js";
+import type { Bounds, Corners, Point } from "../src/raster-tileset/types.js";
+
+/**
+ * Create a mock TilesetLevel backed by a regular grid.
+ *
+ * originX/originY is the top-left corner of the grid in CRS coordinates.
+ * cellSize is CRS units per pixel.
+ */
+function gridLevel(opts: {
+  originX: number;
+  originY: number;
+  cellSize: number;
+  tileWidth: number;
+  tileHeight: number;
+  matrixWidth: number;
+  matrixHeight: number;
+}): TilesetLevel {
+  const {
+    originX,
+    originY,
+    cellSize,
+    tileWidth,
+    tileHeight,
+    matrixWidth,
+    matrixHeight,
+  } = opts;
+  const tileCrsWidth = tileWidth * cellSize;
+  const tileCrsHeight = tileHeight * cellSize;
+
+  return {
+    matrixWidth,
+    matrixHeight,
+    tileWidth,
+    tileHeight,
+    metersPerPixel: cellSize,
+    projectedTileCorners: (col: number, row: number): Corners => {
+      const minX = originX + col * tileCrsWidth;
+      const maxX = minX + tileCrsWidth;
+      const maxY = originY - row * tileCrsHeight;
+      const minY = maxY - tileCrsHeight;
+      return {
+        topLeft: [minX, maxY] as Point,
+        topRight: [maxX, maxY] as Point,
+        bottomLeft: [minX, minY] as Point,
+        bottomRight: [maxX, minY] as Point,
+      };
+    },
+    crsBoundsToTileRange: (
+      projectedMinX: number,
+      projectedMinY: number,
+      projectedMaxX: number,
+      projectedMaxY: number,
+    ) => {
+      let minCol = Math.floor((projectedMinX - originX) / tileCrsWidth);
+      let maxCol = Math.floor((projectedMaxX - originX) / tileCrsWidth);
+      let minRow = Math.floor((originY - projectedMaxY) / tileCrsHeight);
+      let maxRow = Math.floor((originY - projectedMinY) / tileCrsHeight);
+
+      minCol = Math.max(0, Math.min(matrixWidth - 1, minCol));
+      maxCol = Math.max(0, Math.min(matrixWidth - 1, maxCol));
+      minRow = Math.max(0, Math.min(matrixHeight - 1, minRow));
+      maxRow = Math.max(0, Math.min(matrixHeight - 1, maxRow));
+
+      return { minCol, maxCol, minRow, maxRow };
+    },
+  };
+}
+
+describe("resolveSecondaryTiles", () => {
+  // Both grids share origin (600000, 8000000), top-left convention.
+  // Primary: 10m, 256px tiles → each tile covers 2560m
+  // Secondary: 20m, 256px tiles → each tile covers 5120m
+
+  const origin = { x: 600000, y: 8000000 };
+
+  const primaryLevel = gridLevel({
+    originX: origin.x,
+    originY: origin.y,
+    cellSize: 10,
+    tileWidth: 256,
+    tileHeight: 256,
+    matrixWidth: 43,
+    matrixHeight: 43,
+  });
+
+  const secondaryLevel = gridLevel({
+    originX: origin.x,
+    originY: origin.y,
+    cellSize: 20,
+    tileWidth: 256,
+    tileHeight: 256,
+    matrixWidth: 22,
+    matrixHeight: 22,
+  });
+
+  it("returns identity UV transform when primary tile is fully inside one secondary tile", () => {
+    // Primary tile (0,0) covers [600000, 7997440] to [602560, 8000000]
+    // Secondary tile (0,0) covers [600000, 7994880] to [605120, 8000000]
+    // Primary is fully inside secondary.
+    const result = resolveSecondaryTiles(primaryLevel, 0, 0, secondaryLevel);
+
+    expect(result.tileIndices).toEqual([{ col: 0, row: 0 }]);
+
+    // UV transform: primary extent maps to the top-left quarter of secondary
+    // offsetX = (600000 - 600000) / 5120 = 0
+    // offsetY = (8000000 - 8000000) / 5120 = 0
+    // scaleX = 2560 / 5120 = 0.5
+    // scaleY = 2560 / 5120 = 0.5
+    expect(result.uvTransform[0]).toBeCloseTo(0); // offsetX
+    expect(result.uvTransform[1]).toBeCloseTo(0); // offsetY
+    expect(result.uvTransform[2]).toBeCloseTo(0.5); // scaleX
+    expect(result.uvTransform[3]).toBeCloseTo(0.5); // scaleY
+  });
+
+  it("computes correct UV offset for non-origin primary tile", () => {
+    // Primary tile (1,0): covers [602560, 7997440] to [605120, 8000000]
+    // Secondary tile (0,0): covers [600000, 7994880] to [605120, 8000000]
+    // Primary is in the right half of secondary.
+    const result = resolveSecondaryTiles(primaryLevel, 1, 0, secondaryLevel);
+
+    expect(result.tileIndices).toEqual([{ col: 0, row: 0 }]);
+
+    // offsetX = (602560 - 600000) / 5120 = 0.5
+    // offsetY = (8000000 - 8000000) / 5120 = 0
+    // scaleX = 2560 / 5120 = 0.5
+    // scaleY = 2560 / 5120 = 0.5
+    expect(result.uvTransform[0]).toBeCloseTo(0.5);
+    expect(result.uvTransform[1]).toBeCloseTo(0);
+    expect(result.uvTransform[2]).toBeCloseTo(0.5);
+    expect(result.uvTransform[3]).toBeCloseTo(0.5);
+  });
+
+  it("handles primary tile spanning two secondary tiles", () => {
+    // Primary tile (2,0): covers [605120, 7997440] to [607680, 8000000]
+    // This crosses the boundary between secondary tiles (0,0) and (1,0)
+    // Secondary tile (0,0): [600000, 7994880] to [605120, 8000000]
+    // Secondary tile (1,0): [605120, 7994880] to [610240, 8000000]
+    const result = resolveSecondaryTiles(primaryLevel, 2, 0, secondaryLevel);
+
+    expect(result.tileIndices.length).toBe(2);
+
+    // Stitched extent covers both secondary tiles: [600000..610240] x [7994880..8000000]
+    // But we only need the secondary tiles that overlap.
+    // The UV transform maps primary into the stitched region.
+    // stitchedWidth = 10240, stitchedHeight = 5120
+    // scaleX = 2560 / 10240 = 0.25
+    // offsetX = (605120 - 600000) / 10240 = 0.5
+    expect(result.uvTransform[2]).toBeCloseTo(0.25); // scaleX
+    expect(result.uvTransform[0]).toBeCloseTo(0.5); // offsetX
+  });
+
+  it("returns identity-like transform when grids align exactly", () => {
+    // When primary and secondary have the same grid, tile (0,0) maps 1:1
+    const result = resolveSecondaryTiles(
+      primaryLevel,
+      0,
+      0,
+      primaryLevel,
+    );
+
+    expect(result.tileIndices).toEqual([{ col: 0, row: 0 }]);
+    expect(result.uvTransform[0]).toBeCloseTo(0); // offsetX
+    expect(result.uvTransform[1]).toBeCloseTo(0); // offsetY
+    expect(result.uvTransform[2]).toBeCloseTo(1); // scaleX
+    expect(result.uvTransform[3]).toBeCloseTo(1); // scaleY
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement resolveSecondaryTiles**
+
+```ts
+// packages/deck.gl-raster/src/raster-tileset/secondary-tile-resolver.ts
+import type { TilesetLevel } from "./tileset-interface.js";
+
+/** A tile index in a secondary tileset */
+export interface SecondaryTileIndex {
+  col: number;
+  row: number;
+}
+
+/**
+ * Result of resolving secondary tiles for a primary tile.
+ */
+export interface SecondaryTileResolution {
+  /** The secondary tile indices that cover the primary tile's extent. */
+  tileIndices: SecondaryTileIndex[];
+
+  /**
+   * UV transform: [offsetX, offsetY, scaleX, scaleY].
+   *
+   * Maps from the primary tile's UV space [0,1]^2 to the correct sub-region
+   * of the stitched secondary texture.
+   *
+   * Usage in shader: `sampledUV = uv * scale + offset`
+   */
+  uvTransform: [number, number, number, number];
+
+  /**
+   * The total stitched texture size in pixels.
+   * Width = (maxCol - minCol + 1) * tileWidth
+   * Height = (maxRow - minRow + 1) * tileHeight
+   */
+  stitchedWidth: number;
+  stitchedHeight: number;
+
+  /**
+   * The min col/row of the secondary tile range (needed for stitching:
+   * tells you where each fetched tile goes in the stitched buffer).
+   */
+  minCol: number;
+  minRow: number;
+}
+
+/**
+ * Resolve which secondary tiles cover a primary tile's extent, and compute
+ * the UV transform to map from primary UV space into the stitched secondary
+ * texture.
+ *
+ * @param primaryLevel - The primary tileset level
+ * @param primaryCol - Primary tile column index
+ * @param primaryRow - Primary tile row index
+ * @param secondaryLevel - The secondary tileset level to resolve against
+ */
+export function resolveSecondaryTiles(
+  primaryLevel: TilesetLevel,
+  primaryCol: number,
+  primaryRow: number,
+  secondaryLevel: TilesetLevel,
+): SecondaryTileResolution {
+  // Step 1: Get the CRS extent of the primary tile
+  const corners = primaryLevel.projectedTileCorners(primaryCol, primaryRow);
+  const primaryMinX = Math.min(
+    corners.topLeft[0],
+    corners.bottomLeft[0],
+    corners.topRight[0],
+    corners.bottomRight[0],
+  );
+  const primaryMaxX = Math.max(
+    corners.topLeft[0],
+    corners.bottomLeft[0],
+    corners.topRight[0],
+    corners.bottomRight[0],
+  );
+  const primaryMinY = Math.min(
+    corners.topLeft[1],
+    corners.bottomLeft[1],
+    corners.topRight[1],
+    corners.bottomRight[1],
+  );
+  const primaryMaxY = Math.max(
+    corners.topLeft[1],
+    corners.bottomLeft[1],
+    corners.topRight[1],
+    corners.bottomRight[1],
+  );
+
+  // Step 2: Find covering secondary tiles
+  const range = secondaryLevel.crsBoundsToTileRange(
+    primaryMinX,
+    primaryMinY,
+    primaryMaxX,
+    primaryMaxY,
+  );
+
+  const tileIndices: SecondaryTileIndex[] = [];
+  for (let row = range.minRow; row <= range.maxRow; row++) {
+    for (let col = range.minCol; col <= range.maxCol; col++) {
+      tileIndices.push({ col, row });
+    }
+  }
+
+  // Step 3: Compute the CRS extent of the stitched secondary region
+  // Get corners of the min and max secondary tiles to find total extent
+  const minCorners = secondaryLevel.projectedTileCorners(
+    range.minCol,
+    range.minRow,
+  );
+  const maxCorners = secondaryLevel.projectedTileCorners(
+    range.maxCol,
+    range.maxRow,
+  );
+
+  const allCornerPoints = [
+    minCorners.topLeft,
+    minCorners.topRight,
+    minCorners.bottomLeft,
+    minCorners.bottomRight,
+    maxCorners.topLeft,
+    maxCorners.topRight,
+    maxCorners.bottomLeft,
+    maxCorners.bottomRight,
+  ];
+
+  const stitchedMinX = Math.min(...allCornerPoints.map((p) => p[0]));
+  const stitchedMaxX = Math.max(...allCornerPoints.map((p) => p[0]));
+  const stitchedMinY = Math.min(...allCornerPoints.map((p) => p[1]));
+  const stitchedMaxY = Math.max(...allCornerPoints.map((p) => p[1]));
+
+  const stitchedCrsWidth = stitchedMaxX - stitchedMinX;
+  const stitchedCrsHeight = stitchedMaxY - stitchedMinY;
+
+  // Step 4: Compute UV transform
+  const primaryCrsWidth = primaryMaxX - primaryMinX;
+  const primaryCrsHeight = primaryMaxY - primaryMinY;
+
+  const scaleX =
+    stitchedCrsWidth > 0 ? primaryCrsWidth / stitchedCrsWidth : 1;
+  const scaleY =
+    stitchedCrsHeight > 0 ? primaryCrsHeight / stitchedCrsHeight : 1;
+
+  // Offset: how far into the stitched texture the primary tile starts.
+  // Note: Y axis is top-down in texture space but may be bottom-up in CRS.
+  // We use the top-left convention: offset from stitchedMax (top) going down.
+  const offsetX =
+    stitchedCrsWidth > 0 ? (primaryMinX - stitchedMinX) / stitchedCrsWidth : 0;
+  const offsetY =
+    stitchedCrsHeight > 0
+      ? (stitchedMaxY - primaryMaxY) / stitchedCrsHeight
+      : 0;
+
+  // Step 5: Stitched pixel dimensions
+  const numCols = range.maxCol - range.minCol + 1;
+  const numRows = range.maxRow - range.minRow + 1;
+  const stitchedWidth = numCols * secondaryLevel.tileWidth;
+  const stitchedHeight = numRows * secondaryLevel.tileHeight;
+
+  return {
+    tileIndices,
+    uvTransform: [offsetX, offsetY, scaleX, scaleY],
+    stitchedWidth,
+    stitchedHeight,
+    minCol: range.minCol,
+    minRow: range.minRow,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Add exports**
+
+In `packages/deck.gl-raster/src/raster-tileset/index.ts`, add:
+
+```ts
+export type {
+  SecondaryTileIndex,
+  SecondaryTileResolution,
+} from "./secondary-tile-resolver.js";
+export { resolveSecondaryTiles } from "./secondary-tile-resolver.js";
+```
+
+- [ ] **Step 6: Run full test suite and lint**
+
+Run: `npx vitest run packages/deck.gl-raster/`
+Run: `npx biome check packages/deck.gl-raster/src/raster-tileset/secondary-tile-resolver.ts`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/deck.gl-raster/src/raster-tileset/secondary-tile-resolver.ts \
+       packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts \
+       packages/deck.gl-raster/src/raster-tileset/index.ts
+git commit -m "feat: add secondary tile resolver with UV transform computation"
+```
+
+---
+
+## Task 3: CompositeBands GPU Module
+
+A shader module that samples N named band textures with UV transforms and outputs a `vec4` color.
+
+**Files:**
+- Create: `packages/deck.gl-raster/src/gpu-modules/composite-bands.ts`
+- Test: `packages/deck.gl-raster/tests/composite-bands.test.ts`
+- Modify: `packages/deck.gl-raster/src/gpu-modules/index.ts`
+
+- [ ] **Step 1: Write tests for CompositeBands module structure**
+
+```ts
+// packages/deck.gl-raster/tests/composite-bands.test.ts
+import { describe, expect, it } from "vitest";
+import { createCompositeBandsModule } from "../src/gpu-modules/composite-bands.js";
+
+describe("createCompositeBandsModule", () => {
+  it("creates a shader module with correct uniforms for RGB bands", () => {
+    const mod = createCompositeBandsModule({
+      r: "red",
+      g: "green",
+      b: "blue",
+    });
+
+    expect(mod.name).toBe("composite-bands");
+
+    // Should declare sampler2D and vec4 uvTransform for each band
+    const decl = mod.inject["fs:#decl"] as string;
+    expect(decl).toContain("uniform sampler2D band_red;");
+    expect(decl).toContain("uniform sampler2D band_green;");
+    expect(decl).toContain("uniform sampler2D band_blue;");
+    expect(decl).toContain("uniform vec4 uvTransform_red;");
+    expect(decl).toContain("uniform vec4 uvTransform_green;");
+    expect(decl).toContain("uniform vec4 uvTransform_blue;");
+
+    // Should sample bands and assign to color channels
+    const filterColor = mod.inject["fs:DECKGL_FILTER_COLOR"] as string;
+    expect(filterColor).toContain("band_red");
+    expect(filterColor).toContain("band_green");
+    expect(filterColor).toContain("band_blue");
+    expect(filterColor).toContain("uvTransform_red");
+  });
+
+  it("creates a module with only 2 bands (r and g, no blue)", () => {
+    const mod = createCompositeBandsModule({
+      r: "nir",
+      g: "swir",
+    });
+
+    const decl = mod.inject["fs:#decl"] as string;
+    expect(decl).toContain("uniform sampler2D band_nir;");
+    expect(decl).toContain("uniform sampler2D band_swir;");
+    // b channel should default to 0
+    const filterColor = mod.inject["fs:DECKGL_FILTER_COLOR"] as string;
+    expect(filterColor).toContain("0.0"); // default for missing blue
+  });
+
+  it("supports an alpha channel", () => {
+    const mod = createCompositeBandsModule({
+      r: "red",
+      g: "green",
+      b: "blue",
+      a: "alpha",
+    });
+
+    const decl = mod.inject["fs:#decl"] as string;
+    expect(decl).toContain("uniform sampler2D band_alpha;");
+    expect(decl).toContain("uniform vec4 uvTransform_alpha;");
+  });
+
+  it("getUniforms passes through texture and transform props", () => {
+    const mod = createCompositeBandsModule({ r: "red", g: "green", b: "blue" });
+
+    const mockTexture = { id: "tex" };
+    const uniforms = mod.getUniforms!({
+      band_red: mockTexture,
+      uvTransform_red: [0, 0, 1, 1],
+    } as any);
+
+    expect(uniforms.band_red).toBe(mockTexture);
+    expect(uniforms.uvTransform_red).toEqual([0, 0, 1, 1]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run packages/deck.gl-raster/tests/composite-bands.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement CompositeBands**
+
+```ts
+// packages/deck.gl-raster/src/gpu-modules/composite-bands.ts
+import type { ShaderModule } from "@luma.gl/shadertools";
+
+/**
+ * Band mapping: which source band goes to which output channel.
+ * At least `r` is required; missing channels default to 0.0 (or 1.0 for alpha).
+ */
+export interface CompositeBandsMapping {
+  r: string;
+  g?: string;
+  b?: string;
+  a?: string;
+}
+
+/**
+ * Create a shader module that samples named band textures with UV transforms
+ * and outputs a vec4 color.
+ *
+ * Each band gets a `sampler2D band_<name>` and `vec4 uvTransform_<name>`
+ * uniform. The UV transform is applied before sampling so that textures at
+ * different resolutions are correctly aligned.
+ */
+export function createCompositeBandsModule(
+  mapping: CompositeBandsMapping,
+): ShaderModule {
+  // Collect unique band names
+  const bands = new Set<string>();
+  if (mapping.r) bands.add(mapping.r);
+  if (mapping.g) bands.add(mapping.g);
+  if (mapping.b) bands.add(mapping.b);
+  if (mapping.a) bands.add(mapping.a);
+
+  // Generate uniform declarations
+  const declarations = [...bands]
+    .map(
+      (name) =>
+        `uniform sampler2D band_${name};\nuniform vec4 uvTransform_${name};`,
+    )
+    .join("\n");
+
+  const uvHelper = /* glsl */ `
+vec2 compositeBands_applyUv(vec2 uv, vec4 transform) {
+  return uv * transform.zw + transform.xy;
+}`;
+
+  // Generate sampling expressions for each channel
+  function sampleExpr(channel: string | undefined): string {
+    if (!channel) return "0.0";
+    return `texture(band_${channel}, compositeBands_applyUv(geometry.uv, uvTransform_${channel})).r`;
+  }
+
+  const alphaExpr = mapping.a ? sampleExpr(mapping.a) : "1.0";
+
+  const filterColor = /* glsl */ `
+  color = vec4(
+    ${sampleExpr(mapping.r)},
+    ${sampleExpr(mapping.g)},
+    ${sampleExpr(mapping.b)},
+    ${alphaExpr}
+  );`;
+
+  return {
+    name: "composite-bands",
+    inject: {
+      "fs:#decl": `${declarations}\n${uvHelper}`,
+      "fs:DECKGL_FILTER_COLOR": filterColor,
+    },
+    getUniforms: (props: Record<string, unknown>) => {
+      // Pass through all props — they're keyed by band_<name> and uvTransform_<name>
+      const uniforms: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(props)) {
+        if (
+          key.startsWith("band_") ||
+          key.startsWith("uvTransform_")
+        ) {
+          uniforms[key] = value;
+        }
+      }
+      return uniforms;
+    },
+  } as ShaderModule;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run packages/deck.gl-raster/tests/composite-bands.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Add exports**
+
+In `packages/deck.gl-raster/src/gpu-modules/index.ts`, add:
+
+```ts
+export { createCompositeBandsModule } from "./composite-bands.js";
+export type { CompositeBandsMapping } from "./composite-bands.js";
+```
+
+- [ ] **Step 6: Run lint**
+
+Run: `npx biome check packages/deck.gl-raster/src/gpu-modules/composite-bands.ts`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/deck.gl-raster/src/gpu-modules/composite-bands.ts \
+       packages/deck.gl-raster/tests/composite-bands.test.ts \
+       packages/deck.gl-raster/src/gpu-modules/index.ts
+git commit -m "feat: add CompositeBands GPU module for multi-band rendering"
+```
+
+---
+
+## Task 4: MultiCOGLayer — Initialization and Tileset Construction
+
+The layer that opens multiple COGs, builds their TilesetDescriptors, and constructs the MultiTilesetDescriptor. This task handles init only — fetching and rendering come in Task 5.
+
+**Files:**
+- Create: `packages/deck.gl-geotiff/src/multi-cog-layer.ts`
+- Modify: `packages/deck.gl-geotiff/src/index.ts`
+
+- [ ] **Step 1: Implement MultiCOGLayer skeleton with initialization**
+
+Study the existing `COGLayer` at `packages/deck.gl-geotiff/src/cog-layer.ts` for patterns. The `MultiCOGLayer` follows the same structure but opens N COGs.
+
+```ts
+// packages/deck.gl-geotiff/src/multi-cog-layer.ts
+import {
+  CompositeLayer,
+  type CompositeLayerProps,
+  type UpdateParameters,
+} from "@deck.gl/core";
+import type { TileLayerProps } from "@deck.gl/geo-layers";
+import proj4 from "proj4";
+import { parseWkt } from "wkt-parser";
+
+import {
+  type Bounds,
+  type MultiTilesetDescriptor,
+  RasterTileset2D,
+  type RasterModule,
+  TileMatrixSetAdaptor,
+  createMultiTilesetDescriptor,
+} from "@developmentseed/deck.gl-raster";
+import type { Tileset2DProps } from "@deck.gl/geo-layers/dist/tileset-2d/tileset-2d";
+
+import type { GeoTIFF } from "@developmentseed/geotiff";
+import { fetchGeoTIFF } from "./geotiff/fetch-geotiff.js";
+import {
+  type EpsgResolver,
+  defaultEpsgResolver,
+} from "./geotiff/epsg-resolver.js";
+import { generateTileMatrixSet } from "./geotiff/geotiff-tile-matrix-set.js";
+import type { TileMatrixSet } from "./geotiff/tile-matrix-set-types.js";
+import { makeClampedForwardTo3857 } from "./geotiff/projection-utils.js";
+import type { CompositeBandsMapping } from "@developmentseed/deck.gl-raster";
+import type { DecoderPool } from "@developmentseed/geotiff";
+
+/** A single source band configuration */
+export interface MultiCOGSourceConfig {
+  /** URL or ArrayBuffer of the COG */
+  url: string | URL | ArrayBuffer;
+}
+
+export type MultiCOGLayerProps = CompositeLayerProps &
+  Pick<
+    TileLayerProps,
+    | "debounceTime"
+    | "maxCacheSize"
+    | "maxCacheByteSize"
+    | "maxRequests"
+    | "refinementStrategy"
+  > & {
+    /** Named sources — each key becomes a band name. */
+    sources: Record<string, MultiCOGSourceConfig>;
+
+    /** Map source bands to RGB(A) output channels. */
+    composite?: CompositeBandsMapping;
+
+    /** Post-processing render pipeline modules. */
+    renderPipeline?: RasterModule[];
+
+    /** EPSG code resolver. */
+    epsgResolver?: EpsgResolver;
+
+    /** Decoder pool for parallel image chunk decompression. */
+    pool?: DecoderPool;
+
+    /** Maximum reprojection error in pixels. */
+    maxError?: number;
+
+    /** AbortSignal to cancel loading. */
+    signal?: AbortSignal;
+  };
+
+interface SourceState {
+  geotiff: GeoTIFF;
+  tms: TileMatrixSet;
+}
+
+const defaultProps = {
+  epsgResolver: { type: "accessor", value: defaultEpsgResolver },
+  maxError: { type: "number", value: 0.125 },
+};
+
+export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
+  static override layerName = "MultiCOGLayer";
+  static override defaultProps = defaultProps;
+
+  declare state: {
+    sources: Map<string, SourceState>;
+    multiDescriptor: MultiTilesetDescriptor | null;
+    forwardTo4326: (x: number, y: number) => [number, number];
+    inverseFrom4326: (x: number, y: number) => [number, number];
+    forwardTo3857: (x: number, y: number) => [number, number];
+    inverseFrom3857: (x: number, y: number) => [number, number];
+  };
+
+  override initializeState(): void {
+    this.setState({
+      sources: new Map(),
+      multiDescriptor: null,
+    });
+  }
+
+  override updateState({ changeFlags }: UpdateParameters<this>): void {
+    if (changeFlags.dataChanged || changeFlags.propsChanged) {
+      this._parseAllSources();
+    }
+  }
+
+  async _parseAllSources(): Promise<void> {
+    const { sources: sourceConfigs } = this.props;
+    const entries = Object.entries(sourceConfigs);
+
+    // Open all COGs in parallel
+    const results = await Promise.all(
+      entries.map(async ([name, config]) => {
+        const geotiff = await fetchGeoTIFF(config.url);
+        const crs = geotiff.crs;
+        const sourceProjection =
+          typeof crs === "number"
+            ? await this.props.epsgResolver!(crs)
+            : parseWkt(crs);
+
+        const tms = generateTileMatrixSet(geotiff, sourceProjection);
+        return { name, geotiff, tms, sourceProjection };
+      }),
+    );
+
+    // Use the first source's projection for shared projection functions
+    // (all sources must share the same CRS)
+    const firstResult = results[0]!;
+    const sourceProjection = firstResult.sourceProjection;
+
+    // @ts-expect-error - proj4 typings are incomplete
+    const converter4326 = proj4(sourceProjection, "EPSG:4326");
+    const forwardTo4326 = (x: number, y: number) =>
+      converter4326.forward<[number, number]>([x, y], false);
+    const inverseFrom4326 = (x: number, y: number) =>
+      converter4326.inverse<[number, number]>([x, y], false);
+
+    // @ts-expect-error - proj4 typings are incomplete
+    const converter3857 = proj4(sourceProjection, "EPSG:3857");
+    const forwardTo3857 = makeClampedForwardTo3857(
+      (x: number, y: number) =>
+        converter3857.forward<[number, number]>([x, y], false),
+      forwardTo4326,
+    );
+    const inverseFrom3857 = (x: number, y: number) =>
+      converter3857.inverse<[number, number]>([x, y], false);
+
+    // Build TilesetDescriptors
+    const tilesetMap = new Map<string, import("@developmentseed/deck.gl-raster").TilesetDescriptor>();
+    const sourceMap = new Map<string, SourceState>();
+
+    for (const result of results) {
+      const descriptor = new TileMatrixSetAdaptor(result.tms, {
+        projectTo4326: forwardTo4326,
+        projectTo3857: forwardTo3857,
+      });
+      tilesetMap.set(result.name, descriptor);
+      sourceMap.set(result.name, {
+        geotiff: result.geotiff,
+        tms: result.tms,
+      });
+    }
+
+    const multiDescriptor = createMultiTilesetDescriptor(tilesetMap);
+
+    this.setState({
+      sources: sourceMap,
+      multiDescriptor,
+      forwardTo4326,
+      inverseFrom4326,
+      forwardTo3857,
+      inverseFrom3857,
+    });
+  }
+
+  override renderLayers() {
+    // Implemented in Task 5
+    if (!this.state.multiDescriptor) return null;
+    return [];
+  }
+}
+```
+
+- [ ] **Step 2: Add export to index.ts**
+
+In `packages/deck.gl-geotiff/src/index.ts`, add:
+
+```ts
+export type { MultiCOGLayerProps, MultiCOGSourceConfig } from "./multi-cog-layer.js";
+export { MultiCOGLayer } from "./multi-cog-layer.js";
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npx tsc --noEmit -p packages/deck.gl-geotiff/tsconfig.json`
+Expected: No new errors (pre-existing errors in cog-layer.ts / cog-tile-matrix-set.ts are expected)
+
+- [ ] **Step 4: Run lint**
+
+Run: `npx biome check packages/deck.gl-geotiff/src/multi-cog-layer.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/deck.gl-geotiff/src/multi-cog-layer.ts \
+       packages/deck.gl-geotiff/src/index.ts
+git commit -m "feat: add MultiCOGLayer skeleton with multi-source initialization"
+```
+
+---
+
+## Task 5: MultiCOGLayer — Tile Fetching, Stitching, and Rendering
+
+Wire up `getTileData` (fetch primary + secondary tiles, stitch, compute UV transforms) and `renderLayers` (create TileLayer with RasterLayer sub-layers).
+
+**Files:**
+- Modify: `packages/deck.gl-geotiff/src/multi-cog-layer.ts`
+
+- [ ] **Step 1: Add tile fetch imports and helper types**
+
+At the top of `multi-cog-layer.ts`, add the needed imports:
+
+```ts
+import { TileLayer } from "@deck.gl/geo-layers";
+import type { TileLoadProps } from "@deck.gl/geo-layers";
+import {
+  RasterLayer,
+  resolveSecondaryTiles,
+  selectSecondaryLevel,
+  tilesetLevelsEqual,
+  createCompositeBandsModule,
+} from "@developmentseed/deck.gl-raster";
+import { fromAffine, tileTransform } from "./geotiff/geotiff-reprojection.js";
+import type { Overview } from "@developmentseed/geotiff";
+import type { Texture } from "@luma.gl/core";
+```
+
+Add the tile data type inside the file:
+
+```ts
+interface BandTileData {
+  texture: Texture;
+  uvTransform: [number, number, number, number];
+  width: number;
+  height: number;
+}
+
+interface MultiTileResult {
+  bands: Map<string, BandTileData>;
+  /** Reprojection fns for the primary tile (for mesh generation) */
+  forwardTransform: (x: number, y: number) => [number, number];
+  inverseTransform: (x: number, y: number) => [number, number];
+}
+```
+
+- [ ] **Step 2: Implement _getTileData method**
+
+Add this method to the `MultiCOGLayer` class:
+
+```ts
+async _getTileData(tile: TileLoadProps): Promise<MultiTileResult | null> {
+  const { multiDescriptor, sources, forwardTo3857, inverseFrom3857 } =
+    this.state;
+  if (!multiDescriptor) return null;
+
+  const { x, y, z } = tile.index;
+  const { signal } = tile;
+  const primaryLevel = multiDescriptor.primary.levels[z]!;
+
+  // Compute reprojection fns for the primary tile (for mesh generation)
+  const primarySource = sources.get(multiDescriptor.primaryKey)!;
+  const primaryTileMatrix = primarySource.tms.tileMatrices[z]!;
+  const tileAffine = tileTransform(primaryTileMatrix, { col: x, row: y });
+  const { forwardTransform, inverseTransform } = fromAffine(tileAffine);
+
+  const bands = new Map<string, BandTileData>();
+
+  // Fetch all bands in parallel
+  const fetchPromises: Promise<void>[] = [];
+
+  for (const [name, sourceState] of sources) {
+    const descriptor = multiDescriptor.primaryKey === name
+      ? multiDescriptor.primary
+      : multiDescriptor.secondaries.get(name);
+    if (!descriptor) continue;
+
+    const isPrimary = name === multiDescriptor.primaryKey ||
+      tilesetLevelsEqual(descriptor.levels[descriptor.levels.length - 1]!, primaryLevel);
+
+    if (isPrimary) {
+      // Same grid as primary — fetch directly with identity UV transform
+      fetchPromises.push(
+        this._fetchBandTile(sourceState, z, x, y, signal).then((data) => {
+          bands.set(name, {
+            ...data,
+            uvTransform: [0, 0, 1, 1],
+          });
+        }),
+      );
+    } else {
+      // Different grid — resolve secondary tiles
+      const secondaryLevel = selectSecondaryLevel(
+        descriptor.levels,
+        primaryLevel.metersPerPixel,
+      );
+      const secondaryZ = descriptor.levels.indexOf(secondaryLevel);
+      const resolution = resolveSecondaryTiles(
+        primaryLevel,
+        x,
+        y,
+        secondaryLevel,
+      );
+
+      fetchPromises.push(
+        this._fetchAndStitchSecondary(
+          sourceState,
+          secondaryZ,
+          resolution,
+          signal,
+        ).then((data) => {
+          bands.set(name, {
+            ...data,
+            uvTransform: resolution.uvTransform,
+          });
+        }),
+      );
+    }
+  }
+
+  await Promise.all(fetchPromises);
+
+  return { bands, forwardTransform, inverseTransform };
+}
+```
+
+- [ ] **Step 3: Implement _fetchBandTile and _fetchAndStitchSecondary helper methods**
+
+```ts
+/** Fetch a single tile from a COG source and create a GPU texture. */
+async _fetchBandTile(
+  source: SourceState,
+  z: number,
+  col: number,
+  row: number,
+  signal?: AbortSignal,
+): Promise<{ texture: Texture; width: number; height: number }> {
+  const images = [source.geotiff, ...source.geotiff.overviews];
+  const image = images[images.length - 1 - z]!;
+  const tileMatrix = source.tms.tileMatrices[z]!;
+
+  const tileData = await (image as Overview).fetchTile(
+    col,
+    row,
+    { signal, pool: this.props.pool },
+  );
+
+  const texture = this.context.device.createTexture({
+    data: tileData.array.data,
+    width: tileData.array.width,
+    height: tileData.array.height,
+    format: "r8unorm",
+  });
+
+  return {
+    texture,
+    width: tileData.array.width,
+    height: tileData.array.height,
+  };
+}
+
+/**
+ * Fetch covering secondary tiles and stitch them into a single texture.
+ */
+async _fetchAndStitchSecondary(
+  source: SourceState,
+  z: number,
+  resolution: import("@developmentseed/deck.gl-raster").SecondaryTileResolution,
+  signal?: AbortSignal,
+): Promise<{ texture: Texture; width: number; height: number }> {
+  const { tileIndices, stitchedWidth, stitchedHeight, minCol, minRow } =
+    resolution;
+
+  if (tileIndices.length === 1) {
+    // Single tile — no stitching needed
+    const idx = tileIndices[0]!;
+    return this._fetchBandTile(source, z, idx.col, idx.row, signal);
+  }
+
+  // Fetch all covering tiles in parallel
+  const tileResults = await Promise.all(
+    tileIndices.map(async (idx) => {
+      const result = await this._fetchBandTile(
+        source,
+        z,
+        idx.col,
+        idx.row,
+        signal,
+      );
+      return { ...result, col: idx.col, row: idx.row };
+    }),
+  );
+
+  // Stitch into a single buffer
+  const stitched = new Uint8Array(stitchedWidth * stitchedHeight);
+  const tileW = tileResults[0]!.width;
+  const tileH = tileResults[0]!.height;
+
+  for (const tile of tileResults) {
+    const offsetX = (tile.col - minCol) * tileW;
+    const offsetY = (tile.row - minRow) * tileH;
+
+    // Read back texture data — this is a simplification.
+    // In practice we'd stitch raw buffers before creating textures.
+    // For now, copy row by row into the stitched buffer.
+    // TODO: Stitch raw pixel buffers before GPU upload for efficiency.
+    for (let row = 0; row < tileH; row++) {
+      const srcStart = row * tileW;
+      const dstStart = (offsetY + row) * stitchedWidth + offsetX;
+      // This assumes we have access to the raw data.
+      // The actual implementation will need to stitch raw arrays
+      // from fetchTile before creating the texture.
+    }
+  }
+
+  const texture = this.context.device.createTexture({
+    data: stitched,
+    width: stitchedWidth,
+    height: stitchedHeight,
+    format: "r8unorm",
+  });
+
+  return { texture, width: stitchedWidth, height: stitchedHeight };
+}
+```
+
+> **Note to implementer:** The stitching in `_fetchAndStitchSecondary` is sketched out above. The actual implementation must stitch raw pixel `Uint8Array` buffers returned by `fetchTile` before creating a single GPU texture. The `fetchTile` API returns `{ array: { data: TypedArray, width, height } }` — use those raw buffers directly. The row-by-row copy loop needs to use the actual source data, not read back from a texture.
+
+- [ ] **Step 4: Implement renderLayers method**
+
+Replace the placeholder `renderLayers` in the class:
+
+```ts
+override renderLayers() {
+  const { multiDescriptor, forwardTo3857, inverseFrom3857, forwardTo4326 } =
+    this.state;
+  if (!multiDescriptor) return null;
+
+  const { primaryKey } = multiDescriptor;
+  const primarySource = this.state.sources.get(primaryKey)!;
+  const tms = primarySource.tms;
+
+  // Build a Tileset2D class that uses the primary descriptor for traversal
+  const descriptor = multiDescriptor.primary;
+  const forwardTo4326Fn = this.state.forwardTo4326;
+  const forwardTo3857Fn = this.state.forwardTo3857;
+
+  class MultiTilesetFactory extends RasterTileset2D {
+    constructor(opts: Tileset2DProps) {
+      const adapted = new TileMatrixSetAdaptor(tms, {
+        projectTo4326: forwardTo4326Fn,
+        projectTo3857: forwardTo3857Fn,
+      });
+      super(opts, adapted, { projectTo4326: forwardTo4326Fn });
+    }
+  }
+
+  return new TileLayer({
+    ...this.props,
+    id: `${this.props.id}-tiles`,
+    TilesetClass: MultiTilesetFactory as any,
+    getTileData: (tile: TileLoadProps) => this._getTileData(tile),
+    renderSubLayers: (props: any) => {
+      const { data, tile } = props;
+      if (!data) return null;
+
+      const { bands, forwardTransform, inverseTransform } =
+        data as MultiTileResult;
+
+      const primaryBand = bands.get(primaryKey);
+      if (!primaryBand) return null;
+
+      const tileMetadata = tile.metadata as import("@developmentseed/deck.gl-raster").TileMetadata;
+
+      // Build render pipeline
+      const pipeline: RasterModule[] = [];
+
+      // If composite mapping is provided, use CompositeBands module
+      if (this.props.composite) {
+        const compositeMod = createCompositeBandsModule(this.props.composite);
+
+        // Build props for the module: bind textures and UV transforms
+        const compositeProps: Record<string, unknown> = {};
+        for (const [name, bandData] of bands) {
+          compositeProps[`band_${name}`] = bandData.texture;
+          compositeProps[`uvTransform_${name}`] = bandData.uvTransform;
+        }
+
+        pipeline.push({ module: compositeMod, props: compositeProps });
+      }
+
+      // Append user's post-processing pipeline
+      if (this.props.renderPipeline) {
+        pipeline.push(...this.props.renderPipeline);
+      }
+
+      return new RasterLayer({
+        id: `${this.props.id}-raster-${tile.index.x}-${tile.index.y}-${tile.index.z}`,
+        width: tileMetadata.tileWidth,
+        height: tileMetadata.tileHeight,
+        reprojectionFns: {
+          forwardTransform,
+          inverseTransform,
+          forwardReproject: forwardTo3857Fn,
+          inverseReproject: inverseFrom3857,
+        },
+        renderPipeline: pipeline,
+        maxError: this.props.maxError,
+      });
+    },
+  });
+}
+```
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npx tsc --noEmit -p packages/deck.gl-geotiff/tsconfig.json`
+Expected: No new errors
+
+- [ ] **Step 6: Run lint**
+
+Run: `npx biome check packages/deck.gl-geotiff/src/multi-cog-layer.ts`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/deck.gl-geotiff/src/multi-cog-layer.ts
+git commit -m "feat: add tile fetching, stitching, and rendering to MultiCOGLayer"
+```
+
+---
+
+## Task 6: Integration Smoke Test
+
+Create a minimal integration test to verify the full pipeline wires together.
+
+**Files:**
+- Create: `packages/deck.gl-geotiff/tests/multi-cog-layer.test.ts`
+
+- [ ] **Step 1: Write integration test**
+
+```ts
+// packages/deck.gl-geotiff/tests/multi-cog-layer.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  createMultiTilesetDescriptor,
+  selectSecondaryLevel,
+  resolveSecondaryTiles,
+  tilesetLevelsEqual,
+} from "@developmentseed/deck.gl-raster";
+import type {
+  TilesetDescriptor,
+  TilesetLevel,
+} from "@developmentseed/deck.gl-raster";
+import type { Corners, Point } from "@developmentseed/deck.gl-raster";
+
+/**
+ * Simulates a Sentinel-2 scene with 10m and 20m bands.
+ * Origin at (600000, 8000000) in EPSG:32625, top-left convention.
+ */
+function sentinelLevel(cellSize: number, tilePixels: number): TilesetLevel {
+  const originX = 600000;
+  const originY = 8000000;
+  const totalPixels = Math.ceil(109800 / cellSize); // ~110km scene
+  const matrixSize = Math.ceil(totalPixels / tilePixels);
+  const tileCrsWidth = tilePixels * cellSize;
+  const tileCrsHeight = tilePixels * cellSize;
+
+  return {
+    matrixWidth: matrixSize,
+    matrixHeight: matrixSize,
+    tileWidth: tilePixels,
+    tileHeight: tilePixels,
+    metersPerPixel: cellSize,
+    projectedTileCorners: (col: number, row: number): Corners => {
+      const minX = originX + col * tileCrsWidth;
+      const maxX = minX + tileCrsWidth;
+      const maxY = originY - row * tileCrsHeight;
+      const minY = maxY - tileCrsHeight;
+      return {
+        topLeft: [minX, maxY] as Point,
+        topRight: [maxX, maxY] as Point,
+        bottomLeft: [minX, minY] as Point,
+        bottomRight: [maxX, minY] as Point,
+      };
+    },
+    crsBoundsToTileRange: (
+      projectedMinX: number,
+      projectedMinY: number,
+      projectedMaxX: number,
+      projectedMaxY: number,
+    ) => {
+      let minCol = Math.floor((projectedMinX - originX) / tileCrsWidth);
+      let maxCol = Math.floor((projectedMaxX - originX) / tileCrsWidth);
+      let minRow = Math.floor((originY - projectedMaxY) / tileCrsHeight);
+      let maxRow = Math.floor((originY - projectedMinY) / tileCrsHeight);
+      minCol = Math.max(0, Math.min(matrixSize - 1, minCol));
+      maxCol = Math.max(0, Math.min(matrixSize - 1, maxCol));
+      minRow = Math.max(0, Math.min(matrixSize - 1, minRow));
+      maxRow = Math.max(0, Math.min(matrixSize - 1, maxRow));
+      return { minCol, maxCol, minRow, maxRow };
+    },
+  };
+}
+
+function sentinelDescriptor(cellSize: number): TilesetDescriptor {
+  const identity = (x: number, y: number): [number, number] => [x, y];
+  // Create a 2-level pyramid: coarse overview + full resolution
+  return {
+    levels: [
+      sentinelLevel(cellSize * 4, 256), // overview
+      sentinelLevel(cellSize, 256), // full res
+    ],
+    projectTo3857: identity,
+    projectTo4326: identity,
+    projectedBounds: [600000, 7890200, 709800, 8000000],
+  };
+}
+
+describe("Multi-resolution Sentinel-2 simulation", () => {
+  it("builds MultiTilesetDescriptor with 10m as primary", () => {
+    const band10m = sentinelDescriptor(10);
+    const band20m = sentinelDescriptor(20);
+
+    const multi = createMultiTilesetDescriptor(
+      new Map([
+        ["B04", band10m],
+        ["B11", band20m],
+      ]),
+    );
+
+    expect(multi.primaryKey).toBe("B04");
+    expect(multi.secondaries.has("B11")).toBe(true);
+  });
+
+  it("resolves UV transform for 20m band against 10m tile", () => {
+    const level10m = sentinelLevel(10, 256); // 256 * 10 = 2560m per tile
+    const level20m = sentinelLevel(20, 256); // 256 * 20 = 5120m per tile
+
+    // Primary tile (0,0) covers [600000, 7997440] to [602560, 8000000]
+    const result = resolveSecondaryTiles(level10m, 0, 0, level20m);
+
+    // Should map to a sub-region of secondary tile (0,0)
+    expect(result.tileIndices.length).toBe(1);
+    expect(result.uvTransform[2]).toBeCloseTo(0.5); // scaleX: 2560/5120
+    expect(result.uvTransform[3]).toBeCloseTo(0.5); // scaleY: 2560/5120
+    expect(result.uvTransform[0]).toBeCloseTo(0); // offsetX: at origin
+    expect(result.uvTransform[1]).toBeCloseTo(0); // offsetY: at origin
+  });
+
+  it("detects matching grids for same-resolution bands", () => {
+    const level10m_a = sentinelLevel(10, 256);
+    const level10m_b = sentinelLevel(10, 256);
+
+    expect(tilesetLevelsEqual(level10m_a, level10m_b)).toBe(true);
+  });
+
+  it("selectSecondaryLevel picks correct level for zoomed-out view", () => {
+    const band20m = sentinelDescriptor(20);
+    // When primary is at overview level (~40m), secondary should use overview too
+    const selected = selectSecondaryLevel(band20m.levels, 40);
+    expect(selected.metersPerPixel).toBe(20);
+  });
+});
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run: `npx vitest run packages/deck.gl-geotiff/tests/multi-cog-layer.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `npx vitest run`
+Expected: No regressions
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/deck.gl-geotiff/tests/multi-cog-layer.test.ts
+git commit -m "test: add integration smoke test for multi-resolution tile pipeline"
+```

--- a/dev-docs/plans/2026-04-09-multi-resolution-tileset.md
+++ b/dev-docs/plans/2026-04-09-multi-resolution-tileset.md
@@ -6,7 +6,7 @@
 
 **Architecture:** A `MultiTilesetDescriptor` in `deck.gl-raster` describes the relationship between tile grids at different resolutions. A `MultiCOGLayer` in `deck.gl-geotiff` orchestrates fetching tiles from multiple COGs, stitching across tile boundaries, computing UV transforms, and passing named textures to the shader. The primary (highest-resolution) tileset drives tile traversal; secondary tilesets are consulted at fetch time.
 
-**Tech Stack:** TypeScript, deck.gl (CompositeLayer, TileLayer, Tileset2D), luma.gl (Texture, ShaderModule), geotiff.js, vitest, Biome
+**Tech Stack:** TypeScript, deck.gl (CompositeLayer, TileLayer, Tileset2D), luma.gl (Texture, ShaderModule), @developmentseed/geotiff (monorepo package, built on @cogeotiff/core), vitest, Biome
 
 **Spec:** `dev-docs/specs/2026-04-09-multi-resolution-tileset-design.md`
 
@@ -18,19 +18,19 @@
 
 | File | Responsibility |
 |------|---------------|
-| `packages/deck.gl-raster/src/raster-tileset/multi-tileset-descriptor.ts` | `MultiTilesetDescriptor` type + `createMultiTilesetDescriptor()` factory + `selectSecondaryLevel()` + `tilesetLevelsEqual()` |
-| `packages/deck.gl-raster/src/raster-tileset/secondary-tile-resolver.ts` | `resolveSecondaryTiles()` — computes covering tile ranges and UV transforms for a primary tile against a secondary tileset |
+| `packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts` | `MultiTilesetDescriptor` type + `createMultiTilesetDescriptor()` factory + `selectSecondaryLevel()` + `tilesetLevelsEqual()` |
+| `packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts` | `resolveSecondaryTiles()` — computes covering tile ranges and UV transforms for a primary tile against a secondary tileset |
 | `packages/deck.gl-raster/src/gpu-modules/composite-bands.ts` | `CompositeBands` GPU module — samples named band textures with UV transforms, outputs `vec4` |
 | `packages/deck.gl-geotiff/src/multi-cog-layer.ts` | `MultiCOGLayer` — orchestrates multi-source COG loading, tile fetching, stitching, rendering |
-| `packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts` | Tests for `MultiTilesetDescriptor` creation and validation |
-| `packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts` | Tests for secondary tile resolution and UV transform computation |
-| `packages/deck.gl-raster/tests/composite-bands.test.ts` | Tests for `CompositeBands` module structure |
+| `packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts` | Tests for `MultiTilesetDescriptor` creation and validation |
+| `packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts` | Tests for secondary tile resolution and UV transform computation |
+| `packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts` | Tests for `CompositeBands` module structure |
 
 ### Modified files
 
 | File | Change |
 |------|--------|
-| `packages/deck.gl-raster/src/raster-tileset/index.ts` | Export new types and functions |
+| `packages/deck.gl-raster/src/multi-raster-tileset/index.ts` | (New) Barrel exports for multi-raster-tileset |
 | `packages/deck.gl-raster/src/gpu-modules/index.ts` | Export `CompositeBands` |
 | `packages/deck.gl-raster/src/index.ts` | Export new public types |
 | `packages/deck.gl-geotiff/src/index.ts` | Export `MultiCOGLayer` |
@@ -40,27 +40,28 @@
 ## Task 1: MultiTilesetDescriptor Type and Factory
 
 **Files:**
-- Create: `packages/deck.gl-raster/src/raster-tileset/multi-tileset-descriptor.ts`
-- Test: `packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts`
-- Modify: `packages/deck.gl-raster/src/raster-tileset/index.ts`
+- Create: `packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts`
+- Test: `packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts`
+- Create: `packages/deck.gl-raster/src/multi-raster-tileset/index.ts`
+- Modify: `packages/deck.gl-raster/src/index.ts`
 
 - [ ] **Step 1: Write tests for MultiTilesetDescriptor**
 
 Create test file with mock tilesets representing 10m and 20m grids:
 
 ```ts
-// packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts
+// packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
 import { describe, expect, it } from "vitest";
 import {
   createMultiTilesetDescriptor,
   selectSecondaryLevel,
   tilesetLevelsEqual,
-} from "../src/raster-tileset/multi-tileset-descriptor.js";
+} from "../src/multi-raster-tileset/multi-tileset-descriptor.js";
 import type {
   TilesetDescriptor,
   TilesetLevel,
-} from "../src/raster-tileset/tileset-interface.js";
-import type { Corners, Point } from "../src/raster-tileset/types.js";
+} from "../../src/raster-tileset/tileset-interface.js";
+import type { Corners, Point } from "../../src/raster-tileset/types.js";
 
 /** Helper: create a mock TilesetLevel */
 function mockLevel(opts: {
@@ -303,13 +304,13 @@ describe("selectSecondaryLevel", () => {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `npx vitest run packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts`
-Expected: FAIL — module not found
+Run: `npx vitest run packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts`
+Expected: FAIL (module not found)
 
 - [ ] **Step 3: Implement MultiTilesetDescriptor**
 
 ```ts
-// packages/deck.gl-raster/src/raster-tileset/multi-tileset-descriptor.ts
+// packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts
 import type { TilesetDescriptor, TilesetLevel } from "./tileset-interface.js";
 import type { Bounds, ProjectionFunction } from "./types.js";
 
@@ -428,12 +429,12 @@ export function tilesetLevelsEqual(
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `npx vitest run packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts`
+Run: `npx vitest run packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts`
 Expected: All tests PASS
 
 - [ ] **Step 5: Add exports**
 
-In `packages/deck.gl-raster/src/raster-tileset/index.ts`, add:
+Create `packages/deck.gl-raster/src/multi-raster-tileset/index.ts`:
 
 ```ts
 export type { MultiTilesetDescriptor } from "./multi-tileset-descriptor.js";
@@ -444,27 +445,27 @@ export {
 } from "./multi-tileset-descriptor.js";
 ```
 
-In `packages/deck.gl-raster/src/index.ts`, add to the raster-tileset re-exports:
+In `packages/deck.gl-raster/src/index.ts`, add:
 
 ```ts
-export type { MultiTilesetDescriptor } from "./raster-tileset/index.js";
+export type { MultiTilesetDescriptor } from "./multi-raster-tileset/index.js";
 export {
   createMultiTilesetDescriptor,
   selectSecondaryLevel,
   tilesetLevelsEqual,
-} from "./raster-tileset/index.js";
+} from "./multi-raster-tileset/index.js";
 ```
 
 - [ ] **Step 6: Run full test suite and lint**
 
 Run: `npx vitest run packages/deck.gl-raster/`
-Run: `npx biome check packages/deck.gl-raster/src/raster-tileset/multi-tileset-descriptor.ts`
+Run: `npx biome check packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts`
 
 - [ ] **Step 7: Commit**
 
 ```bash
-git add packages/deck.gl-raster/src/raster-tileset/multi-tileset-descriptor.ts \
-       packages/deck.gl-raster/tests/multi-tileset-descriptor.test.ts \
+git add packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts \
+       packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts \
        packages/deck.gl-raster/src/raster-tileset/index.ts \
        packages/deck.gl-raster/src/index.ts
 git commit -m "feat: add MultiTilesetDescriptor type and factory"
@@ -477,16 +478,16 @@ git commit -m "feat: add MultiTilesetDescriptor type and factory"
 Computes which secondary tiles cover a primary tile's extent, and the UV transform to map between them.
 
 **Files:**
-- Create: `packages/deck.gl-raster/src/raster-tileset/secondary-tile-resolver.ts`
-- Test: `packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts`
-- Modify: `packages/deck.gl-raster/src/raster-tileset/index.ts`
+- Create: `packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts`
+- Test: `packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts`
+- Modify: `packages/deck.gl-raster/src/multi-raster-tileset/index.ts`
 
 - [ ] **Step 1: Write tests for secondary tile resolution**
 
 ```ts
-// packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts
+// packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts
 import { describe, expect, it } from "vitest";
-import { resolveSecondaryTiles } from "../src/raster-tileset/secondary-tile-resolver.js";
+import { resolveSecondaryTiles } from "../src/multi-raster-tileset/secondary-tile-resolver.js";
 import type { TilesetLevel } from "../src/raster-tileset/tileset-interface.js";
 import type { Bounds, Corners, Point } from "../src/raster-tileset/types.js";
 
@@ -659,13 +660,13 @@ describe("resolveSecondaryTiles", () => {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `npx vitest run packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts`
-Expected: FAIL — module not found
+Run: `npx vitest run packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts`
+Expected: FAIL (module not found)
 
 - [ ] **Step 3: Implement resolveSecondaryTiles**
 
 ```ts
-// packages/deck.gl-raster/src/raster-tileset/secondary-tile-resolver.ts
+// packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
 import type { TilesetLevel } from "./tileset-interface.js";
 
 /** A tile index in a secondary tileset */
@@ -833,12 +834,12 @@ export function resolveSecondaryTiles(
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `npx vitest run packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts`
+Run: `npx vitest run packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts`
 Expected: All tests PASS
 
 - [ ] **Step 5: Add exports**
 
-In `packages/deck.gl-raster/src/raster-tileset/index.ts`, add:
+In `packages/deck.gl-raster/src/multi-raster-tileset/index.ts`, add:
 
 ```ts
 export type {
@@ -851,13 +852,13 @@ export { resolveSecondaryTiles } from "./secondary-tile-resolver.js";
 - [ ] **Step 6: Run full test suite and lint**
 
 Run: `npx vitest run packages/deck.gl-raster/`
-Run: `npx biome check packages/deck.gl-raster/src/raster-tileset/secondary-tile-resolver.ts`
+Run: `npx biome check packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts`
 
 - [ ] **Step 7: Commit**
 
 ```bash
-git add packages/deck.gl-raster/src/raster-tileset/secondary-tile-resolver.ts \
-       packages/deck.gl-raster/tests/secondary-tile-resolver.test.ts \
+git add packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts \
+       packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts \
        packages/deck.gl-raster/src/raster-tileset/index.ts
 git commit -m "feat: add secondary tile resolver with UV transform computation"
 ```
@@ -870,15 +871,15 @@ A shader module that samples N named band textures with UV transforms and output
 
 **Files:**
 - Create: `packages/deck.gl-raster/src/gpu-modules/composite-bands.ts`
-- Test: `packages/deck.gl-raster/tests/composite-bands.test.ts`
+- Test: `packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts`
 - Modify: `packages/deck.gl-raster/src/gpu-modules/index.ts`
 
 - [ ] **Step 1: Write tests for CompositeBands module structure**
 
 ```ts
-// packages/deck.gl-raster/tests/composite-bands.test.ts
+// packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts
 import { describe, expect, it } from "vitest";
-import { createCompositeBandsModule } from "../src/gpu-modules/composite-bands.js";
+import { createCompositeBandsModule } from "../../src/gpu-modules/composite-bands.js";
 
 describe("createCompositeBandsModule", () => {
   it("creates a shader module with correct uniforms for RGB bands", () => {
@@ -951,8 +952,8 @@ describe("createCompositeBandsModule", () => {
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `npx vitest run packages/deck.gl-raster/tests/composite-bands.test.ts`
-Expected: FAIL — module not found
+Run: `npx vitest run packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts`
+Expected: FAIL (module not found)
 
 - [ ] **Step 3: Implement CompositeBands**
 
@@ -1043,7 +1044,7 @@ vec2 compositeBands_applyUv(vec2 uv, vec4 transform) {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `npx vitest run packages/deck.gl-raster/tests/composite-bands.test.ts`
+Run: `npx vitest run packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts`
 Expected: All tests PASS
 
 - [ ] **Step 5: Add exports**
@@ -1063,7 +1064,7 @@ Run: `npx biome check packages/deck.gl-raster/src/gpu-modules/composite-bands.ts
 
 ```bash
 git add packages/deck.gl-raster/src/gpu-modules/composite-bands.ts \
-       packages/deck.gl-raster/tests/composite-bands.test.ts \
+       packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts \
        packages/deck.gl-raster/src/gpu-modules/index.ts
 git commit -m "feat: add CompositeBands GPU module for multi-band rendering"
 ```
@@ -1623,97 +1624,64 @@ git commit -m "feat: add tile fetching, stitching, and rendering to MultiCOGLaye
 
 ---
 
-## Task 6: Integration Smoke Test
+## Task 6: Integration Test with Real Sentinel-2 TileMatrixSet
 
-Create a minimal integration test to verify the full pipeline wires together.
+Use the real Sentinel-2 multiscales fixture (`packages/geozarr/multiscales/examples/sentinel-2-multiresolution.json`) to build TileMatrixSet-backed tilesets and verify the full multi-resolution pipeline with real-world grid parameters.
 
 **Files:**
-- Create: `packages/deck.gl-geotiff/tests/multi-cog-layer.test.ts`
+- Create: `packages/deck.gl-raster/tests/multi-raster-tileset/sentinel2-integration.test.ts`
 
-- [ ] **Step 1: Write integration test**
+- [ ] **Step 1: Write integration test using real Sentinel-2 TMS data**
+
+The Sentinel-2 fixture at `packages/geozarr/multiscales/examples/sentinel-2-multiresolution.json` contains a `tile_matrix_set` with real tile matrices for r10m, r20m, r60m, etc. Use `TileMatrixSetAdaptor` to create real `TilesetDescriptor` instances from those.
 
 ```ts
-// packages/deck.gl-geotiff/tests/multi-cog-layer.test.ts
+// packages/deck.gl-raster/tests/multi-raster-tileset/sentinel2-integration.test.ts
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   createMultiTilesetDescriptor,
   selectSecondaryLevel,
   resolveSecondaryTiles,
   tilesetLevelsEqual,
-} from "@developmentseed/deck.gl-raster";
-import type {
-  TilesetDescriptor,
-  TilesetLevel,
-} from "@developmentseed/deck.gl-raster";
-import type { Corners, Point } from "@developmentseed/deck.gl-raster";
+  TileMatrixSetAdaptor,
+} from "../../src/index.js";
+import type { TilesetDescriptor } from "../../src/index.js";
+
+// Load the real Sentinel-2 multiscales fixture
+const fixturePath = resolve(
+  import.meta.dirname,
+  "../../../geozarr/multiscales/examples/sentinel-2-multiresolution.json",
+);
+const fixture = JSON.parse(readFileSync(fixturePath, "utf-8"));
+const tms = fixture.attributes.multiscales.tile_matrix_set;
+
+// Identity projection (the fixture is in UTM, we're testing grid logic not reprojection)
+const identity = (x: number, y: number): [number, number] => [x, y];
 
 /**
- * Simulates a Sentinel-2 scene with 10m and 20m bands.
- * Origin at (600000, 8000000) in EPSG:32625, top-left convention.
+ * Build a TilesetDescriptor from a subset of tile matrices in the Sentinel-2 TMS.
+ * @param matrixIds - The tile matrix IDs to include (e.g. ["r10m", "r720m"])
  */
-function sentinelLevel(cellSize: number, tilePixels: number): TilesetLevel {
-  const originX = 600000;
-  const originY = 8000000;
-  const totalPixels = Math.ceil(109800 / cellSize); // ~110km scene
-  const matrixSize = Math.ceil(totalPixels / tilePixels);
-  const tileCrsWidth = tilePixels * cellSize;
-  const tileCrsHeight = tilePixels * cellSize;
-
-  return {
-    matrixWidth: matrixSize,
-    matrixHeight: matrixSize,
-    tileWidth: tilePixels,
-    tileHeight: tilePixels,
-    metersPerPixel: cellSize,
-    projectedTileCorners: (col: number, row: number): Corners => {
-      const minX = originX + col * tileCrsWidth;
-      const maxX = minX + tileCrsWidth;
-      const maxY = originY - row * tileCrsHeight;
-      const minY = maxY - tileCrsHeight;
-      return {
-        topLeft: [minX, maxY] as Point,
-        topRight: [maxX, maxY] as Point,
-        bottomLeft: [minX, minY] as Point,
-        bottomRight: [maxX, minY] as Point,
-      };
-    },
-    crsBoundsToTileRange: (
-      projectedMinX: number,
-      projectedMinY: number,
-      projectedMaxX: number,
-      projectedMaxY: number,
-    ) => {
-      let minCol = Math.floor((projectedMinX - originX) / tileCrsWidth);
-      let maxCol = Math.floor((projectedMaxX - originX) / tileCrsWidth);
-      let minRow = Math.floor((originY - projectedMaxY) / tileCrsHeight);
-      let maxRow = Math.floor((originY - projectedMinY) / tileCrsHeight);
-      minCol = Math.max(0, Math.min(matrixSize - 1, minCol));
-      maxCol = Math.max(0, Math.min(matrixSize - 1, maxCol));
-      minRow = Math.max(0, Math.min(matrixSize - 1, minRow));
-      maxRow = Math.max(0, Math.min(matrixSize - 1, maxRow));
-      return { minCol, maxCol, minRow, maxRow };
-    },
+function descriptorFromMatrixIds(matrixIds: string[]): TilesetDescriptor {
+  const filtered = {
+    ...tms,
+    tileMatrices: tms.tileMatrices.filter((m: any) =>
+      matrixIds.includes(m.id),
+    ),
   };
-}
-
-function sentinelDescriptor(cellSize: number): TilesetDescriptor {
-  const identity = (x: number, y: number): [number, number] => [x, y];
-  // Create a 2-level pyramid: coarse overview + full resolution
-  return {
-    levels: [
-      sentinelLevel(cellSize * 4, 256), // overview
-      sentinelLevel(cellSize, 256), // full res
-    ],
-    projectTo3857: identity,
+  return new TileMatrixSetAdaptor(filtered, {
     projectTo4326: identity,
-    projectedBounds: [600000, 7890200, 709800, 8000000],
-  };
+    projectTo3857: identity,
+  });
 }
 
-describe("Multi-resolution Sentinel-2 simulation", () => {
-  it("builds MultiTilesetDescriptor with 10m as primary", () => {
-    const band10m = sentinelDescriptor(10);
-    const band20m = sentinelDescriptor(20);
+describe("Sentinel-2 multi-resolution integration", () => {
+  it("creates MultiTilesetDescriptor with 10m primary from real TMS", () => {
+    // B04 (red) at 10m, B11 (SWIR) at 20m — each with their own overview pyramid
+    const band10m = descriptorFromMatrixIds(["r720m", "r360m", "r120m", "r60m", "r10m"]);
+    const band20m = descriptorFromMatrixIds(["r720m", "r360m", "r120m", "r60m", "r20m"]);
 
     const multi = createMultiTilesetDescriptor(
       new Map([
@@ -1722,44 +1690,65 @@ describe("Multi-resolution Sentinel-2 simulation", () => {
       ]),
     );
 
+    // 10m has finer metersPerPixel at its finest level, so it should be primary
     expect(multi.primaryKey).toBe("B04");
     expect(multi.secondaries.has("B11")).toBe(true);
+    expect(multi.secondaries.size).toBe(1);
   });
 
-  it("resolves UV transform for 20m band against 10m tile", () => {
-    const level10m = sentinelLevel(10, 256); // 256 * 10 = 2560m per tile
-    const level20m = sentinelLevel(20, 256); // 256 * 20 = 5120m per tile
+  it("detects that two 10m band tilesets share the same grid", () => {
+    const band10m_a = descriptorFromMatrixIds(["r720m", "r360m", "r10m"]);
+    const band10m_b = descriptorFromMatrixIds(["r720m", "r360m", "r10m"]);
 
-    // Primary tile (0,0) covers [600000, 7997440] to [602560, 8000000]
+    // Finest levels should be equal (both are r10m)
+    const finestA = band10m_a.levels[band10m_a.levels.length - 1]!;
+    const finestB = band10m_b.levels[band10m_b.levels.length - 1]!;
+    expect(tilesetLevelsEqual(finestA, finestB)).toBe(true);
+  });
+
+  it("selects correct secondary level for 20m band at 10m primary zoom", () => {
+    const band20m = descriptorFromMatrixIds(["r720m", "r360m", "r120m", "r60m", "r20m"]);
+
+    // At 10m primary resolution, best secondary level is the 20m (finest available)
+    const finestLevel = band20m.levels[band20m.levels.length - 1]!;
+    const selected = selectSecondaryLevel(band20m.levels, 10);
+    expect(selected).toBe(finestLevel);
+  });
+
+  it("resolves UV transform for 20m tile against 10m tile grid", () => {
+    const band10m = descriptorFromMatrixIds(["r10m"]);
+    const band20m = descriptorFromMatrixIds(["r20m"]);
+
+    const level10m = band10m.levels[band10m.levels.length - 1]!;
+    const level20m = band20m.levels[band20m.levels.length - 1]!;
+
+    // Tile (0,0) at 10m resolution
     const result = resolveSecondaryTiles(level10m, 0, 0, level20m);
 
-    // Should map to a sub-region of secondary tile (0,0)
-    expect(result.tileIndices.length).toBe(1);
-    expect(result.uvTransform[2]).toBeCloseTo(0.5); // scaleX: 2560/5120
-    expect(result.uvTransform[3]).toBeCloseTo(0.5); // scaleY: 2560/5120
-    expect(result.uvTransform[0]).toBeCloseTo(0); // offsetX: at origin
-    expect(result.uvTransform[1]).toBeCloseTo(0); // offsetY: at origin
+    // 10m tile should map into a sub-region of the 20m tile grid
+    expect(result.tileIndices.length).toBeGreaterThanOrEqual(1);
+    // UV scale should be < 1 (10m tile is smaller than 20m tile in CRS extent)
+    expect(result.uvTransform[2]).toBeLessThanOrEqual(1); // scaleX
+    expect(result.uvTransform[3]).toBeLessThanOrEqual(1); // scaleY
   });
 
-  it("detects matching grids for same-resolution bands", () => {
-    const level10m_a = sentinelLevel(10, 256);
-    const level10m_b = sentinelLevel(10, 256);
+  it("10m and 20m finest levels have different grid parameters", () => {
+    const band10m = descriptorFromMatrixIds(["r10m"]);
+    const band20m = descriptorFromMatrixIds(["r20m"]);
 
-    expect(tilesetLevelsEqual(level10m_a, level10m_b)).toBe(true);
-  });
+    const finest10m = band10m.levels[band10m.levels.length - 1]!;
+    const finest20m = band20m.levels[band20m.levels.length - 1]!;
 
-  it("selectSecondaryLevel picks correct level for zoomed-out view", () => {
-    const band20m = sentinelDescriptor(20);
-    // When primary is at overview level (~40m), secondary should use overview too
-    const selected = selectSecondaryLevel(band20m.levels, 40);
-    expect(selected.metersPerPixel).toBe(20);
+    expect(tilesetLevelsEqual(finest10m, finest20m)).toBe(false);
+    // 10m has finer resolution
+    expect(finest10m.metersPerPixel).toBeLessThan(finest20m.metersPerPixel);
   });
 });
 ```
 
 - [ ] **Step 2: Run integration test**
 
-Run: `npx vitest run packages/deck.gl-geotiff/tests/multi-cog-layer.test.ts`
+Run: `npx vitest run packages/deck.gl-raster/tests/multi-raster-tileset/sentinel2-integration.test.ts`
 Expected: All tests PASS
 
 - [ ] **Step 3: Run full test suite**
@@ -1770,6 +1759,6 @@ Expected: No regressions
 - [ ] **Step 4: Commit**
 
 ```bash
-git add packages/deck.gl-geotiff/tests/multi-cog-layer.test.ts
-git commit -m "test: add integration smoke test for multi-resolution tile pipeline"
+git add packages/deck.gl-raster/tests/multi-raster-tileset/sentinel2-integration.test.ts
+git commit -m "test: add Sentinel-2 integration test for multi-resolution tileset"
 ```

--- a/dev-docs/specs/2026-04-09-multi-resolution-tileset-design.md
+++ b/dev-docs/specs/2026-04-09-multi-resolution-tileset-design.md
@@ -1,0 +1,275 @@
+# Multi-Resolution Tileset Design
+
+## Problem
+
+Satellites like Sentinel-2 have bands at different spatial resolutions (10m, 20m, 60m). When rendering a scene that combines bands from different resolution groups (e.g., NDVI from a 10m red band and a 20m NIR band), the internal tiling grids don't align across resolutions. The tile pyramids have different tile sizes, grid dimensions, and overview structures.
+
+The GPU naturally handles resolution differences — if two textures represent the same geographic area but one has 2x the pixels, the GPU's bilinear sampler interpolates correctly. The hard part is aligning the tile grids so that each texture covers the correct geographic region.
+
+## Goals
+
+- Render multiple bands from different resolution groups in a single shader pass
+- Tile traversal driven by the highest-resolution tileset
+- No CPU resampling — GPU handles interpolation via texture sampling
+- Resolution alignment (UV transforms, stitching) is invisible to shader/module authors
+- Support both separate COGs per band and Zarr multiscales convention
+- Start with COG implementation (`MultiCOGLayer`), extract common abstractions later
+
+## Non-Goals (Deferred)
+
+- Arbitrary overlapping rasters with different CRS/extent (only same-scene, same-extent sources)
+- Shader module pipeline evolution for >4 channel inter-module data flow
+- Tile caching optimization (future work)
+- Coalesced tile fetching a la `fetchTiles` (future optimization, orthogonal to this design)
+
+## Design
+
+### 1. MultiTilesetDescriptor
+
+A new type in `deck.gl-raster` that groups N tilesets representing the same geographic extent at different native resolutions.
+
+```ts
+interface MultiTilesetDescriptor {
+  /** Highest resolution tileset — drives tile traversal */
+  primary: TilesetDescriptor;
+
+  /** Lower-resolution tilesets, keyed by user-defined name */
+  secondaries: Map<string, TilesetDescriptor>;
+
+  /** Shared CRS bounds (all tilesets must match within tolerance) */
+  bounds: [minX: number, minY: number, maxX: number, maxY: number];
+
+  /** Shared projection functions */
+  projectTo3857: (x: number, y: number) => [number, number];
+  projectTo4326: (x: number, y: number) => [number, number];
+}
+```
+
+**Primary selection**: The tileset with the finest `metersPerPixel` at its highest-resolution level is the primary. This can be auto-detected or user-specified.
+
+**Constraint**: All tilesets must share the same CRS and geographic extent. Enforced at construction time.
+
+**Tile traversal**: Unchanged. Only `primary.levels` are used by `getTileIndices()` and `RasterTileNode`. Secondaries are never traversed independently.
+
+**Short-circuit**: When multiple sources share the same tile grid (e.g., all 10m Sentinel-2 bands), they can share a single `TilesetDescriptor` entry. The layer detects grid equality and avoids redundant UV transform computation.
+
+### 2. Tile Fetch & Stitch
+
+When a primary tile `(x, y, z)` is selected for rendering:
+
+#### Step 1: Compute primary tile extent
+
+From the primary tileset level's affine transform, compute the CRS bounding box of the tile.
+
+#### Step 2: Select secondary level
+
+For each secondary tileset, pick the level whose `metersPerPixel` is the closest finer-than-or-equal-to the primary tile's level. If the secondary's finest level is still coarser than the primary (e.g., 60m band at 10m zoom), use the finest available — this is physically correct (the band simply has lower resolution).
+
+#### Step 3: Find covering secondary tiles
+
+Use the selected secondary level's `crsBoundsToTileRange(primaryBounds)` to get the set of secondary tile indices that overlap the primary tile's extent. Typically 1 tile, occasionally 2-4 at grid boundaries.
+
+#### Step 4: Fetch secondary tiles
+
+Fetch all covering secondary tiles as raw pixel buffers at their native resolution.
+
+#### Step 5: Stitch
+
+If multiple secondary tiles cover the primary extent, stitch them into a single contiguous pixel buffer. This is a memcpy operation — no resampling. The stitched buffer covers the bounding box of all fetched secondary tiles (which is >= the primary tile's extent).
+
+#### Step 6: Compute UV transform
+
+The stitched texture covers a slightly larger geographic area than the primary tile. Compute a UV transform that maps from the primary tile's UV space `[0,1]²` to the correct sub-region of the stitched texture:
+
+```
+uvScale.x = primaryExtent.width / stitchedExtent.width
+uvScale.y = primaryExtent.height / stitchedExtent.height
+uvOffset.x = (primaryExtent.minX - stitchedExtent.minX) / stitchedExtent.width
+uvOffset.y = (primaryExtent.minY - stitchedExtent.minY) / stitchedExtent.height
+```
+
+The shader samples with: `sampledUV = uv * uvScale + uvOffset`
+
+#### Fetch return type
+
+```ts
+interface MultiTileData {
+  /** Primary source texture — UV transform is identity */
+  primary: {
+    texture: Texture;
+    uvTransform: [0, 0, 1, 1]; // [offsetX, offsetY, scaleX, scaleY]
+  };
+
+  /** One entry per secondary source */
+  secondaries: Record<string, {
+    texture: Texture;
+    uvTransform: [number, number, number, number];
+  }>;
+}
+```
+
+### 3. MultiCOGLayer
+
+A new layer in `deck.gl-geotiff` that orchestrates multi-resolution rendering.
+
+#### User API
+
+```ts
+new MultiCOGLayer({
+  sources: {
+    red:  { url: "B04.tif" },   // 10m
+    nir:  { url: "B08.tif" },   // 10m — same grid as red
+    swir: { url: "B11.tif" },   // 20m — different grid
+  },
+
+  // Option A: built-in band reduction for common cases
+  // (mutually exclusive with fragmentShader)
+  composite: { r: "nir", g: "swir", b: "red" },
+
+  // Option B: custom fragment shader for complex cases
+  // (mutually exclusive with composite)
+  fragmentShader: `
+    uniform sampler2D bandRed;
+    uniform sampler2D bandNir;
+    uniform vec4 uvTransform_red;
+    uniform vec4 uvTransform_nir;
+
+    vec2 applyUvTransform(vec2 uv, vec4 transform) {
+      return uv * transform.zw + transform.xy;
+    }
+
+    void main() {
+      float red = texture(bandRed, applyUvTransform(vTexCoord, uvTransform_red)).r;
+      float nir = texture(bandNir, applyUvTransform(vTexCoord, uvTransform_nir)).r;
+      float ndvi = (nir - red) / (nir + red);
+      fragColor = vec4(ndvi, ndvi, ndvi, 1.0);
+    }
+  `,
+
+  // Standard render pipeline modules still work for post-processing
+  // (colormap, nodata filtering, etc.) on the vec4 output
+  renderPipeline: [Colormap({ ... })],
+})
+```
+
+#### Initialization
+
+1. Open all source COGs in parallel
+2. Build a `TilesetDescriptor` from each (reusing existing COG metadata parsing)
+3. Detect grid equality across sources — group sources that share the same tile grid
+4. Construct `MultiTilesetDescriptor` with the finest-resolution tileset as primary
+5. Set up `RasterTileset2D` using the primary tileset for traversal
+
+#### getTileData(tileIndex)
+
+1. Fetch primary tile data (existing COG tile fetch logic)
+2. For each secondary group:
+   a. Compute primary tile CRS extent
+   b. Select appropriate secondary level
+   c. Find covering secondary tiles via `crsBoundsToTileRange`
+   d. Fetch covering tiles
+   e. Stitch if needed (memcpy)
+   f. Compute UV transform
+3. Return `MultiTileData` bundle
+
+Sources that share the primary's tile grid are fetched with identity UV transforms (the short-circuit optimization).
+
+#### renderTile(tileData)
+
+1. Upload all textures to GPU
+2. Bind UV transforms as uniforms
+3. Create mesh from primary tileset (existing `RasterReprojector`)
+4. If using built-in composite: inject a `CompositeBands` GPU module that samples named bands, applies UV transforms, and outputs a `vec4` color
+5. If using custom fragment shader: pass it through with texture/transform uniforms
+6. Append any `renderPipeline` modules for post-processing
+7. Render via `MeshTextureLayer`
+
+### 4. Shader Integration
+
+#### UV Transform Injection
+
+A utility GLSL function provided to all shaders:
+
+```glsl
+vec2 applyBandUvTransform(vec2 uv, vec4 transform) {
+  return uv * transform.zw + transform.xy;
+}
+```
+
+Where `transform = vec4(offsetX, offsetY, scaleX, scaleY)`.
+
+#### Built-in CompositeBands Module
+
+A new GPU module that handles the common case of combining 1-4 bands into an RGB(A) output:
+
+```ts
+CompositeBands({
+  r: "red",   // semantic band name → texture uniform
+  g: "nir",
+  b: "swir",
+  // optional: a: "alpha"
+})
+```
+
+This module:
+- Declares `sampler2D` and `vec4 uvTransform` uniforms for each referenced band
+- Samples each band with the UV transform applied
+- Outputs a `vec4 color` into the pipeline
+- Downstream modules (colormap, nodata, etc.) work on this `vec4` as today
+
+#### Custom Shader Escape Hatch
+
+For complex band math (spectral indices, classification), users write a custom fragment shader that directly samples named band textures. The layer provides:
+- `sampler2D band_<name>` uniforms for each source
+- `vec4 uvTransform_<name>` uniforms
+- The `applyBandUvTransform` utility function
+
+The custom shader outputs a `vec4 fragColor` which can then be post-processed by standard render pipeline modules.
+
+### 5. Data Flow Summary
+
+```
+User Config
+  ├── sources: { red: B04.tif (10m), nir: B08.tif (10m), swir: B11.tif (20m) }
+  └── composite: { r: "red", g: "swir", b: "nir" }
+          │
+          ▼
+MultiCOGLayer.init()
+  ├── Opens all COGs
+  ├── Builds TilesetDescriptor per source
+  ├── Groups by grid equality: { 10m: [red, nir], 20m: [swir] }
+  └── Constructs MultiTilesetDescriptor (primary = 10m grid)
+          │
+          ▼
+Tile Traversal (primary grid only)
+  └── Selected tile (x=3, y=7, z=2)
+          │
+          ▼
+getTileData(3, 7, 2)
+  ├── Fetch red tile (3,7,2) from 10m grid → texture, uvTransform=[0,0,1,1]
+  ├── Fetch nir tile (3,7,2) from 10m grid → texture, uvTransform=[0,0,1,1]
+  │   (same grid as primary — short circuit)
+  └── Fetch swir:
+      ├── Primary tile CRS extent → [600100, 7990200, 602700, 7992800]
+      ├── Secondary level selection → 20m level
+      ├── crsBoundsToTileRange → covers secondary tile (1, 3)
+      ├── Fetch secondary tile (1, 3) → texture
+      └── Compute uvTransform → [0.02, 0.05, 0.48, 0.48]
+          │
+          ▼
+renderTile(multiTileData)
+  ├── Upload textures: bandRed, bandNir, bandSwir
+  ├── Upload uniforms: uvTransform_red, uvTransform_nir, uvTransform_swir
+  ├── Generate mesh from primary tile (RasterReprojector)
+  ├── CompositeBands module: sample each band with UV transform → vec4
+  ├── Downstream pipeline: colormap, nodata, etc.
+  └── MeshTextureLayer.draw()
+```
+
+## Future Considerations
+
+- **Coalesced fetching**: When multiple primary tiles need overlapping secondary tiles, dedup fetches. Orthogonal to this design — can be added to the fetch layer later.
+- **Zarr support**: The `MultiTilesetDescriptor` is format-agnostic. A future `MultiZarrLayer` would parse the Zarr multiscales convention to construct it, using `transform.scale` and `derived_from` fields.
+- **RasterTileLayer abstraction**: When `RasterTileLayer` is extracted into `deck.gl-raster`, `MultiCOGLayer` should become a thin wrapper that provides sources and a `getTileData` implementation.
+- **>4 band pipeline**: The current design limits inter-module data flow to `vec4`. Supporting richer data flow between modules (structs, multiple named channels) is a separate evolution of the GPU module system.
+- **Tile caching**: Secondary tile fetches may be shared across primary tiles. A cache keyed by (source, level, tileX, tileY) would reduce redundant fetches.

--- a/dev-docs/specs/2026-04-09-multi-resolution-tileset-design.md
+++ b/dev-docs/specs/2026-04-09-multi-resolution-tileset-design.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-Satellites like Sentinel-2 have bands at different spatial resolutions (10m, 20m, 60m). When rendering a scene that combines bands from different resolution groups (e.g., NDVI from a 10m red band and a 20m NIR band), the internal tiling grids don't align across resolutions. The tile pyramids have different tile sizes, grid dimensions, and overview structures.
+Satellites like Sentinel-2 have bands at different spatial resolutions (10m, 20m, 60m). When rendering a scene that combines bands from different resolution groups (e.g., NDVI from a 10m red band and a 20m NIR band), the internal tiling grids don't _necessarily_ align across resolutions. The tile pyramids have different tile sizes, grid dimensions, and overview structures.
 
 The GPU naturally handles resolution differences — if two textures represent the same geographic area but one has 2x the pixels, the GPU's bilinear sampler interpolates correctly. The hard part is aligning the tile grids so that each texture covers the correct geographic region.
 
@@ -164,12 +164,12 @@ new MultiCOGLayer({
 
 1. Fetch primary tile data (existing COG tile fetch logic)
 2. For each secondary group:
-   a. Compute primary tile CRS extent
-   b. Select appropriate secondary level
-   c. Find covering secondary tiles via `crsBoundsToTileRange`
-   d. Fetch covering tiles
-   e. Stitch if needed (memcpy)
-   f. Compute UV transform
+    1. Compute primary tile CRS extent
+    1. Select appropriate secondary level
+    1. Find covering secondary tiles via `crsBoundsToTileRange`
+    1. Fetch covering tiles
+    1. Stitch if needed (memcpy)
+    1. Compute UV transform
 3. Return `MultiTileData` bundle
 
 Sources that share the primary's tile grid are fetched with identity UV transforms (the short-circuit optimization).

--- a/examples/sentinel-2/index.html
+++ b/examples/sentinel-2/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sentinel-2 Multi-Band Example</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+      #root {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/sentinel-2/package.json
+++ b/examples/sentinel-2/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "deck.gl-sentinel-2-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@deck.gl/core": "^9.2.10",
+    "@deck.gl/geo-layers": "^9.2.10",
+    "@deck.gl/layers": "^9.2.10",
+    "@deck.gl/mapbox": "^9.2.10",
+    "@deck.gl/mesh-layers": "^9.2.10",
+    "@developmentseed/deck.gl-geotiff": "workspace:^",
+    "@luma.gl/core": "9.2.6",
+    "maplibre-gl": "^5.19.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-map-gl": "^8.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
+    "vite": "^7.3.1"
+  }
+}

--- a/examples/sentinel-2/package.json
+++ b/examples/sentinel-2/package.json
@@ -14,6 +14,7 @@
     "@deck.gl/mapbox": "^9.2.10",
     "@deck.gl/mesh-layers": "^9.2.10",
     "@developmentseed/deck.gl-geotiff": "workspace:^",
+    "@developmentseed/deck.gl-raster": "workspace:^",
     "@luma.gl/core": "9.2.6",
     "maplibre-gl": "^5.19.0",
     "react": "^19.2.4",

--- a/examples/sentinel-2/src/App.tsx
+++ b/examples/sentinel-2/src/App.tsx
@@ -1,7 +1,7 @@
 import type { MapboxOverlayProps } from "@deck.gl/mapbox";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import { MultiCOGLayer } from "@developmentseed/deck.gl-geotiff";
-import { LinearRescale } from "@developmentseed/deck.gl-raster";
+import { LinearRescale } from "@developmentseed/deck.gl-raster/gpu-modules";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useRef, useState } from "react";
 import type { MapRef } from "react-map-gl/maplibre";

--- a/examples/sentinel-2/src/App.tsx
+++ b/examples/sentinel-2/src/App.tsx
@@ -1,6 +1,7 @@
 import type { MapboxOverlayProps } from "@deck.gl/mapbox";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import { MultiCOGLayer } from "@developmentseed/deck.gl-geotiff";
+import { LinearRescale } from "@developmentseed/deck.gl-raster";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useRef, useState } from "react";
 import type { MapRef } from "react-map-gl/maplibre";
@@ -75,6 +76,9 @@ export default function App() {
     id: "sentinel-2-multi",
     sources: preset.sources,
     composite: preset.composite,
+    renderPipeline: [
+      { module: LinearRescale, props: { rescaleMin: 0, rescaleMax: 0.05 } },
+    ],
   });
 
   return (

--- a/examples/sentinel-2/src/App.tsx
+++ b/examples/sentinel-2/src/App.tsx
@@ -1,0 +1,153 @@
+import type { MapboxOverlayProps } from "@deck.gl/mapbox";
+import { MapboxOverlay } from "@deck.gl/mapbox";
+import { MultiCOGLayer } from "@developmentseed/deck.gl-geotiff";
+import "maplibre-gl/dist/maplibre-gl.css";
+import { useRef, useState } from "react";
+import type { MapRef } from "react-map-gl/maplibre";
+import { Map as MaplibreMap, useControl } from "react-map-gl/maplibre";
+
+function DeckGLOverlay(props: MapboxOverlayProps) {
+  const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));
+  overlay.setProps(props);
+  return null;
+}
+
+// Sentinel-2 L2A scene — New York area, 2026-01-01
+// Band COGs are stored individually with different spatial resolutions:
+// - B02 (Blue), B03 (Green), B04 (Red), B08 (NIR): 10m
+// - B05, B06, B07, B8A, B11, B12: 20m
+// - B01, B09, B10: 60m
+const SCENE_BASE =
+  "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/18/T/WL/2026/1/S2B_18TWL_20260101_0_L2A";
+
+type CompositePreset = {
+  title: string;
+  sources: Record<string, { url: string }>;
+  composite: { r: string; g?: string; b?: string };
+};
+
+const PRESETS: CompositePreset[] = [
+  {
+    title: "True Color (B04, B03, B02) — all 10m",
+    sources: {
+      red: { url: `${SCENE_BASE}/B04.tif` },
+      green: { url: `${SCENE_BASE}/B03.tif` },
+      blue: { url: `${SCENE_BASE}/B02.tif` },
+    },
+    composite: { r: "red", g: "green", b: "blue" },
+  },
+  {
+    title: "False Color NIR (B08, B04, B03) — all 10m",
+    sources: {
+      nir: { url: `${SCENE_BASE}/B08.tif` },
+      red: { url: `${SCENE_BASE}/B04.tif` },
+      green: { url: `${SCENE_BASE}/B03.tif` },
+    },
+    composite: { r: "nir", g: "red", b: "green" },
+  },
+  {
+    title: "SWIR Composite (B12, B8A, B04) — 20m + 20m + 10m",
+    sources: {
+      swir: { url: `${SCENE_BASE}/B12.tif` },
+      nir: { url: `${SCENE_BASE}/B8A.tif` },
+      red: { url: `${SCENE_BASE}/B04.tif` },
+    },
+    composite: { r: "swir", g: "nir", b: "red" },
+  },
+  {
+    title: "Vegetation (B08, B11, B04) — 10m + 20m + 10m",
+    sources: {
+      nir: { url: `${SCENE_BASE}/B08.tif` },
+      swir: { url: `${SCENE_BASE}/B11.tif` },
+      red: { url: `${SCENE_BASE}/B04.tif` },
+    },
+    composite: { r: "nir", g: "swir", b: "red" },
+  },
+];
+
+export default function App() {
+  const mapRef = useRef<MapRef>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const preset = PRESETS[selectedIndex];
+
+  const layer = new MultiCOGLayer({
+    id: "sentinel-2-multi",
+    sources: preset.sources,
+    composite: preset.composite,
+  });
+
+  return (
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <MaplibreMap
+        ref={mapRef}
+        initialViewState={{
+          longitude: -74.0,
+          latitude: 40.7,
+          zoom: 10,
+        }}
+        mapStyle="https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
+      >
+        <DeckGLOverlay layers={[layer]} interleaved />
+      </MaplibreMap>
+
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          pointerEvents: "none",
+          zIndex: 1000,
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: "20px",
+            left: "20px",
+            background: "white",
+            padding: "16px",
+            borderRadius: "8px",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
+            maxWidth: "350px",
+            pointerEvents: "auto",
+          }}
+        >
+          <h3 style={{ margin: "0 0 8px 0", fontSize: "16px" }}>
+            Sentinel-2 Multi-Band
+          </h3>
+          <p style={{ margin: "0 0 12px 0", fontSize: "13px", color: "#666" }}>
+            Renders individual band COGs at different resolutions using
+            MultiCOGLayer. The GPU handles cross-resolution resampling.
+          </p>
+          <select
+            value={selectedIndex}
+            onChange={(e) => setSelectedIndex(Number(e.target.value))}
+            style={{
+              width: "100%",
+              padding: "4px",
+              cursor: "pointer",
+            }}
+          >
+            {PRESETS.map((p, i) => (
+              <option key={p.title} value={i}>
+                {p.title}
+              </option>
+            ))}
+          </select>
+          <p style={{ margin: "8px 0 0 0", fontSize: "11px", color: "#999" }}>
+            Bands:{" "}
+            {Object.entries(preset.sources)
+              .map(([name, s]) => {
+                const band = s.url.split("/").pop()?.replace(".tif", "");
+                return `${name}=${band}`;
+              })
+              .join(", ")}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/examples/sentinel-2/src/main.tsx
+++ b/examples/sentinel-2/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/sentinel-2/tsconfig.json
+++ b/examples/sentinel-2/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/examples/sentinel-2/vite.config.ts
+++ b/examples/sentinel-2/vite.config.ts
@@ -1,0 +1,11 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  base: "/deck.gl-raster/examples/sentinel-2/",
+  worker: { format: "es" },
+  server: {
+    port: 3001,
+  },
+});

--- a/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
@@ -335,7 +335,7 @@ function resolveModule<T>(m: UnresolvedRasterModule<T>, data: T): RasterModule {
  * For all array types, we must match our typed array type to what WebGL
  * expects, so this must return the same array type as what was passed in.
  */
-function enforceAlignment<T extends RasterTypedArray>(
+export function enforceAlignment<T extends RasterTypedArray>(
   data: T,
   {
     width,

--- a/packages/deck.gl-geotiff/src/index.ts
+++ b/packages/deck.gl-geotiff/src/index.ts
@@ -5,12 +5,17 @@ export type {
 } from "./cog-layer.js";
 export { COGLayer } from "./cog-layer.js";
 export * as texture from "./geotiff/texture.js";
-// Don't export GeoTIFF Layer for now; nudge people towards COGLayer
-// export type { GeoTIFFLayerProps } from "./geotiff-layer.js";
-// export { GeoTIFFLayer } from "./geotiff-layer.js";
 export type { MosaicLayerProps } from "./mosaic-layer/mosaic-layer.js";
 export { MosaicLayer } from "./mosaic-layer/mosaic-layer.js";
 export {
   type MosaicSource,
   MosaicTileset2D,
 } from "./mosaic-layer/mosaic-tileset-2d";
+// Don't export GeoTIFF Layer for now; nudge people towards COGLayer
+// export type { GeoTIFFLayerProps } from "./geotiff-layer.js";
+// export { GeoTIFFLayer } from "./geotiff-layer.js";
+export type {
+  MultiCOGLayerProps,
+  MultiCOGSourceConfig,
+} from "./multi-cog-layer.js";
+export { MultiCOGLayer } from "./multi-cog-layer.js";

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -1,0 +1,255 @@
+import type {
+  CompositeLayerProps,
+  Layer,
+  LayersList,
+  UpdateParameters,
+} from "@deck.gl/core";
+import { CompositeLayer } from "@deck.gl/core";
+import type { TileLayerProps } from "@deck.gl/geo-layers";
+import type {
+  CompositeBandsMapping,
+  MultiTilesetDescriptor,
+  RasterModule,
+  TilesetDescriptor,
+} from "@developmentseed/deck.gl-raster";
+import {
+  createMultiTilesetDescriptor,
+  TileMatrixSetAdaptor,
+} from "@developmentseed/deck.gl-raster";
+import type { DecoderPool, GeoTIFF } from "@developmentseed/geotiff";
+import { generateTileMatrixSet } from "@developmentseed/geotiff";
+import type { TileMatrixSet } from "@developmentseed/morecantile";
+import type { EpsgResolver } from "@developmentseed/proj";
+import {
+  epsgResolver as defaultEpsgResolver,
+  makeClampedForwardTo3857,
+  parseWkt,
+} from "@developmentseed/proj";
+import type { ReprojectionFns } from "@developmentseed/raster-reproject";
+import proj4 from "proj4";
+import { fetchGeoTIFF } from "./geotiff/geotiff.js";
+
+/**
+ * Configuration for a single COG source within a {@link MultiCOGLayer}.
+ */
+export interface MultiCOGSourceConfig {
+  /**
+   * URL or ArrayBuffer of the COG.
+   *
+   * @see {@link fetchGeoTIFF} for supported input types.
+   */
+  url: string | URL | ArrayBuffer;
+}
+
+/** Internal state for a single opened COG source. */
+interface SourceState {
+  geotiff: GeoTIFF;
+  tms: TileMatrixSet;
+}
+
+/**
+ * Props accepted by {@link MultiCOGLayer}.
+ *
+ * Extends {@link CompositeLayerProps} with multi-source COG configuration and
+ * optional tile-layer tuning knobs forwarded to the underlying
+ * {@link TileLayerProps | TileLayer}.
+ *
+ * @see {@link MultiCOGLayer}
+ * @see {@link MultiCOGSourceConfig}
+ */
+export type MultiCOGLayerProps = CompositeLayerProps &
+  Pick<
+    TileLayerProps,
+    | "debounceTime"
+    | "maxCacheSize"
+    | "maxCacheByteSize"
+    | "maxRequests"
+    | "refinementStrategy"
+  > & {
+    /**
+     * Named sources -- each key becomes a band name used when compositing.
+     *
+     * @see {@link MultiCOGSourceConfig}
+     */
+    sources: Record<string, MultiCOGSourceConfig>;
+
+    /**
+     * Map source bands to RGB(A) output channels.
+     *
+     * @see {@link CompositeBandsMapping}
+     */
+    composite?: CompositeBandsMapping;
+
+    /**
+     * Post-processing render pipeline modules applied after compositing.
+     *
+     * @see {@link RasterModule}
+     */
+    renderPipeline?: RasterModule[];
+
+    /**
+     * EPSG code resolver used to look up projection definitions for numeric
+     * CRS codes found in GeoTIFF metadata.
+     *
+     * @default defaultEpsgResolver
+     * @see {@link EpsgResolver}
+     */
+    epsgResolver?: EpsgResolver;
+
+    /**
+     * Decoder pool for parallel image chunk decompression.
+     *
+     * @see {@link DecoderPool}
+     */
+    pool?: DecoderPool;
+
+    /**
+     * Maximum reprojection error in pixels for mesh refinement.
+     * Lower values create denser meshes with higher accuracy.
+     *
+     * @default 0.125
+     */
+    maxError?: number;
+
+    /**
+     * AbortSignal to cancel loading of all sources.
+     */
+    signal?: AbortSignal;
+  };
+
+const defaultProps = {
+  epsgResolver: { type: "accessor" as const, value: defaultEpsgResolver },
+  maxError: { type: "number" as const, value: 0.125 },
+};
+
+/**
+ * A deck.gl {@link CompositeLayer} that opens multiple Cloud-Optimized GeoTIFFs
+ * (COGs) in parallel, builds a {@link TilesetDescriptor} for each, and groups
+ * them into a single {@link MultiTilesetDescriptor}.
+ *
+ * The finest-resolution source is automatically selected as the primary
+ * tileset, which drives the tile grid. Secondary sources are sampled at the
+ * closest matching resolution.
+ *
+ * This layer handles initialization only -- tile fetching and rendering are
+ * added in a subsequent task.
+ *
+ * @see {@link MultiCOGLayerProps} for accepted props.
+ * @see {@link createMultiTilesetDescriptor} for the grouping logic.
+ * @see {@link TileMatrixSetAdaptor} for the per-source tileset adapter.
+ */
+export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
+  static override layerName = "MultiCOGLayer";
+  static override defaultProps = defaultProps;
+
+  declare state: {
+    sources: Map<string, SourceState> | null;
+    multiDescriptor: MultiTilesetDescriptor | null;
+    forwardTo4326: ReprojectionFns["forwardReproject"] | null;
+    inverseFrom4326: ReprojectionFns["inverseReproject"] | null;
+    forwardTo3857: ReprojectionFns["forwardReproject"] | null;
+    inverseFrom3857: ReprojectionFns["inverseReproject"] | null;
+  };
+
+  override initializeState(): void {
+    this.setState({
+      sources: null,
+      multiDescriptor: null,
+      forwardTo4326: null,
+      inverseFrom4326: null,
+      forwardTo3857: null,
+      inverseFrom3857: null,
+    });
+  }
+
+  override updateState({ changeFlags }: UpdateParameters<this>): void {
+    if (changeFlags.dataChanged || changeFlags.propsChanged) {
+      this._parseAllSources();
+    }
+  }
+
+  /**
+   * Open all configured COG sources in parallel, compute shared projection
+   * functions, and build the {@link MultiTilesetDescriptor}.
+   *
+   * All sources are assumed to share the same CRS; the projection of the
+   * first source is used for the shared coordinate converters.
+   *
+   * @returns Resolves when all sources have been opened and state has been set.
+   */
+  async _parseAllSources(): Promise<void> {
+    const { sources } = this.props;
+    const entries = Object.entries(sources);
+
+    // Open all COGs in parallel
+    const cogSources = await Promise.all(
+      entries.map(async ([name, config]) => {
+        const geotiff = await fetchGeoTIFF(config.url);
+        const crs = geotiff.crs;
+        const sourceProjection =
+          typeof crs === "number"
+            ? await this.props.epsgResolver!(crs)
+            : parseWkt(crs);
+        const tms = generateTileMatrixSet(geotiff, sourceProjection);
+        return { name, geotiff, tms, sourceProjection };
+      }),
+    );
+
+    // Use the first source's projection for shared projection functions
+    // (all sources must share the same CRS)
+    const firstCogSource = cogSources[0]!;
+    const sourceProjection = firstCogSource.sourceProjection;
+
+    // @ts-expect-error - proj4 typings are incomplete and don't support
+    // wkt-parser input
+    const converter4326 = proj4(sourceProjection, "EPSG:4326");
+    const forwardTo4326 = (x: number, y: number) =>
+      converter4326.forward<[number, number]>([x, y], false);
+    const inverseFrom4326 = (x: number, y: number) =>
+      converter4326.inverse<[number, number]>([x, y], false);
+
+    // @ts-expect-error - proj4 typings are incomplete and don't support
+    // wkt-parser input
+    const converter3857 = proj4(sourceProjection, "EPSG:3857");
+    const forwardTo3857 = makeClampedForwardTo3857(
+      (x: number, y: number) =>
+        converter3857.forward<[number, number]>([x, y], false),
+      forwardTo4326,
+    );
+    const inverseFrom3857 = (x: number, y: number) =>
+      converter3857.inverse<[number, number]>([x, y], false);
+
+    // Build TilesetDescriptors
+    const tilesetMap = new Map<string, TilesetDescriptor>();
+    const sourceMap = new Map<string, SourceState>();
+
+    for (const cogSource of cogSources) {
+      const descriptor = new TileMatrixSetAdaptor(cogSource.tms, {
+        projectTo4326: forwardTo4326,
+        projectTo3857: forwardTo3857,
+      });
+      tilesetMap.set(cogSource.name, descriptor);
+      sourceMap.set(cogSource.name, {
+        geotiff: cogSource.geotiff,
+        tms: cogSource.tms,
+      });
+    }
+
+    const multiDescriptor = createMultiTilesetDescriptor(tilesetMap);
+
+    this.setState({
+      sources: sourceMap,
+      multiDescriptor,
+      forwardTo4326,
+      inverseFrom4326,
+      forwardTo3857,
+      inverseFrom3857,
+    });
+  }
+
+  override renderLayers(): Layer | LayersList | null {
+    // Placeholder -- tile fetching and rendering will be added in Task 5
+    if (!this.state.multiDescriptor) return null;
+    return [];
+  }
+}

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -53,6 +53,7 @@ import type { ReprojectionFns } from "@developmentseed/raster-reproject";
 import type { Device, Texture, TextureFormat } from "@luma.gl/core";
 import proj4 from "proj4";
 import { fetchGeoTIFF } from "./geotiff/geotiff.js";
+import { enforceAlignment } from "./geotiff/render-pipeline.js";
 import { fromAffine } from "./geotiff-reprojection.js";
 
 /** Size of deck.gl's common coordinate space in world units. */
@@ -763,13 +764,16 @@ function createBandTexture(device: Device, array: RasterArray): Texture {
     throw new Error("Band-separate layout not yet supported in MultiCOGLayer");
   }
 
-  const { data, width, height } = array;
+  const { data, width, height, count } = array;
   let format: TextureFormat;
+  let bytesPerSample: number;
 
   if (data instanceof Uint8Array || data instanceof Uint8ClampedArray) {
     format = "r8unorm";
+    bytesPerSample = 1;
   } else if (data instanceof Uint16Array) {
     format = "r16unorm";
+    bytesPerSample = 2;
   } else {
     throw new Error(
       `Unsupported typed array type: ${data.constructor.name}. ` +
@@ -777,8 +781,14 @@ function createBandTexture(device: Device, array: RasterArray): Texture {
     );
   }
 
+  const aligned = enforceAlignment(data, {
+    width,
+    height,
+    bytesPerPixel: bytesPerSample * count,
+  });
+
   return device.createTexture({
-    data,
+    data: aligned,
     format,
     width,
     height,

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -1,24 +1,48 @@
 import type {
   CompositeLayerProps,
   Layer,
+  LayerProps,
   LayersList,
   UpdateParameters,
 } from "@deck.gl/core";
-import { CompositeLayer } from "@deck.gl/core";
-import type { TileLayerProps } from "@deck.gl/geo-layers";
+import { COORDINATE_SYSTEM, CompositeLayer } from "@deck.gl/core";
+import type {
+  _Tile2DHeader as Tile2DHeader,
+  TileLayerProps,
+  _TileLoadProps as TileLoadProps,
+  _Tileset2DProps as Tileset2DProps,
+} from "@deck.gl/geo-layers";
+import { TileLayer } from "@deck.gl/geo-layers";
 import type {
   CompositeBandsMapping,
   MultiTilesetDescriptor,
   RasterModule,
   TilesetDescriptor,
+  TilesetLevel,
 } from "@developmentseed/deck.gl-raster";
 import {
+  createCompositeBandsModule,
   createMultiTilesetDescriptor,
+  RasterLayer,
+  RasterTileset2D,
+  resolveSecondaryTiles,
+  selectSecondaryLevel,
   TileMatrixSetAdaptor,
+  tilesetLevelsEqual,
 } from "@developmentseed/deck.gl-raster";
-import type { DecoderPool, GeoTIFF } from "@developmentseed/geotiff";
-import { generateTileMatrixSet } from "@developmentseed/geotiff";
+import type {
+  DecoderPool,
+  GeoTIFF,
+  Overview,
+  RasterArray,
+} from "@developmentseed/geotiff";
+import {
+  assembleTiles,
+  defaultDecoderPool,
+  generateTileMatrixSet,
+} from "@developmentseed/geotiff";
 import type { TileMatrixSet } from "@developmentseed/morecantile";
+import { tileTransform } from "@developmentseed/morecantile";
 import type { EpsgResolver } from "@developmentseed/proj";
 import {
   epsgResolver as defaultEpsgResolver,
@@ -26,8 +50,77 @@ import {
   parseWkt,
 } from "@developmentseed/proj";
 import type { ReprojectionFns } from "@developmentseed/raster-reproject";
+import type { Device, Texture } from "@luma.gl/core";
 import proj4 from "proj4";
 import { fetchGeoTIFF } from "./geotiff/geotiff.js";
+import { fromAffine } from "./geotiff-reprojection.js";
+
+/** Size of deck.gl's common coordinate space in world units. */
+const TILE_SIZE = 512;
+
+/** The size of the globe in web mercator meters. */
+const WEB_MERCATOR_METER_CIRCUMFERENCE = 40075016.686;
+
+/**
+ * Scale factor for converting EPSG:3857 meters into deck.gl world units
+ * (512x512).
+ */
+const WEB_MERCATOR_TO_WORLD_SCALE =
+  TILE_SIZE / WEB_MERCATOR_METER_CIRCUMFERENCE;
+
+/**
+ * UV transform mapping primary tile UV space to the correct sub-region of a
+ * band texture.
+ *
+ * Applied in the shader as: `sampledUV = uv * [scaleX, scaleY] + [offsetX, offsetY]`
+ *
+ * For primary-grid bands this is the identity `[0, 0, 1, 1]`.
+ * For secondary bands it accounts for resolution and alignment differences.
+ */
+interface UvTransform {
+  /** Horizontal offset: left edge of the primary tile within the band texture, in UV units. */
+  offsetX: number;
+  /** Vertical offset: top edge of the primary tile within the band texture, in UV units. */
+  offsetY: number;
+  /** Horizontal scale: fraction of the band texture width covered by the primary tile. */
+  scaleX: number;
+  /** Vertical scale: fraction of the band texture height covered by the primary tile. */
+  scaleY: number;
+}
+
+/**
+ * Convert the `[offsetX, offsetY, scaleX, scaleY]` tuple returned by
+ * {@link resolveSecondaryTiles} into the named {@link UvTransform} form.
+ */
+function tupleToUvTransform(t: [number, number, number, number]): UvTransform {
+  return { offsetX: t[0], offsetY: t[1], scaleX: t[2], scaleY: t[3] };
+}
+
+/** Data returned per band from tile fetching. */
+interface BandTileData {
+  /** GPU texture containing the band's raster data. */
+  texture: Texture;
+  /** UV transform for aligning this band's texture to the primary tile. */
+  uvTransform: UvTransform;
+  /** Width of the texture in pixels. */
+  width: number;
+  /** Height of the texture in pixels. */
+  height: number;
+}
+
+/** Result of {@link MultiCOGLayer._getTileData} -- all band textures plus reprojection functions. */
+interface MultiTileResult {
+  /** Per-band texture data, keyed by source name. */
+  bands: Map<string, BandTileData>;
+  /** Forward transform from pixel coordinates to CRS coordinates. */
+  forwardTransform: (x: number, y: number) => [number, number];
+  /** Inverse transform from CRS coordinates to pixel coordinates. */
+  inverseTransform: (x: number, y: number) => [number, number];
+  /** Width of the primary tile in pixels. */
+  width: number;
+  /** Height of the primary tile in pixels. */
+  height: number;
+}
 
 /**
  * Configuration for a single COG source within a {@link MultiCOGLayer}.
@@ -130,9 +223,6 @@ const defaultProps = {
  * The finest-resolution source is automatically selected as the primary
  * tileset, which drives the tile grid. Secondary sources are sampled at the
  * closest matching resolution.
- *
- * This layer handles initialization only -- tile fetching and rendering are
- * added in a subsequent task.
  *
  * @see {@link MultiCOGLayerProps} for accepted props.
  * @see {@link createMultiTilesetDescriptor} for the grouping logic.
@@ -247,9 +337,435 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
     });
   }
 
-  override renderLayers(): Layer | LayersList | null {
-    // Placeholder -- tile fetching and rendering will be added in Task 5
-    if (!this.state.multiDescriptor) return null;
-    return [];
+  /**
+   * Fetch tile data for all configured sources at the given tile index.
+   *
+   * Primary-grid sources are fetched directly at (x, y, z). Secondary
+   * sources are resolved to covering tiles at the closest matching zoom
+   * level, fetched (potentially multiple tiles), stitched if necessary,
+   * and returned with the appropriate UV transform.
+   *
+   * @param tile - Tile load props from the TileLayer, containing index and signal.
+   * @returns Per-band textures, UV transforms, and reprojection functions.
+   */
+  async _getTileData(tile: TileLoadProps): Promise<MultiTileResult> {
+    const { signal } = tile;
+    const { x, y, z } = tile.index;
+    const { multiDescriptor, sources } = this.state;
+    const pool = this.props.pool ?? defaultDecoderPool();
+    const device = this.context.device;
+
+    // Combine abort signals if both are defined
+    const combinedSignal =
+      signal && this.props.signal
+        ? AbortSignal.any([signal, this.props.signal])
+        : signal || this.props.signal;
+
+    // Compute reprojection transforms from the primary TMS
+    const primaryKey = multiDescriptor!.primaryKey;
+    const primarySource = sources!.get(primaryKey)!;
+    const primaryTms = primarySource.tms;
+    const tileMatrix = primaryTms.tileMatrices[z]!;
+    const tileAffine = tileTransform(tileMatrix, { col: x, row: y });
+    const { forwardTransform, inverseTransform } = fromAffine(tileAffine);
+
+    const primaryLevel = multiDescriptor!.primary.levels[z]!;
+
+    // Collect fetch promises for all bands
+    const bandPromises: Array<Promise<[string, BandTileData]>> = [];
+
+    for (const [name, sourceState] of sources!) {
+      const descriptor =
+        name === primaryKey
+          ? multiDescriptor!.primary
+          : multiDescriptor!.secondaries.get(name)!;
+
+      const isPrimary =
+        name === primaryKey ||
+        tilesetLevelsEqual(
+          descriptor.levels[z] ?? descriptor.levels[0]!,
+          primaryLevel,
+        );
+
+      if (isPrimary) {
+        // Primary-grid source: fetch tile directly with identity UV transform
+        bandPromises.push(
+          this._fetchPrimaryBand(name, sourceState, {
+            x,
+            y,
+            z,
+            pool,
+            signal: combinedSignal,
+            device,
+          }),
+        );
+      } else {
+        // Secondary source: resolve covering tiles and fetch
+        bandPromises.push(
+          this._fetchSecondaryBand(name, sourceState, {
+            descriptor,
+            primaryLevel,
+            primaryCol: x,
+            primaryRow: y,
+            primaryZ: z,
+            pool,
+            signal: combinedSignal,
+            device,
+          }),
+        );
+      }
+    }
+
+    const bandEntries = await Promise.all(bandPromises);
+    const bands = new Map(bandEntries);
+
+    return {
+      bands,
+      forwardTransform,
+      inverseTransform,
+      width: primaryLevel.tileWidth,
+      height: primaryLevel.tileHeight,
+    };
   }
+
+  /**
+   * Fetch a single tile for a source that shares the primary tile grid.
+   *
+   * @returns A `[name, BandTileData]` tuple with identity UV transform.
+   */
+  private async _fetchPrimaryBand(
+    name: string,
+    sourceState: SourceState,
+    opts: {
+      x: number;
+      y: number;
+      z: number;
+      pool: DecoderPool;
+      signal: AbortSignal | undefined;
+      device: Device;
+    },
+  ): Promise<[string, BandTileData]> {
+    const { x, y, z, pool, signal, device } = opts;
+    const image = selectImage(sourceState.geotiff, z);
+
+    const tile = await image.fetchTile(x, y, {
+      boundless: false,
+      pool,
+      signal,
+    });
+
+    const texture = createBandTexture(device, tile.array);
+
+    return [
+      name,
+      {
+        texture,
+        uvTransform: { offsetX: 0, offsetY: 0, scaleX: 1, scaleY: 1 },
+        width: tile.array.width,
+        height: tile.array.height,
+      },
+    ];
+  }
+
+  /**
+   * Fetch covering tiles for a secondary source and stitch them into a
+   * single texture using {@link assembleTiles}.
+   *
+   * @returns A `[name, BandTileData]` tuple with the computed UV transform.
+   */
+  private async _fetchSecondaryBand(
+    name: string,
+    sourceState: SourceState,
+    opts: {
+      descriptor: TilesetDescriptor;
+      primaryLevel: TilesetLevel;
+      primaryCol: number;
+      primaryRow: number;
+      primaryZ: number;
+      pool: DecoderPool;
+      signal: AbortSignal | undefined;
+      device: Device;
+    },
+  ): Promise<[string, BandTileData]> {
+    const {
+      descriptor,
+      primaryLevel,
+      primaryCol,
+      primaryRow,
+      primaryZ,
+      pool,
+      signal,
+      device,
+    } = opts;
+
+    // Select the best secondary level
+    const primaryMpp =
+      this.state.multiDescriptor!.primary.levels[primaryZ]!.metersPerPixel;
+    const secondaryLevel = selectSecondaryLevel(descriptor.levels, primaryMpp);
+    const secondaryZ = descriptor.levels.indexOf(secondaryLevel);
+
+    // Resolve covering tile indices and UV transform
+    const resolution = resolveSecondaryTiles(
+      primaryLevel,
+      primaryCol,
+      primaryRow,
+      secondaryLevel,
+      secondaryZ,
+    );
+
+    // Fetch all covering tiles via fetchTiles
+    const image = selectImage(sourceState.geotiff, secondaryZ);
+    const xy: Array<[number, number]> = resolution.tileIndices.map((idx) => [
+      idx.x,
+      idx.y,
+    ]);
+    const tiles = await image.fetchTiles(xy, {
+      boundless: false,
+      pool,
+      signal,
+    });
+
+    // Assemble into a single RasterArray (handles stitching + typed array preservation)
+    const assembled = assembleTiles(tiles, {
+      width: resolution.stitchedWidth,
+      height: resolution.stitchedHeight,
+      tileWidth: secondaryLevel.tileWidth,
+      tileHeight: secondaryLevel.tileHeight,
+      minCol: resolution.minCol,
+      minRow: resolution.minRow,
+    });
+
+    const texture = createBandTexture(device, assembled);
+
+    return [
+      name,
+      {
+        texture,
+        uvTransform: tupleToUvTransform(resolution.uvTransform),
+        width: assembled.width,
+        height: assembled.height,
+      },
+    ];
+  }
+
+  /**
+   * Create sub-layers for a single loaded tile.
+   *
+   * Builds a {@link RasterLayer} with reprojection functions and a render
+   * pipeline that starts with a {@link CompositeBands} module binding all
+   * band textures, followed by any user-provided pipeline modules.
+   */
+  _renderSubLayers(
+    props: TileLayerProps<MultiTileResult> & {
+      id: string;
+      data?: MultiTileResult;
+      _offset: number;
+      tile: Tile2DHeader<MultiTileResult>;
+    },
+    forwardTo4326: ReprojectionFns["forwardReproject"],
+    inverseFrom4326: ReprojectionFns["inverseReproject"],
+    forwardTo3857: ReprojectionFns["forwardReproject"],
+    inverseFrom3857: ReprojectionFns["inverseReproject"],
+  ): Layer | LayersList | null {
+    const { maxError } = this.props;
+
+    if (!props.data) {
+      return null;
+    }
+
+    const { bands, forwardTransform, inverseTransform, width, height } =
+      props.data;
+
+    // Build the composite bands mapping — default to first source for R if
+    // no composite mapping is provided
+    const composite = this.props.composite ?? {
+      r: [...bands.keys()][0]!,
+    };
+
+    // Create the CompositeBands shader module
+    const compositeBandsModule = createCompositeBandsModule(composite);
+
+    // Build props for the CompositeBands module: bind textures and UV transforms
+    const compositeBandsProps: Record<string, unknown> = {};
+    for (const [bandName, bandData] of bands) {
+      compositeBandsProps[`band_${bandName}`] = bandData.texture;
+      const uv = bandData.uvTransform;
+      compositeBandsProps[`uvTransform_${bandName}`] = [
+        uv.offsetX,
+        uv.offsetY,
+        uv.scaleX,
+        uv.scaleY,
+      ];
+    }
+
+    // Assemble the full render pipeline
+    // Cast required because CompositeBandsModule uses Record<string, unknown>
+    // for its getUniforms return type, while RasterModule expects
+    // ShaderModule<Record<string, number | Texture>>.
+    const renderPipeline: RasterModule[] = [
+      {
+        module: compositeBandsModule as RasterModule["module"],
+        props: compositeBandsProps as RasterModule["props"],
+      },
+      ...(this.props.renderPipeline ?? []),
+    ];
+
+    // Determine projection mode (globe vs web mercator)
+    const isGlobe = this.context.viewport.resolution !== undefined;
+    let reprojectionFns: ReprojectionFns;
+    let deckProjectionProps: Partial<LayerProps>;
+
+    if (isGlobe) {
+      reprojectionFns = {
+        forwardTransform,
+        inverseTransform,
+        forwardReproject: forwardTo4326,
+        inverseReproject: inverseFrom4326,
+      };
+      deckProjectionProps = {};
+    } else {
+      reprojectionFns = {
+        forwardTransform,
+        inverseTransform,
+        forwardReproject: forwardTo3857,
+        inverseReproject: inverseFrom3857,
+      };
+      deckProjectionProps = {
+        coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
+        coordinateOrigin: [TILE_SIZE / 2, TILE_SIZE / 2, 0],
+        // biome-ignore format: array
+        modelMatrix: [
+            WEB_MERCATOR_TO_WORLD_SCALE, 0, 0, 0,
+            0, WEB_MERCATOR_TO_WORLD_SCALE, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1
+          ],
+      };
+    }
+
+    const rasterLayer = new RasterLayer(
+      this.getSubLayerProps({
+        id: `${props.id}-raster`,
+        width,
+        height,
+        renderPipeline,
+        maxError,
+        reprojectionFns,
+        ...deckProjectionProps,
+      }),
+    );
+
+    return [rasterLayer];
+  }
+
+  /**
+   * Build the tile layer that drives tile traversal and rendering.
+   *
+   * Creates a {@link RasterTileset2D} factory from the primary tileset,
+   * then returns a {@link TileLayer} wired up with tile fetching and
+   * sub-layer rendering.
+   */
+  renderTileLayer(
+    multiDescriptor: MultiTilesetDescriptor,
+    forwardTo4326: ReprojectionFns["forwardReproject"],
+    inverseFrom4326: ReprojectionFns["inverseReproject"],
+    forwardTo3857: ReprojectionFns["forwardReproject"],
+    inverseFrom3857: ReprojectionFns["inverseReproject"],
+  ): TileLayer {
+    const { primary } = multiDescriptor;
+
+    // Create a factory class that wraps RasterTileset2D with the primary descriptor
+    class PrimaryTilesetFactory extends RasterTileset2D {
+      constructor(opts: Tileset2DProps) {
+        super(opts, primary, {
+          projectTo4326: forwardTo4326,
+        });
+      }
+    }
+
+    const {
+      maxRequests,
+      maxCacheSize,
+      maxCacheByteSize,
+      debounceTime,
+      refinementStrategy,
+    } = this.props;
+
+    return new TileLayer<MultiTileResult>({
+      id: `multi-cog-tile-layer-${this.id}`,
+      TilesetClass: PrimaryTilesetFactory,
+      getTileData: async (tile) => this._getTileData(tile),
+      renderSubLayers: (props) =>
+        this._renderSubLayers(
+          props,
+          forwardTo4326,
+          inverseFrom4326,
+          forwardTo3857,
+          inverseFrom3857,
+        ),
+      debounceTime,
+      maxCacheByteSize,
+      maxCacheSize,
+      maxRequests,
+      refinementStrategy,
+    });
+  }
+
+  override renderLayers(): Layer | LayersList | null {
+    const {
+      multiDescriptor,
+      forwardTo4326,
+      inverseFrom4326,
+      forwardTo3857,
+      inverseFrom3857,
+    } = this.state;
+
+    if (
+      !multiDescriptor ||
+      !forwardTo4326 ||
+      !inverseFrom4326 ||
+      !forwardTo3857 ||
+      !inverseFrom3857
+    ) {
+      return null;
+    }
+
+    return this.renderTileLayer(
+      multiDescriptor,
+      forwardTo4326,
+      inverseFrom4326,
+      forwardTo3857,
+      inverseFrom3857,
+    );
+  }
+}
+
+/**
+ * Select the correct GeoTIFF image (full-res or overview) for a zoom level.
+ *
+ * z=0 is the coarsest overview, z=max is full resolution.
+ */
+function selectImage(geotiff: GeoTIFF, z: number): GeoTIFF | Overview {
+  const images: Array<GeoTIFF | Overview> = [geotiff, ...geotiff.overviews];
+  return images[images.length - 1 - z]!;
+}
+
+/**
+ * Create a GPU texture from a {@link RasterArray}.
+ *
+ * Currently hardcoded to `r8unorm` for single-band uint8 data.
+ * TODO: infer texture format from the array's typed array type and band count.
+ */
+function createBandTexture(device: Device, array: RasterArray): Texture {
+  if (array.layout !== "pixel-interleaved") {
+    throw new Error("Band-separate layout not yet supported in MultiCOGLayer");
+  }
+
+  return device.createTexture({
+    data: array.data as Uint8Array,
+    format: "r8unorm",
+    width: array.width,
+    height: array.height,
+    sampler: { minFilter: "linear", magFilter: "linear" },
+  });
 }

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -50,7 +50,7 @@ import {
   parseWkt,
 } from "@developmentseed/proj";
 import type { ReprojectionFns } from "@developmentseed/raster-reproject";
-import type { Device, Texture } from "@luma.gl/core";
+import type { Device, Texture, TextureFormat } from "@luma.gl/core";
 import proj4 from "proj4";
 import { fetchGeoTIFF } from "./geotiff/geotiff.js";
 import { fromAffine } from "./geotiff-reprojection.js";
@@ -753,19 +753,35 @@ function selectImage(geotiff: GeoTIFF, z: number): GeoTIFF | Overview {
 /**
  * Create a GPU texture from a {@link RasterArray}.
  *
- * Currently hardcoded to `r8unorm` for single-band uint8 data.
- * TODO: infer texture format from the array's typed array type and band count.
+ * Infers the texture format from the typed array type. Currently supports
+ * single-band `Uint8Array` (`r8unorm`) and `Uint16Array` (`r16unorm`).
+ *
+ * TODO: use `inferTextureFormat` from `texture.ts` for full format support.
  */
 function createBandTexture(device: Device, array: RasterArray): Texture {
   if (array.layout !== "pixel-interleaved") {
     throw new Error("Band-separate layout not yet supported in MultiCOGLayer");
   }
 
+  const { data, width, height } = array;
+  let format: TextureFormat;
+
+  if (data instanceof Uint8Array || data instanceof Uint8ClampedArray) {
+    format = "r8unorm";
+  } else if (data instanceof Uint16Array) {
+    format = "r16unorm";
+  } else {
+    throw new Error(
+      `Unsupported typed array type: ${data.constructor.name}. ` +
+        "Currently only Uint8Array and Uint16Array are supported.",
+    );
+  }
+
   return device.createTexture({
-    data: array.data as Uint8Array,
-    format: "r8unorm",
-    width: array.width,
-    height: array.height,
+    data,
+    format,
+    width,
+    height,
     sampler: { minFilter: "linear", magFilter: "linear" },
   });
 }

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -14,14 +14,14 @@ import type {
 } from "@deck.gl/geo-layers";
 import { TileLayer } from "@deck.gl/geo-layers";
 import type {
-  CompositeBandsMapping,
   MultiTilesetDescriptor,
   RasterModule,
   TilesetDescriptor,
   TilesetLevel,
 } from "@developmentseed/deck.gl-raster";
 import {
-  createCompositeBandsModule,
+  buildCompositeBandsProps,
+  CompositeBands,
   createMultiTilesetDescriptor,
   RasterLayer,
   RasterTileset2D,
@@ -170,9 +170,9 @@ export type MultiCOGLayerProps = CompositeLayerProps &
     /**
      * Map source bands to RGB(A) output channels.
      *
-     * @see {@link CompositeBandsMapping}
+     * @see {@link buildCompositeBandsProps}
      */
-    composite?: CompositeBandsMapping;
+    composite?: { r: string; g?: string; b?: string; a?: string };
 
     /**
      * Post-processing render pipeline modules applied after compositing.
@@ -583,29 +583,24 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       r: [...bands.keys()][0]!,
     };
 
-    // Create the CompositeBands shader module
-    const compositeBandsModule = createCompositeBandsModule(composite);
-
-    // Build props for the CompositeBands module: bind textures and UV transforms
-    const compositeBandsProps: Record<string, unknown> = {};
-    for (const [bandName, bandData] of bands) {
-      compositeBandsProps[`band_${bandName}`] = bandData.texture;
-      const uv = bandData.uvTransform;
-      compositeBandsProps[`uvTransform_${bandName}`] = [
-        uv.offsetX,
-        uv.offsetY,
-        uv.scaleX,
-        uv.scaleY,
-      ];
+    // Skip rendering if cached tile data doesn't have the required bands
+    // (happens when switching presets — old tiles will be re-fetched)
+    const requiredBands = [
+      composite.r,
+      composite.g,
+      composite.b,
+      composite.a,
+    ].filter((n): n is string => n != null);
+    if (requiredBands.some((name) => !bands.has(name))) {
+      return null;
     }
 
-    // Assemble the full render pipeline
-    // Cast required because CompositeBandsModule uses Record<string, unknown>
-    // for its getUniforms return type, while RasterModule expects
-    // ShaderModule<Record<string, number | Texture>>.
+    // Map named bands to fixed slot indices and build module props
+    const compositeBandsProps = buildCompositeBandsProps(composite, bands);
+
     const renderPipeline: RasterModule[] = [
       {
-        module: compositeBandsModule as RasterModule["module"],
+        module: CompositeBands as RasterModule["module"],
         props: compositeBandsProps as RasterModule["props"],
       },
       ...(this.props.renderPipeline ?? []),
@@ -692,8 +687,16 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       refinementStrategy,
     } = this.props;
 
+    // Stringify sources to detect when the set of COG URLs changes.
+    // This triggers TileLayer to invalidate its cache and re-fetch.
+    const sourceKeys = Object.keys(this.props.sources).sort().join(",");
+    const sourceUrls = Object.values(this.props.sources)
+      .map((s) => String(s.url))
+      .sort()
+      .join(",");
+
     return new TileLayer<MultiTileResult>({
-      id: `multi-cog-tile-layer-${this.id}`,
+      id: `multi-cog-tile-layer-${this.id}-${sourceUrls}`,
       TilesetClass: PrimaryTilesetFactory,
       getTileData: async (tile) => this._getTileData(tile),
       renderSubLayers: (props) =>
@@ -704,6 +707,9 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
           forwardTo3857,
           inverseFrom3857,
         ),
+      updateTriggers: {
+        getTileData: [sourceKeys, sourceUrls],
+      },
       debounceTime,
       maxCacheByteSize,
       maxCacheSize,

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -20,8 +20,6 @@ import type {
   TilesetLevel,
 } from "@developmentseed/deck.gl-raster";
 import {
-  buildCompositeBandsProps,
-  CompositeBands,
   createMultiTilesetDescriptor,
   RasterLayer,
   RasterTileset2D,
@@ -30,6 +28,10 @@ import {
   TileMatrixSetAdaptor,
   tilesetLevelsEqual,
 } from "@developmentseed/deck.gl-raster";
+import {
+  buildCompositeBandsProps,
+  CompositeBands,
+} from "@developmentseed/deck.gl-raster/gpu-modules";
 import type {
   DecoderPool,
   GeoTIFF,

--- a/packages/deck.gl-raster/src/gpu-modules/composite-bands.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/composite-bands.ts
@@ -1,0 +1,116 @@
+import type { ShaderModule } from "@luma.gl/shadertools";
+
+/**
+ * Band mapping: which source band goes to which output channel.
+ * At least `r` is required; missing channels default to 0.0 (or 1.0 for alpha).
+ *
+ * @example
+ * ```ts
+ * const mapping: CompositeBandsMapping = { r: "red", g: "green", b: "blue" };
+ * ```
+ */
+export interface CompositeBandsMapping {
+  /** Source band name for the red channel. */
+  r: string;
+  /** Source band name for the green channel. If omitted, defaults to 0.0. */
+  g?: string;
+  /** Source band name for the blue channel. If omitted, defaults to 0.0. */
+  b?: string;
+  /** Source band name for the alpha channel. If omitted, defaults to 1.0. */
+  a?: string;
+}
+
+/**
+ * The concrete shape returned by {@link createCompositeBandsModule}.
+ *
+ * Narrows the `inject` record to plain strings so callers don't need casts.
+ */
+export interface CompositeBandsModule
+  extends Omit<ShaderModule, "inject" | "getUniforms"> {
+  inject: {
+    "fs:#decl": string;
+    "fs:DECKGL_FILTER_COLOR": string;
+  };
+  getUniforms: (props: Record<string, unknown>) => Record<string, unknown>;
+}
+
+/**
+ * Create a shader module that samples named band textures with UV transforms
+ * and outputs a vec4 color.
+ *
+ * Each band gets a `sampler2D band_<name>` and `vec4 uvTransform_<name>`
+ * uniform. The UV transform is applied before sampling so that textures at
+ * different resolutions are correctly aligned.
+ *
+ * The UV transform encodes `[offsetX, offsetY, scaleX, scaleY]`. The
+ * transform is applied as `uv * transform.zw + transform.xy`.
+ *
+ * @param mapping - Mapping from RGBA output channels to source band names.
+ * @returns A luma.gl {@link ShaderModule} ready to use with a deck.gl layer.
+ *
+ * @see {@link CompositeBandsMapping}
+ *
+ * @example
+ * ```ts
+ * const mod = createCompositeBandsModule({ r: "red", g: "green", b: "blue" });
+ * // Pass uniforms: band_red, uvTransform_red, band_green, uvTransform_green, …
+ * ```
+ */
+export function createCompositeBandsModule(
+  mapping: CompositeBandsMapping,
+): CompositeBandsModule {
+  const bands = new Set<string>();
+  if (mapping.r) bands.add(mapping.r);
+  if (mapping.g) bands.add(mapping.g);
+  if (mapping.b) bands.add(mapping.b);
+  if (mapping.a) bands.add(mapping.a);
+
+  const declarations = [...bands]
+    .map(
+      (name) =>
+        `uniform sampler2D band_${name};\nuniform vec4 uvTransform_${name};`,
+    )
+    .join("\n");
+
+  const uvHelper = `
+vec2 compositeBands_applyUv(vec2 uv, vec4 transform) {
+  return uv * transform.zw + transform.xy;
+}`;
+
+  /**
+   * Returns a GLSL expression that samples a single channel from the named
+   * band texture, or a constant literal when the channel is absent.
+   *
+   * @param channel - Band name, or `undefined` if the channel is not mapped.
+   * @param defaultVal - GLSL literal to use when the channel is absent.
+   */
+  function sampleExpr(channel: string | undefined, defaultVal: string): string {
+    if (!channel) return defaultVal;
+    return `texture(band_${channel}, compositeBands_applyUv(geometry.uv, uvTransform_${channel})).r`;
+  }
+
+  const filterColor = `
+  color = vec4(
+    ${sampleExpr(mapping.r, "0.0")},
+    ${sampleExpr(mapping.g, "0.0")},
+    ${sampleExpr(mapping.b, "0.0")},
+    ${sampleExpr(mapping.a, "1.0")}
+  );`;
+
+  return {
+    name: "composite-bands",
+    inject: {
+      "fs:#decl": `${declarations}\n${uvHelper}`,
+      "fs:DECKGL_FILTER_COLOR": filterColor,
+    },
+    getUniforms: (props: Record<string, unknown>) => {
+      const uniforms: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(props)) {
+        if (key.startsWith("band_") || key.startsWith("uvTransform_")) {
+          uniforms[key] = value;
+        }
+      }
+      return uniforms;
+    },
+  };
+}

--- a/packages/deck.gl-raster/src/gpu-modules/composite-bands.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/composite-bands.ts
@@ -1,116 +1,193 @@
+import type { Texture } from "@luma.gl/core";
 import type { ShaderModule } from "@luma.gl/shadertools";
 
 /**
- * Band mapping: which source band goes to which output channel.
- * At least `r` is required; missing channels default to 0.0 (or 1.0 for alpha).
- *
- * @example
- * ```ts
- * const mapping: CompositeBandsMapping = { r: "red", g: "green", b: "blue" };
- * ```
+ * Maximum number of band texture slots supported by {@link CompositeBands}.
  */
-export interface CompositeBandsMapping {
-  /** Source band name for the red channel. */
-  r: string;
-  /** Source band name for the green channel. If omitted, defaults to 0.0. */
-  g?: string;
-  /** Source band name for the blue channel. If omitted, defaults to 0.0. */
-  b?: string;
-  /** Source band name for the alpha channel. If omitted, defaults to 1.0. */
-  a?: string;
-}
+export const MAX_BAND_SLOTS = 4;
 
 /**
- * The concrete shape returned by {@link createCompositeBandsModule}.
+ * Props for the {@link CompositeBands} shader module.
  *
- * Narrows the `inject` record to plain strings so callers don't need casts.
+ * Textures (`band0`–`band3`) are bound via `getUniforms`. Scalar uniforms
+ * (`uvTransform0`–`uvTransform3`, `channelMap`) go through a uniform block.
  */
-export interface CompositeBandsModule
-  extends Omit<ShaderModule, "inject" | "getUniforms"> {
+export type CompositeBandsProps = {
+  band0: Texture;
+  band1: Texture;
+  band2: Texture;
+  band3: Texture;
+  uvTransform0: [number, number, number, number];
+  uvTransform1: [number, number, number, number];
+  uvTransform2: [number, number, number, number];
+  uvTransform3: [number, number, number, number];
+  channelMap: [number, number, number, number];
+};
+
+const MODULE_NAME = "compositeBands";
+
+/**
+ * A shader module that samples up to 4 band textures with per-band UV
+ * transforms and composites them into a `vec4` color.
+ *
+ * Uses fixed uniform slots (`band0`–`band3`) for textures (bound via
+ * `getUniforms`) and a uniform block for scalar values (`uvTransform0`–
+ * `uvTransform3`, `channelMap`).
+ *
+ * @see {@link CompositeBandsProps}
+ * @see {@link buildCompositeBandsProps} for a helper that maps named bands
+ *   to slot indices.
+ */
+export const CompositeBands = {
+  name: MODULE_NAME,
+  // Texture samplers — declared via inject, bound via getUniforms
   inject: {
-    "fs:#decl": string;
-    "fs:DECKGL_FILTER_COLOR": string;
-  };
-  getUniforms: (props: Record<string, unknown>) => Record<string, unknown>;
-}
+    "fs:#decl": /* glsl */ `
+uniform sampler2D band0;
+uniform sampler2D band1;
+uniform sampler2D band2;
+uniform sampler2D band3;
 
-/**
- * Create a shader module that samples named band textures with UV transforms
- * and outputs a vec4 color.
- *
- * Each band gets a `sampler2D band_<name>` and `vec4 uvTransform_<name>`
- * uniform. The UV transform is applied before sampling so that textures at
- * different resolutions are correctly aligned.
- *
- * The UV transform encodes `[offsetX, offsetY, scaleX, scaleY]`. The
- * transform is applied as `uv * transform.zw + transform.xy`.
- *
- * @param mapping - Mapping from RGBA output channels to source band names.
- * @returns A luma.gl {@link ShaderModule} ready to use with a deck.gl layer.
- *
- * @see {@link CompositeBandsMapping}
- *
- * @example
- * ```ts
- * const mod = createCompositeBandsModule({ r: "red", g: "green", b: "blue" });
- * // Pass uniforms: band_red, uvTransform_red, band_green, uvTransform_green, …
- * ```
- */
-export function createCompositeBandsModule(
-  mapping: CompositeBandsMapping,
-): CompositeBandsModule {
-  const bands = new Set<string>();
-  if (mapping.r) bands.add(mapping.r);
-  if (mapping.g) bands.add(mapping.g);
-  if (mapping.b) bands.add(mapping.b);
-  if (mapping.a) bands.add(mapping.a);
-
-  const declarations = [...bands]
-    .map(
-      (name) =>
-        `uniform sampler2D band_${name};\nuniform vec4 uvTransform_${name};`,
-    )
-    .join("\n");
-
-  const uvHelper = `
 vec2 compositeBands_applyUv(vec2 uv, vec4 transform) {
   return uv * transform.zw + transform.xy;
-}`;
+}
 
-  /**
-   * Returns a GLSL expression that samples a single channel from the named
-   * band texture, or a constant literal when the channel is absent.
-   *
-   * @param channel - Band name, or `undefined` if the channel is not mapped.
-   * @param defaultVal - GLSL literal to use when the channel is absent.
-   */
-  function sampleExpr(channel: string | undefined, defaultVal: string): string {
-    if (!channel) return defaultVal;
-    return `texture(band_${channel}, compositeBands_applyUv(geometry.uv, uvTransform_${channel})).r`;
+float compositeBands_sampleSlot(int slot, vec2 uv) {
+  if (slot == 0) return texture(band0, compositeBands_applyUv(uv, ${MODULE_NAME}.uvTransform0)).r;
+  if (slot == 1) return texture(band1, compositeBands_applyUv(uv, ${MODULE_NAME}.uvTransform1)).r;
+  if (slot == 2) return texture(band2, compositeBands_applyUv(uv, ${MODULE_NAME}.uvTransform2)).r;
+  if (slot == 3) return texture(band3, compositeBands_applyUv(uv, ${MODULE_NAME}.uvTransform3)).r;
+  return 0.0;
+}
+`,
+    "fs:DECKGL_FILTER_COLOR": /* glsl */ `
+  float r = ${MODULE_NAME}.channelMap.r >= 0 ? compositeBands_sampleSlot(${MODULE_NAME}.channelMap.r, geometry.uv) : 0.0;
+  float g = ${MODULE_NAME}.channelMap.g >= 0 ? compositeBands_sampleSlot(${MODULE_NAME}.channelMap.g, geometry.uv) : 0.0;
+  float b = ${MODULE_NAME}.channelMap.b >= 0 ? compositeBands_sampleSlot(${MODULE_NAME}.channelMap.b, geometry.uv) : 0.0;
+  float a = ${MODULE_NAME}.channelMap.a >= 0 ? compositeBands_sampleSlot(${MODULE_NAME}.channelMap.a, geometry.uv) : 1.0;
+  color = vec4(r, g, b, a);
+`,
+  },
+  // Scalar uniforms — declared via fs uniform block + uniformTypes
+  fs: `\
+uniform ${MODULE_NAME}Uniforms {
+  vec4 uvTransform0;
+  vec4 uvTransform1;
+  vec4 uvTransform2;
+  vec4 uvTransform3;
+  ivec4 channelMap;
+} ${MODULE_NAME};
+`,
+  uniformTypes: {
+    uvTransform0: "vec4<f32>",
+    uvTransform1: "vec4<f32>",
+    uvTransform2: "vec4<f32>",
+    uvTransform3: "vec4<f32>",
+    channelMap: "vec4<i32>",
+  },
+  getUniforms: (props: Partial<CompositeBandsProps>) => {
+    return {
+      // Texture bindings
+      band0: props.band0,
+      band1: props.band1,
+      band2: props.band2,
+      band3: props.band3,
+      // Scalar uniforms (uniform block)
+      uvTransform0: props.uvTransform0 ?? [0, 0, 1, 1],
+      uvTransform1: props.uvTransform1 ?? [0, 0, 1, 1],
+      uvTransform2: props.uvTransform2 ?? [0, 0, 1, 1],
+      uvTransform3: props.uvTransform3 ?? [0, 0, 1, 1],
+      channelMap: props.channelMap ?? [0, 1, 2, -1],
+    };
+  },
+} as const satisfies ShaderModule<CompositeBandsProps>;
+
+/**
+ * Maps named bands and their UV transforms to {@link CompositeBandsProps}
+ * slot indices.
+ *
+ * Assigns each unique band name to a fixed slot (0–3), builds the
+ * `channelMap` that maps RGBA output channels to slots, and fills unused
+ * slots with a placeholder texture to satisfy WebGL binding requirements.
+ *
+ * @param mapping - Which named band goes to which RGBA channel.
+ * @param bands - Map of band name to texture + UV transform.
+ * @returns Props ready to pass to `{ module: CompositeBands, props: ... }`.
+ *
+ * @see {@link CompositeBands}
+ */
+export function buildCompositeBandsProps(
+  mapping: { r: string; g?: string; b?: string; a?: string },
+  bands: Map<
+    string,
+    {
+      texture: Texture;
+      uvTransform: {
+        offsetX: number;
+        offsetY: number;
+        scaleX: number;
+        scaleY: number;
+      };
+    }
+  >,
+): Partial<CompositeBandsProps> {
+  // Collect unique band names in mapping order and assign slot indices
+  const slotNames: string[] = [];
+  const slotIndex = new Map<string, number>();
+
+  for (const name of [mapping.r, mapping.g, mapping.b, mapping.a]) {
+    if (name && !slotIndex.has(name)) {
+      if (slotNames.length >= MAX_BAND_SLOTS) {
+        throw new Error(
+          `CompositeBands supports at most ${MAX_BAND_SLOTS} band slots`,
+        );
+      }
+      slotIndex.set(name, slotNames.length);
+      slotNames.push(name);
+    }
   }
 
-  const filterColor = `
-  color = vec4(
-    ${sampleExpr(mapping.r, "0.0")},
-    ${sampleExpr(mapping.g, "0.0")},
-    ${sampleExpr(mapping.b, "0.0")},
-    ${sampleExpr(mapping.a, "1.0")}
-  );`;
+  function slotFor(name: string | undefined): number {
+    return name ? (slotIndex.get(name) ?? -1) : -1;
+  }
 
-  return {
-    name: "composite-bands",
-    inject: {
-      "fs:#decl": `${declarations}\n${uvHelper}`,
-      "fs:DECKGL_FILTER_COLOR": filterColor,
-    },
-    getUniforms: (props: Record<string, unknown>) => {
-      const uniforms: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(props)) {
-        if (key.startsWith("band_") || key.startsWith("uvTransform_")) {
-          uniforms[key] = value;
-        }
-      }
-      return uniforms;
-    },
+  const props: Record<string, unknown> = {
+    channelMap: [
+      slotFor(mapping.r),
+      slotFor(mapping.g),
+      slotFor(mapping.b),
+      slotFor(mapping.a),
+    ],
   };
+
+  // Get the first texture to use as a placeholder for unused slots.
+  // WebGL requires all declared samplers to have a valid texture bound,
+  // even if the channelMap never references them.
+  const firstBandName = slotNames[0];
+  if (!firstBandName) {
+    throw new Error("At least one band is required");
+  }
+  const firstTexture = bands.get(firstBandName)!.texture;
+
+  for (const [name, slot] of slotIndex) {
+    const band = bands.get(name);
+    if (!band) {
+      throw new Error(`Band "${name}" not found in fetched bands`);
+    }
+    const uv = band.uvTransform;
+    props[`band${slot}`] = band.texture;
+    props[`uvTransform${slot}`] = [
+      uv.offsetX,
+      uv.offsetY,
+      uv.scaleX,
+      uv.scaleY,
+    ];
+  }
+
+  // Fill unused slots with the first texture as a placeholder
+  for (let i = slotNames.length; i < MAX_BAND_SLOTS; i++) {
+    props[`band${i}`] = firstTexture;
+  }
+
+  return props as Partial<CompositeBandsProps>;
 }

--- a/packages/deck.gl-raster/src/gpu-modules/index.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/index.ts
@@ -6,12 +6,14 @@ export {
   YCbCrToRGB,
 } from "./color";
 export { Colormap } from "./colormap";
-export type {
-  CompositeBandsMapping,
-  CompositeBandsModule,
+export type { CompositeBandsProps } from "./composite-bands.js";
+export {
+  buildCompositeBandsProps,
+  CompositeBands,
 } from "./composite-bands.js";
-export { createCompositeBandsModule } from "./composite-bands.js";
 export { CreateTexture } from "./create-texture";
 export { FilterNoDataVal } from "./filter-nodata";
+export type { LinearRescaleProps } from "./linear-rescale.js";
+export { LinearRescale } from "./linear-rescale.js";
 export { MaskTexture } from "./mask-texture";
 export type { RasterModule } from "./types";

--- a/packages/deck.gl-raster/src/gpu-modules/index.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/index.ts
@@ -6,6 +6,11 @@ export {
   YCbCrToRGB,
 } from "./color";
 export { Colormap } from "./colormap";
+export type {
+  CompositeBandsMapping,
+  CompositeBandsModule,
+} from "./composite-bands.js";
+export { createCompositeBandsModule } from "./composite-bands.js";
 export { CreateTexture } from "./create-texture";
 export { FilterNoDataVal } from "./filter-nodata";
 export { MaskTexture } from "./mask-texture";

--- a/packages/deck.gl-raster/src/gpu-modules/linear-rescale.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/linear-rescale.ts
@@ -1,0 +1,52 @@
+import type { ShaderModule } from "@luma.gl/shadertools";
+
+/**
+ * Props for the {@link LinearRescale} shader module.
+ */
+export type LinearRescaleProps = {
+  /** Minimum input value (maps to 0.0 in output). */
+  rescaleMin: number;
+  /** Maximum input value (maps to 1.0 in output). */
+  rescaleMax: number;
+};
+
+const MODULE_NAME = "linearRescale";
+
+/**
+ * A shader module that linearly rescales RGB color values from
+ * `[min, max]` to `[0, 1]`, clamping values outside the range.
+ *
+ * Useful for normalizing data like Sentinel-2 reflectance (0-10000 stored
+ * as uint16) into a visible range after `r16unorm` normalization maps
+ * them to approximately 0.0-0.15.
+ *
+ * @example
+ * ```ts
+ * // Sentinel-2 L2A: reflectance 0-10000 → r16unorm 0.0-0.153
+ * { module: LinearRescale, props: { rescaleMin: 0, rescaleMax: 0.15 } }
+ * ```
+ */
+export const LinearRescale = {
+  name: MODULE_NAME,
+  fs: `\
+uniform ${MODULE_NAME}Uniforms {
+  float rescaleMin;
+  float rescaleMax;
+} ${MODULE_NAME};
+`,
+  inject: {
+    "fs:DECKGL_FILTER_COLOR": /* glsl */ `
+  color.rgb = clamp((color.rgb - ${MODULE_NAME}.rescaleMin) / (${MODULE_NAME}.rescaleMax - ${MODULE_NAME}.rescaleMin), 0.0, 1.0);
+`,
+  },
+  uniformTypes: {
+    rescaleMin: "f32",
+    rescaleMax: "f32",
+  },
+  getUniforms: (props: Partial<LinearRescaleProps>) => {
+    return {
+      rescaleMin: props.rescaleMin ?? 0.0,
+      rescaleMax: props.rescaleMax ?? 1.0,
+    };
+  },
+} as const satisfies ShaderModule<LinearRescaleProps>;

--- a/packages/deck.gl-raster/src/gpu-modules/types.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/types.ts
@@ -1,10 +1,19 @@
 import type { Texture } from "@luma.gl/core";
 import type { ShaderModule } from "@luma.gl/shadertools";
 
+/**
+ * Allowed prop value types for shader modules: scalars, typed tuples
+ * (matching luma.gl's internal `UniformValue`), or texture bindings.
+ */
+type RasterModulePropValue = number | boolean | readonly number[] | Texture;
+
+/**
+ * A shader module paired with its props, forming one step in a render pipeline.
+ */
 export type RasterModule<
-  PropsT extends Record<string, number | Texture> = Record<
+  PropsT extends Record<string, RasterModulePropValue> = Record<
     string,
-    number | Texture
+    RasterModulePropValue
   >,
 > = {
   module: ShaderModule<PropsT>;

--- a/packages/deck.gl-raster/src/index.ts
+++ b/packages/deck.gl-raster/src/index.ts
@@ -1,12 +1,3 @@
-export type {
-  CompositeBandsProps,
-  LinearRescaleProps,
-} from "./gpu-modules/index.js";
-export {
-  buildCompositeBandsProps,
-  CompositeBands,
-  LinearRescale,
-} from "./gpu-modules/index.js";
 export type { RasterModule } from "./gpu-modules/types.js";
 // Not a public API; exported for use in COGLayer and ZarrLayer
 export { renderDebugTileOutline as _renderDebugTileOutline } from "./layer-utils.js";

--- a/packages/deck.gl-raster/src/index.ts
+++ b/packages/deck.gl-raster/src/index.ts
@@ -1,3 +1,8 @@
+export type {
+  CompositeBandsMapping,
+  CompositeBandsModule,
+} from "./gpu-modules/index.js";
+export { createCompositeBandsModule } from "./gpu-modules/index.js";
 export type { RasterModule } from "./gpu-modules/types.js";
 // Not a public API; exported for use in COGLayer and ZarrLayer
 export { renderDebugTileOutline as _renderDebugTileOutline } from "./layer-utils.js";

--- a/packages/deck.gl-raster/src/index.ts
+++ b/packages/deck.gl-raster/src/index.ts
@@ -1,6 +1,12 @@
 export type { RasterModule } from "./gpu-modules/types.js";
 // Not a public API; exported for use in COGLayer and ZarrLayer
 export { renderDebugTileOutline as _renderDebugTileOutline } from "./layer-utils.js";
+export type { MultiTilesetDescriptor } from "./multi-raster-tileset/index.js";
+export {
+  createMultiTilesetDescriptor,
+  selectSecondaryLevel,
+  tilesetLevelsEqual,
+} from "./multi-raster-tileset/index.js";
 export type { RasterLayerProps, RenderTileResult } from "./raster-layer.js";
 export { RasterLayer } from "./raster-layer.js";
 export type {

--- a/packages/deck.gl-raster/src/index.ts
+++ b/packages/deck.gl-raster/src/index.ts
@@ -1,9 +1,14 @@
 export type { RasterModule } from "./gpu-modules/types.js";
 // Not a public API; exported for use in COGLayer and ZarrLayer
 export { renderDebugTileOutline as _renderDebugTileOutline } from "./layer-utils.js";
-export type { MultiTilesetDescriptor } from "./multi-raster-tileset/index.js";
+export type {
+  MultiTilesetDescriptor,
+  SecondaryTileIndex,
+  SecondaryTileResolution,
+} from "./multi-raster-tileset/index.js";
 export {
   createMultiTilesetDescriptor,
+  resolveSecondaryTiles,
   selectSecondaryLevel,
   tilesetLevelsEqual,
 } from "./multi-raster-tileset/index.js";

--- a/packages/deck.gl-raster/src/index.ts
+++ b/packages/deck.gl-raster/src/index.ts
@@ -1,8 +1,12 @@
 export type {
-  CompositeBandsMapping,
-  CompositeBandsModule,
+  CompositeBandsProps,
+  LinearRescaleProps,
 } from "./gpu-modules/index.js";
-export { createCompositeBandsModule } from "./gpu-modules/index.js";
+export {
+  buildCompositeBandsProps,
+  CompositeBands,
+  LinearRescale,
+} from "./gpu-modules/index.js";
 export type { RasterModule } from "./gpu-modules/types.js";
 // Not a public API; exported for use in COGLayer and ZarrLayer
 export { renderDebugTileOutline as _renderDebugTileOutline } from "./layer-utils.js";

--- a/packages/deck.gl-raster/src/multi-raster-tileset/index.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/index.ts
@@ -7,3 +7,8 @@ export {
   selectSecondaryLevel,
   tilesetLevelsEqual,
 } from "./multi-tileset-descriptor.js";
+export type {
+  SecondaryTileIndex,
+  SecondaryTileResolution,
+} from "./secondary-tile-resolver.js";
+export { resolveSecondaryTiles } from "./secondary-tile-resolver.js";

--- a/packages/deck.gl-raster/src/multi-raster-tileset/index.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/index.ts
@@ -1,0 +1,6 @@
+export type { MultiTilesetDescriptor } from "./multi-tileset-descriptor.js";
+export {
+  createMultiTilesetDescriptor,
+  selectSecondaryLevel,
+  tilesetLevelsEqual,
+} from "./multi-tileset-descriptor.js";

--- a/packages/deck.gl-raster/src/multi-raster-tileset/index.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/index.ts
@@ -1,4 +1,7 @@
-export type { MultiTilesetDescriptor } from "./multi-tileset-descriptor.js";
+export type {
+  MultiTilesetDescriptor,
+  SecondaryLevelStrategy,
+} from "./multi-tileset-descriptor.js";
 export {
   createMultiTilesetDescriptor,
   selectSecondaryLevel,

--- a/packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts
@@ -72,23 +72,52 @@ export function createMultiTilesetDescriptor(
 }
 
 /**
+ * Strategy for selecting a secondary tileset level.
+ *
+ * - `"closest"` — Pick the level whose `metersPerPixel` is nearest to the
+ *   primary's, in either direction. Minimizes wasted bandwidth but may return
+ *   a slightly coarser level than necessary.
+ * - `"closest-finer"` — Prefer the finest level whose `metersPerPixel` is
+ *   <= the primary's. Falls back to the finest available if all levels are
+ *   coarser. Ensures the secondary is never blurrier than necessary when a
+ *   finer option exists.
+ */
+export type SecondaryLevelStrategy = "closest" | "closest-finer";
+
+/**
  * Select the best {@link TilesetLevel} from a secondary tileset for a given
  * primary {@link TilesetLevel.metersPerPixel}.
- *
- * Picks the level whose `metersPerPixel` is closest to the primary's,
- * avoiding both over-fetching (using too-fine a level) and under-fetching
- * (using too-coarse a level).
  *
  * @param levels - Ordered coarsest-first (index 0 = coarsest), matching
  *   {@link TilesetDescriptor.levels} convention
  * @param primaryMetersPerPixel - The `metersPerPixel` of the current primary
  *   tile's zoom level
- * @returns The level with the closest `metersPerPixel` to the primary
+ * @param strategy - Selection strategy. Defaults to `"closest-finer"`.
+ * @returns The selected {@link TilesetLevel}
+ *
+ * @see {@link SecondaryLevelStrategy} for available strategies
  */
 export function selectSecondaryLevel(
   levels: TilesetLevel[],
   primaryMetersPerPixel: number,
+  strategy: SecondaryLevelStrategy = "closest-finer",
 ): TilesetLevel {
+  if (strategy === "closest-finer") {
+    // Among levels that are finer-or-equal to the primary, pick the closest
+    // (coarsest of the finer-or-equal set). Walk from coarsest to finest,
+    // tracking the last level that's <= primary.
+    let bestFiner: TilesetLevel | null = null;
+    for (let i = 0; i < levels.length; i++) {
+      if (levels[i]!.metersPerPixel <= primaryMetersPerPixel) {
+        bestFiner = levels[i]!;
+        break;
+      }
+    }
+    // If found, return it; otherwise fall back to the finest available
+    return bestFiner ?? levels[levels.length - 1]!;
+  }
+
+  // "closest" — pick the level with the smallest absolute difference
   let best = levels[0]!;
   let bestDiff = Math.abs(best.metersPerPixel - primaryMetersPerPixel);
   for (let i = 1; i < levels.length; i++) {

--- a/packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts
@@ -1,0 +1,72 @@
+import type {
+  TilesetDescriptor,
+  TilesetLevel,
+} from "../raster-tileset/tileset-interface.js";
+import type { Bounds, ProjectionFunction } from "../raster-tileset/types.js";
+
+export interface MultiTilesetDescriptor {
+  primary: TilesetDescriptor;
+  primaryKey: string;
+  secondaries: Map<string, TilesetDescriptor>;
+  bounds: Bounds;
+  projectTo3857: ProjectionFunction;
+  projectTo4326: ProjectionFunction;
+}
+
+export function createMultiTilesetDescriptor(
+  tilesets: Map<string, TilesetDescriptor>,
+): MultiTilesetDescriptor {
+  if (tilesets.size === 0) {
+    throw new Error("At least one tileset is required");
+  }
+  let primaryKey: string | null = null;
+  let finestMpp = Number.POSITIVE_INFINITY;
+  for (const [key, descriptor] of tilesets) {
+    const finestLevel = descriptor.levels[descriptor.levels.length - 1];
+    if (finestLevel && finestLevel.metersPerPixel < finestMpp) {
+      finestMpp = finestLevel.metersPerPixel;
+      primaryKey = key;
+    }
+  }
+  const primary = tilesets.get(primaryKey!)!;
+  const secondaries = new Map<string, TilesetDescriptor>();
+  for (const [key, descriptor] of tilesets) {
+    if (key !== primaryKey) {
+      secondaries.set(key, descriptor);
+    }
+  }
+  return {
+    primary,
+    primaryKey: primaryKey!,
+    secondaries,
+    bounds: primary.projectedBounds,
+    projectTo3857: primary.projectTo3857,
+    projectTo4326: primary.projectTo4326,
+  };
+}
+
+export function selectSecondaryLevel(
+  levels: TilesetLevel[],
+  primaryMetersPerPixel: number,
+): TilesetLevel {
+  let best = levels[0]!;
+  let bestDiff = Math.abs(best.metersPerPixel - primaryMetersPerPixel);
+  for (let i = 1; i < levels.length; i++) {
+    const diff = Math.abs(levels[i]!.metersPerPixel - primaryMetersPerPixel);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = levels[i]!;
+    }
+  }
+  return best;
+}
+
+export function tilesetLevelsEqual(a: TilesetLevel, b: TilesetLevel): boolean {
+  return (
+    a.matrixWidth === b.matrixWidth &&
+    a.matrixHeight === b.matrixHeight &&
+    a.tileWidth === b.tileWidth &&
+    a.tileHeight === b.tileHeight &&
+    a.metersPerPixel === b.metersPerPixel
+  );
+}

--- a/packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts
@@ -4,15 +4,41 @@ import type {
 } from "../raster-tileset/tileset-interface.js";
 import type { Bounds, ProjectionFunction } from "../raster-tileset/types.js";
 
+/**
+ * Groups N {@link TilesetDescriptor}s representing the same geographic extent
+ * at different native resolutions.
+ *
+ * The {@link primary} tileset (finest resolution) drives tile traversal;
+ * {@link secondaries} are consulted at fetch time to resolve covering tiles
+ * and compute UV transforms.
+ *
+ * @see {@link createMultiTilesetDescriptor} to construct from a named map of tilesets
+ */
 export interface MultiTilesetDescriptor {
+  /** Highest-resolution tileset — drives tile traversal. */
   primary: TilesetDescriptor;
+  /** The key under which the primary was provided to {@link createMultiTilesetDescriptor}. */
   primaryKey: string;
+  /** Lower-resolution tilesets, keyed by user-defined name. */
   secondaries: Map<string, TilesetDescriptor>;
+  /** Shared CRS bounds (from primary's {@link TilesetDescriptor.projectedBounds}). */
   bounds: Bounds;
+  /** Shared projection: source CRS -> EPSG:3857. */
   projectTo3857: ProjectionFunction;
+  /** Shared projection: source CRS -> EPSG:4326. */
   projectTo4326: ProjectionFunction;
 }
 
+/**
+ * Create a {@link MultiTilesetDescriptor} from a map of named tilesets.
+ *
+ * Automatically selects the tileset with the finest
+ * {@link TilesetLevel.metersPerPixel} at its highest-resolution level as the
+ * primary. All others become secondaries.
+ *
+ * @param tilesets - Named tilesets, e.g. `new Map([["B04", band10m], ["B11", band20m]])`
+ * @throws If `tilesets` is empty
+ */
 export function createMultiTilesetDescriptor(
   tilesets: Map<string, TilesetDescriptor>,
 ): MultiTilesetDescriptor {
@@ -45,6 +71,20 @@ export function createMultiTilesetDescriptor(
   };
 }
 
+/**
+ * Select the best {@link TilesetLevel} from a secondary tileset for a given
+ * primary {@link TilesetLevel.metersPerPixel}.
+ *
+ * Picks the level whose `metersPerPixel` is closest to the primary's,
+ * avoiding both over-fetching (using too-fine a level) and under-fetching
+ * (using too-coarse a level).
+ *
+ * @param levels - Ordered coarsest-first (index 0 = coarsest), matching
+ *   {@link TilesetDescriptor.levels} convention
+ * @param primaryMetersPerPixel - The `metersPerPixel` of the current primary
+ *   tile's zoom level
+ * @returns The level with the closest `metersPerPixel` to the primary
+ */
 export function selectSecondaryLevel(
   levels: TilesetLevel[],
   primaryMetersPerPixel: number,
@@ -61,6 +101,16 @@ export function selectSecondaryLevel(
   return best;
 }
 
+/**
+ * Check if two {@link TilesetLevel}s have the same grid parameters.
+ *
+ * Used to detect when sources share a tile grid and can skip UV transform
+ * computation (e.g., all 10m Sentinel-2 bands share the same grid).
+ *
+ * Compares {@link TilesetLevel.matrixWidth}, {@link TilesetLevel.matrixHeight},
+ * {@link TilesetLevel.tileWidth}, {@link TilesetLevel.tileHeight}, and
+ * {@link TilesetLevel.metersPerPixel}.
+ */
 export function tilesetLevelsEqual(a: TilesetLevel, b: TilesetLevel): boolean {
   return (
     a.matrixWidth === b.matrixWidth &&

--- a/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
@@ -1,0 +1,204 @@
+import type { TilesetLevel } from "../raster-tileset/tileset-interface.js";
+
+/**
+ * A tile index in a secondary tileset.
+ *
+ * @see {@link SecondaryTileResolution}
+ */
+export interface SecondaryTileIndex {
+  /** Column index of the secondary tile. */
+  col: number;
+  /** Row index of the secondary tile. */
+  row: number;
+}
+
+/**
+ * Result of resolving secondary tiles for a primary tile.
+ *
+ * @see {@link resolveSecondaryTiles}
+ */
+export interface SecondaryTileResolution {
+  /**
+   * The secondary tile indices that cover the primary tile's extent.
+   *
+   * When the primary tile falls within a single secondary tile, this array
+   * has one element. When the primary tile straddles a boundary, it may
+   * contain multiple entries that must be stitched together.
+   */
+  tileIndices: SecondaryTileIndex[];
+
+  /**
+   * UV transform: `[offsetX, offsetY, scaleX, scaleY]`.
+   *
+   * Maps from the primary tile's UV space [0,1]^2 to the correct sub-region
+   * of the stitched secondary texture.
+   *
+   * Usage in shader: `sampledUV = uv * scale + offset`
+   *
+   * - `offsetX`, `offsetY`: top-left corner of the primary tile's footprint
+   *   within the stitched texture, in UV units.
+   * - `scaleX`, `scaleY`: fraction of the stitched texture covered by the
+   *   primary tile.
+   */
+  uvTransform: [number, number, number, number];
+
+  /**
+   * The total stitched texture width in pixels.
+   *
+   * Equals `(maxCol - minCol + 1) * secondaryLevel.tileWidth`.
+   */
+  stitchedWidth: number;
+
+  /**
+   * The total stitched texture height in pixels.
+   *
+   * Equals `(maxRow - minRow + 1) * secondaryLevel.tileHeight`.
+   */
+  stitchedHeight: number;
+
+  /**
+   * The minimum column index of the secondary tile range.
+   *
+   * Used when stitching: tells you where each fetched tile goes in the
+   * stitched buffer (tile at column `col` starts at pixel
+   * `(col - minCol) * tileWidth`).
+   */
+  minCol: number;
+
+  /**
+   * The minimum row index of the secondary tile range.
+   *
+   * Used when stitching: tells you where each fetched tile goes in the
+   * stitched buffer (tile at row `row` starts at pixel
+   * `(row - minRow) * tileHeight`).
+   */
+  minRow: number;
+}
+
+/**
+ * Resolve which secondary tiles cover a primary tile's extent, and compute
+ * the UV transform to map from primary UV space into the stitched secondary
+ * texture.
+ *
+ * The UV transform `[offsetX, offsetY, scaleX, scaleY]` is intended for use
+ * in a shader as `sampledUV = uv * scale + offset`, where `uv` is the
+ * primary tile's local UV coordinate in [0,1]^2.
+ *
+ * The Y axis follows a top-left convention: origin is at the top-left corner,
+ * Y increases downward in texture/UV space. CRS coordinates may increase
+ * upward (north), so `offsetY` is computed as
+ * `(stitchedMaxY - primaryMaxY) / stitchedCrsHeight` to account for the flip.
+ *
+ * @param primaryLevel - The {@link TilesetLevel} describing the primary tileset.
+ * @param primaryCol - Column index of the primary tile.
+ * @param primaryRow - Row index of the primary tile.
+ * @param secondaryLevel - The {@link TilesetLevel} describing the secondary tileset.
+ * @returns A {@link SecondaryTileResolution} with tile indices, UV transform,
+ *   stitched dimensions, and the min col/row of the covered range.
+ */
+export function resolveSecondaryTiles(
+  primaryLevel: TilesetLevel,
+  primaryCol: number,
+  primaryRow: number,
+  secondaryLevel: TilesetLevel,
+): SecondaryTileResolution {
+  // Step 1: Get the CRS extent of the primary tile
+  const corners = primaryLevel.projectedTileCorners(primaryCol, primaryRow);
+  const primaryMinX = Math.min(
+    corners.topLeft[0],
+    corners.bottomLeft[0],
+    corners.topRight[0],
+    corners.bottomRight[0],
+  );
+  const primaryMaxX = Math.max(
+    corners.topLeft[0],
+    corners.bottomLeft[0],
+    corners.topRight[0],
+    corners.bottomRight[0],
+  );
+  const primaryMinY = Math.min(
+    corners.topLeft[1],
+    corners.bottomLeft[1],
+    corners.topRight[1],
+    corners.bottomRight[1],
+  );
+  const primaryMaxY = Math.max(
+    corners.topLeft[1],
+    corners.bottomLeft[1],
+    corners.topRight[1],
+    corners.bottomRight[1],
+  );
+
+  // Step 2: Find covering secondary tiles
+  const range = secondaryLevel.crsBoundsToTileRange(
+    primaryMinX,
+    primaryMinY,
+    primaryMaxX,
+    primaryMaxY,
+  );
+  const tileIndices: SecondaryTileIndex[] = [];
+  for (let row = range.minRow; row <= range.maxRow; row++) {
+    for (let col = range.minCol; col <= range.maxCol; col++) {
+      tileIndices.push({ col, row });
+    }
+  }
+
+  // Step 3: Compute the CRS extent of the stitched secondary region
+  const minCorners = secondaryLevel.projectedTileCorners(
+    range.minCol,
+    range.minRow,
+  );
+  const maxCorners = secondaryLevel.projectedTileCorners(
+    range.maxCol,
+    range.maxRow,
+  );
+  const allCornerPoints = [
+    minCorners.topLeft,
+    minCorners.topRight,
+    minCorners.bottomLeft,
+    minCorners.bottomRight,
+    maxCorners.topLeft,
+    maxCorners.topRight,
+    maxCorners.bottomLeft,
+    maxCorners.bottomRight,
+  ];
+  const stitchedMinX = Math.min(...allCornerPoints.map((p) => p[0]));
+  const stitchedMaxX = Math.max(...allCornerPoints.map((p) => p[0]));
+  const stitchedMinY = Math.min(...allCornerPoints.map((p) => p[1]));
+  const stitchedMaxY = Math.max(...allCornerPoints.map((p) => p[1]));
+
+  const stitchedCrsWidth = stitchedMaxX - stitchedMinX;
+  const stitchedCrsHeight = stitchedMaxY - stitchedMinY;
+
+  // Step 4: Compute UV transform.
+  // offsetX: how far the primary tile's left edge is from the stitched left edge.
+  // offsetY: how far the primary tile's top edge is from the stitched top edge.
+  //   CRS Y increases upward, but UV Y increases downward, so we use
+  //   (stitchedMaxY - primaryMaxY) for the top-edge offset.
+  const primaryCrsWidth = primaryMaxX - primaryMinX;
+  const primaryCrsHeight = primaryMaxY - primaryMinY;
+  const scaleX = stitchedCrsWidth > 0 ? primaryCrsWidth / stitchedCrsWidth : 1;
+  const scaleY =
+    stitchedCrsHeight > 0 ? primaryCrsHeight / stitchedCrsHeight : 1;
+  const offsetX =
+    stitchedCrsWidth > 0 ? (primaryMinX - stitchedMinX) / stitchedCrsWidth : 0;
+  const offsetY =
+    stitchedCrsHeight > 0
+      ? (stitchedMaxY - primaryMaxY) / stitchedCrsHeight
+      : 0;
+
+  // Step 5: Stitched pixel dimensions
+  const numCols = range.maxCol - range.minCol + 1;
+  const numRows = range.maxRow - range.minRow + 1;
+  const stitchedWidth = numCols * secondaryLevel.tileWidth;
+  const stitchedHeight = numRows * secondaryLevel.tileHeight;
+
+  return {
+    tileIndices,
+    uvTransform: [offsetX, offsetY, scaleX, scaleY],
+    stitchedWidth,
+    stitchedHeight,
+    minCol: range.minCol,
+    minRow: range.minRow,
+  };
+}

--- a/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
@@ -47,14 +47,18 @@ export interface SecondaryTileResolution {
   /**
    * The total stitched texture width in pixels.
    *
-   * Equals `(maxCol - minCol + 1) * secondaryLevel.tileWidth`.
+   * Equals the number of tile columns in the covering range times the
+   * secondary tile width. For example, if 2 tiles of 256px wide are
+   * fetched, `stitchedWidth` is 512.
    */
   stitchedWidth: number;
 
   /**
    * The total stitched texture height in pixels.
    *
-   * Equals `(maxRow - minRow + 1) * secondaryLevel.tileHeight`.
+   * Equals the number of tile rows in the covering range times the
+   * secondary tile height. For example, if 2 tiles of 256px tall are
+   * fetched, `stitchedHeight` is 512.
    */
   stitchedHeight: number;
 

--- a/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
@@ -3,13 +3,15 @@ import type { TilesetLevel } from "../raster-tileset/tileset-interface.js";
 /**
  * A tile index in a secondary tileset.
  *
+ * Uses `x`/`y` naming to match {@link TileIndex} convention.
+ *
  * @see {@link SecondaryTileResolution}
  */
 export interface SecondaryTileIndex {
   /** Column index of the secondary tile. */
-  col: number;
+  x: number;
   /** Row index of the secondary tile. */
-  row: number;
+  y: number;
 }
 
 /**
@@ -73,6 +75,14 @@ export interface SecondaryTileResolution {
    * `(row - minRow) * tileHeight`).
    */
   minRow: number;
+
+  /**
+   * Zoom level index into {@link TilesetDescriptor.levels}.
+   *
+   * All tiles in {@link tileIndices} come from this same level. Tells the
+   * consumer which COG overview to fetch from.
+   */
+  z: number;
 }
 
 /**
@@ -93,6 +103,10 @@ export interface SecondaryTileResolution {
  * @param primaryCol - Column index of the primary tile.
  * @param primaryRow - Row index of the primary tile.
  * @param secondaryLevel - The {@link TilesetLevel} describing the secondary tileset.
+ * @param secondaryZ - The zoom level index of `secondaryLevel` within its
+ *   {@link TilesetDescriptor.levels} array. Stored in the returned
+ *   {@link SecondaryTileResolution.z} so the consumer knows which COG overview
+ *   to fetch.
  * @returns A {@link SecondaryTileResolution} with tile indices, UV transform,
  *   stitched dimensions, and the min col/row of the covered range.
  */
@@ -101,6 +115,7 @@ export function resolveSecondaryTiles(
   primaryCol: number,
   primaryRow: number,
   secondaryLevel: TilesetLevel,
+  secondaryZ: number,
 ): SecondaryTileResolution {
   // Step 1: Get the CRS extent of the primary tile
   const corners = primaryLevel.projectedTileCorners(primaryCol, primaryRow);
@@ -139,7 +154,7 @@ export function resolveSecondaryTiles(
   const tileIndices: SecondaryTileIndex[] = [];
   for (let row = range.minRow; row <= range.maxRow; row++) {
     for (let col = range.minCol; col <= range.maxCol; col++) {
-      tileIndices.push({ col, row });
+      tileIndices.push({ x: col, y: row });
     }
   }
 
@@ -200,5 +215,6 @@ export function resolveSecondaryTiles(
     stitchedHeight,
     minCol: range.minCol,
     minRow: range.minRow,
+    z: secondaryZ,
   };
 }

--- a/packages/deck.gl-raster/src/raster-tileset/tileset-interface.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/tileset-interface.ts
@@ -43,6 +43,9 @@ export interface TilesetLevel {
   /**
    * Get the range of tile indices that overlap a given CRS bounding box.
    *
+   * The returned range is **inclusive** on both ends: a consumer should
+   * iterate `for (let col = minCol; col <= maxCol; col++)`.
+   *
    * Used by the traversal algorithm to find child tiles from a parent tile's
    * projected bounds.
    */

--- a/packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts
+++ b/packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts
@@ -1,53 +1,112 @@
+import type { Texture } from "@luma.gl/core";
 import { describe, expect, it } from "vitest";
-import { createCompositeBandsModule } from "../../src/gpu-modules/composite-bands.js";
+import {
+  buildCompositeBandsProps,
+  CompositeBands,
+} from "../../src/gpu-modules/composite-bands.js";
 
-describe("createCompositeBandsModule", () => {
-  it("creates a shader module with correct uniforms for RGB bands", () => {
-    const mod = createCompositeBandsModule({ r: "red", g: "green", b: "blue" });
-    expect(mod.name).toBe("composite-bands");
-    const decl = mod.inject["fs:#decl"];
-    expect(decl).toContain("uniform sampler2D band_red;");
-    expect(decl).toContain("uniform sampler2D band_green;");
-    expect(decl).toContain("uniform sampler2D band_blue;");
-    expect(decl).toContain("uniform vec4 uvTransform_red;");
-    expect(decl).toContain("uniform vec4 uvTransform_green;");
-    expect(decl).toContain("uniform vec4 uvTransform_blue;");
-    const filterColor = mod.inject["fs:DECKGL_FILTER_COLOR"];
-    expect(filterColor).toContain("band_red");
-    expect(filterColor).toContain("band_green");
-    expect(filterColor).toContain("band_blue");
-    expect(filterColor).toContain("uvTransform_red");
+describe("CompositeBands", () => {
+  it("has static uniform declarations for 4 band slots", () => {
+    // Texture samplers are in inject["fs:#decl"]
+    const decl = CompositeBands.inject["fs:#decl"];
+    expect(decl).toContain("uniform sampler2D band0;");
+    expect(decl).toContain("uniform sampler2D band1;");
+    expect(decl).toContain("uniform sampler2D band2;");
+    expect(decl).toContain("uniform sampler2D band3;");
+
+    // Scalar uniforms are in fs (uniform block)
+    const fsBlock = CompositeBands.fs;
+    expect(fsBlock).toContain("uvTransform0");
+    expect(fsBlock).toContain("uvTransform1");
+    expect(fsBlock).toContain("channelMap");
   });
 
-  it("creates a module with only 2 bands (r and g, no blue)", () => {
-    const mod = createCompositeBandsModule({ r: "nir", g: "swir" });
-    const decl = mod.inject["fs:#decl"];
-    expect(decl).toContain("uniform sampler2D band_nir;");
-    expect(decl).toContain("uniform sampler2D band_swir;");
-    const filterColor = mod.inject["fs:DECKGL_FILTER_COLOR"];
-    expect(filterColor).toContain("0.0"); // default for missing blue
+  it("has uniformTypes for vec4 transforms and ivec4 channelMap", () => {
+    expect(CompositeBands.uniformTypes.uvTransform0).toBe("vec4<f32>");
+    expect(CompositeBands.uniformTypes.channelMap).toBe("vec4<i32>");
   });
 
-  it("supports an alpha channel", () => {
-    const mod = createCompositeBandsModule({
-      r: "red",
-      g: "green",
-      b: "blue",
-      a: "alpha",
-    });
-    const decl = mod.inject["fs:#decl"];
-    expect(decl).toContain("uniform sampler2D band_alpha;");
-    expect(decl).toContain("uniform vec4 uvTransform_alpha;");
+  it("getUniforms provides defaults", () => {
+    const uniforms = CompositeBands.getUniforms({});
+    expect(uniforms.uvTransform0).toEqual([0, 0, 1, 1]);
+    expect(uniforms.channelMap).toEqual([0, 1, 2, -1]);
+  });
+});
+
+describe("buildCompositeBandsProps", () => {
+  const mockTexture = (id: string) => ({ id }) as unknown as Texture;
+  const identityUv = { offsetX: 0, offsetY: 0, scaleX: 1, scaleY: 1 };
+
+  it("maps RGB bands to slots 0, 1, 2", () => {
+    const bands = new Map([
+      ["red", { texture: mockTexture("r"), uvTransform: identityUv }],
+      ["green", { texture: mockTexture("g"), uvTransform: identityUv }],
+      ["blue", { texture: mockTexture("b"), uvTransform: identityUv }],
+    ]);
+
+    const props = buildCompositeBandsProps(
+      { r: "red", g: "green", b: "blue" },
+      bands,
+    );
+
+    expect(props.band0).toBe(bands.get("red")!.texture);
+    expect(props.band1).toBe(bands.get("green")!.texture);
+    expect(props.band2).toBe(bands.get("blue")!.texture);
+    expect(props.channelMap).toEqual([0, 1, 2, -1]);
   });
 
-  it("getUniforms passes through texture and transform props", () => {
-    const mod = createCompositeBandsModule({ r: "red", g: "green", b: "blue" });
-    const mockTexture = { id: "tex" };
-    const uniforms = mod.getUniforms({
-      band_red: mockTexture,
-      uvTransform_red: [0, 0, 1, 1],
-    });
-    expect(uniforms.band_red).toBe(mockTexture);
-    expect(uniforms.uvTransform_red).toEqual([0, 0, 1, 1]);
+  it("deduplicates bands used in multiple channels", () => {
+    const bands = new Map([
+      ["gray", { texture: mockTexture("g"), uvTransform: identityUv }],
+    ]);
+
+    const props = buildCompositeBandsProps(
+      { r: "gray", g: "gray", b: "gray" },
+      bands,
+    );
+
+    expect(props.band0).toBe(bands.get("gray")!.texture);
+    // Unused slots are filled with the first texture as a placeholder
+    expect(props.band1).toBe(bands.get("gray")!.texture);
+    expect(props.band2).toBe(bands.get("gray")!.texture);
+    expect(props.band3).toBe(bands.get("gray")!.texture);
+    expect(props.channelMap).toEqual([0, 0, 0, -1]);
+  });
+
+  it("passes UV transforms to correct slots", () => {
+    const customUv = {
+      offsetX: 0.1,
+      offsetY: 0.2,
+      scaleX: 0.5,
+      scaleY: 0.5,
+    };
+    const bands = new Map([
+      ["nir", { texture: mockTexture("nir"), uvTransform: customUv }],
+      ["red", { texture: mockTexture("red"), uvTransform: identityUv }],
+    ]);
+
+    const props = buildCompositeBandsProps({ r: "nir", g: "red" }, bands);
+
+    expect(props.uvTransform0).toEqual([0.1, 0.2, 0.5, 0.5]);
+    expect(props.uvTransform1).toEqual([0, 0, 1, 1]);
+  });
+
+  it("sets alpha channel to -1 when not provided", () => {
+    const bands = new Map([
+      ["r", { texture: mockTexture("r"), uvTransform: identityUv }],
+    ]);
+
+    const props = buildCompositeBandsProps({ r: "r" }, bands);
+    expect(props.channelMap![3]).toBe(-1);
+  });
+
+  it("throws when band is not found in the map", () => {
+    const bands = new Map([
+      ["red", { texture: mockTexture("r"), uvTransform: identityUv }],
+    ]);
+
+    expect(() =>
+      buildCompositeBandsProps({ r: "red", g: "missing" }, bands),
+    ).toThrow('Band "missing" not found');
   });
 });

--- a/packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts
+++ b/packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { createCompositeBandsModule } from "../../src/gpu-modules/composite-bands.js";
+
+describe("createCompositeBandsModule", () => {
+  it("creates a shader module with correct uniforms for RGB bands", () => {
+    const mod = createCompositeBandsModule({ r: "red", g: "green", b: "blue" });
+    expect(mod.name).toBe("composite-bands");
+    const decl = mod.inject["fs:#decl"];
+    expect(decl).toContain("uniform sampler2D band_red;");
+    expect(decl).toContain("uniform sampler2D band_green;");
+    expect(decl).toContain("uniform sampler2D band_blue;");
+    expect(decl).toContain("uniform vec4 uvTransform_red;");
+    expect(decl).toContain("uniform vec4 uvTransform_green;");
+    expect(decl).toContain("uniform vec4 uvTransform_blue;");
+    const filterColor = mod.inject["fs:DECKGL_FILTER_COLOR"];
+    expect(filterColor).toContain("band_red");
+    expect(filterColor).toContain("band_green");
+    expect(filterColor).toContain("band_blue");
+    expect(filterColor).toContain("uvTransform_red");
+  });
+
+  it("creates a module with only 2 bands (r and g, no blue)", () => {
+    const mod = createCompositeBandsModule({ r: "nir", g: "swir" });
+    const decl = mod.inject["fs:#decl"];
+    expect(decl).toContain("uniform sampler2D band_nir;");
+    expect(decl).toContain("uniform sampler2D band_swir;");
+    const filterColor = mod.inject["fs:DECKGL_FILTER_COLOR"];
+    expect(filterColor).toContain("0.0"); // default for missing blue
+  });
+
+  it("supports an alpha channel", () => {
+    const mod = createCompositeBandsModule({
+      r: "red",
+      g: "green",
+      b: "blue",
+      a: "alpha",
+    });
+    const decl = mod.inject["fs:#decl"];
+    expect(decl).toContain("uniform sampler2D band_alpha;");
+    expect(decl).toContain("uniform vec4 uvTransform_alpha;");
+  });
+
+  it("getUniforms passes through texture and transform props", () => {
+    const mod = createCompositeBandsModule({ r: "red", g: "green", b: "blue" });
+    const mockTexture = { id: "tex" };
+    const uniforms = mod.getUniforms({
+      band_red: mockTexture,
+      uvTransform_red: [0, 0, 1, 1],
+    });
+    expect(uniforms.band_red).toBe(mockTexture);
+    expect(uniforms.uvTransform_red).toEqual([0, 0, 1, 1]);
+  });
+});

--- a/packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
+++ b/packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
@@ -159,80 +159,66 @@ describe("createMultiTilesetDescriptor", () => {
 });
 
 describe("selectSecondaryLevel", () => {
-  it("picks the finest level that is >= primary metersPerPixel", () => {
-    const levels = [
-      mockLevel({
-        matrixWidth: 1,
-        matrixHeight: 1,
-        tileWidth: 256,
-        tileHeight: 256,
-        metersPerPixel: 200,
-      }),
-      mockLevel({
-        matrixWidth: 5,
-        matrixHeight: 5,
-        tileWidth: 256,
-        tileHeight: 256,
-        metersPerPixel: 60,
-      }),
-      mockLevel({
-        matrixWidth: 22,
-        matrixHeight: 22,
-        tileWidth: 256,
-        tileHeight: 256,
-        metersPerPixel: 20,
-      }),
-    ];
-    const selected = selectSecondaryLevel(levels, 10);
-    expect(selected).toBe(levels[2]);
+  const levels = [
+    mockLevel({
+      matrixWidth: 1,
+      matrixHeight: 1,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 200,
+    }),
+    mockLevel({
+      matrixWidth: 5,
+      matrixHeight: 5,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 60,
+    }),
+    mockLevel({
+      matrixWidth: 22,
+      matrixHeight: 22,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 20,
+    }),
+  ];
+
+  describe("closest-finer (default)", () => {
+    it("falls back to finest when all levels are coarser than primary", () => {
+      // Primary at 10m — all levels (200, 60, 20) are coarser
+      const selected = selectSecondaryLevel(levels, 10);
+      expect(selected).toBe(levels[2]); // 20m — finest available
+    });
+
+    it("picks the coarsest level that is still finer than primary", () => {
+      // Primary at 100m — finer-or-equal candidates are [60, 20]
+      // Pick the coarsest among them (closest to 100m without exceeding)
+      const selected = selectSecondaryLevel(levels, 100);
+      expect(selected).toBe(levels[1]); // 60m
+    });
+
+    it("picks exact match when available", () => {
+      const selected = selectSecondaryLevel(levels, 60);
+      expect(selected).toBe(levels[1]); // 60m exact
+    });
   });
 
-  it("returns the finest level when all are coarser than primary", () => {
-    const levels = [
-      mockLevel({
-        matrixWidth: 1,
-        matrixHeight: 1,
-        tileWidth: 256,
-        tileHeight: 256,
-        metersPerPixel: 200,
-      }),
-      mockLevel({
-        matrixWidth: 3,
-        matrixHeight: 3,
-        tileWidth: 256,
-        tileHeight: 256,
-        metersPerPixel: 60,
-      }),
-    ];
-    const selected = selectSecondaryLevel(levels, 10);
-    expect(selected).toBe(levels[1]);
-  });
+  describe("closest", () => {
+    it("picks the level with the smallest absolute mpp difference", () => {
+      // Primary at 50m — diffs: |200-50|=150, |60-50|=10, |20-50|=30
+      const selected = selectSecondaryLevel(levels, 50, "closest");
+      expect(selected).toBe(levels[1]); // 60m (closest by abs diff)
+    });
 
-  it("selects a coarser level when primary is zoomed out", () => {
-    const levels = [
-      mockLevel({
-        matrixWidth: 1,
-        matrixHeight: 1,
-        tileWidth: 256,
-        tileHeight: 256,
-        metersPerPixel: 200,
-      }),
-      mockLevel({
-        matrixWidth: 5,
-        matrixHeight: 5,
-        tileWidth: 256,
-        tileHeight: 256,
-        metersPerPixel: 60,
-      }),
-      mockLevel({
-        matrixWidth: 22,
-        matrixHeight: 22,
-        tileWidth: 256,
-        tileHeight: 256,
-        metersPerPixel: 20,
-      }),
-    ];
-    const selected = selectSecondaryLevel(levels, 100);
-    expect(selected).toBe(levels[1]);
+    it("may pick a coarser level if it is closer than all finer ones", () => {
+      // Primary at 100m — diffs: |200-100|=100, |60-100|=40, |20-100|=80
+      const selected = selectSecondaryLevel(levels, 100, "closest");
+      expect(selected).toBe(levels[1]); // 60m
+    });
+
+    it("picks finest when primary is finer than all levels", () => {
+      const selected = selectSecondaryLevel(levels, 10, "closest");
+      expect(selected).toBe(levels[2]); // 20m (closest to 10m)
+    });
   });
 });

--- a/packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
+++ b/packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
@@ -8,7 +8,7 @@ import type {
   TilesetDescriptor,
   TilesetLevel,
 } from "../../src/raster-tileset/tileset-interface.js";
-import type { Corners, Point } from "../../src/raster-tileset/types.js";
+import type { Corners } from "../../src/raster-tileset/types.js";
 
 /** Helper: create a mock TilesetLevel */
 function mockLevel(opts: {
@@ -21,10 +21,10 @@ function mockLevel(opts: {
   return {
     ...opts,
     projectedTileCorners: (_col: number, _row: number): Corners => ({
-      topLeft: [0, 1] as Point,
-      topRight: [1, 1] as Point,
-      bottomLeft: [0, 0] as Point,
-      bottomRight: [1, 0] as Point,
+      topLeft: [0, 1],
+      topRight: [1, 1],
+      bottomLeft: [0, 0],
+      bottomRight: [1, 0],
     }),
     crsBoundsToTileRange: () => ({
       minCol: 0,
@@ -48,14 +48,38 @@ function mockDescriptor(levels: TilesetLevel[]): TilesetDescriptor {
 
 describe("tilesetLevelsEqual", () => {
   it("returns true for levels with same grid parameters", () => {
-    const a = mockLevel({ matrixWidth: 43, matrixHeight: 43, tileWidth: 256, tileHeight: 256, metersPerPixel: 10 });
-    const b = mockLevel({ matrixWidth: 43, matrixHeight: 43, tileWidth: 256, tileHeight: 256, metersPerPixel: 10 });
+    const a = mockLevel({
+      matrixWidth: 43,
+      matrixHeight: 43,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 10,
+    });
+    const b = mockLevel({
+      matrixWidth: 43,
+      matrixHeight: 43,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 10,
+    });
     expect(tilesetLevelsEqual(a, b)).toBe(true);
   });
 
   it("returns false for levels with different grid parameters", () => {
-    const a = mockLevel({ matrixWidth: 43, matrixHeight: 43, tileWidth: 256, tileHeight: 256, metersPerPixel: 10 });
-    const b = mockLevel({ matrixWidth: 22, matrixHeight: 22, tileWidth: 256, tileHeight: 256, metersPerPixel: 20 });
+    const a = mockLevel({
+      matrixWidth: 43,
+      matrixHeight: 43,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 10,
+    });
+    const b = mockLevel({
+      matrixWidth: 22,
+      matrixHeight: 22,
+      tileWidth: 256,
+      tileHeight: 256,
+      metersPerPixel: 20,
+    });
     expect(tilesetLevelsEqual(a, b)).toBe(false);
   });
 });
@@ -63,23 +87,73 @@ describe("tilesetLevelsEqual", () => {
 describe("createMultiTilesetDescriptor", () => {
   it("selects the finest-resolution tileset as primary", () => {
     const fine = mockDescriptor([
-      mockLevel({ matrixWidth: 1, matrixHeight: 1, tileWidth: 256, tileHeight: 256, metersPerPixel: 100 }),
-      mockLevel({ matrixWidth: 43, matrixHeight: 43, tileWidth: 256, tileHeight: 256, metersPerPixel: 10 }),
+      mockLevel({
+        matrixWidth: 1,
+        matrixHeight: 1,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 100,
+      }),
+      mockLevel({
+        matrixWidth: 43,
+        matrixHeight: 43,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 10,
+      }),
     ]);
     const coarse = mockDescriptor([
-      mockLevel({ matrixWidth: 1, matrixHeight: 1, tileWidth: 256, tileHeight: 256, metersPerPixel: 200 }),
-      mockLevel({ matrixWidth: 22, matrixHeight: 22, tileWidth: 256, tileHeight: 256, metersPerPixel: 20 }),
+      mockLevel({
+        matrixWidth: 1,
+        matrixHeight: 1,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 200,
+      }),
+      mockLevel({
+        matrixWidth: 22,
+        matrixHeight: 22,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 20,
+      }),
     ]);
-    const multi = createMultiTilesetDescriptor(new Map([["red", fine], ["swir", coarse]]));
+    const multi = createMultiTilesetDescriptor(
+      new Map([
+        ["red", fine],
+        ["swir", coarse],
+      ]),
+    );
     expect(multi.primary).toBe(fine);
     expect(multi.secondaries.size).toBe(1);
     expect(multi.secondaries.get("swir")).toBe(coarse);
   });
 
   it("does not include the primary key in secondaries", () => {
-    const fine = mockDescriptor([mockLevel({ matrixWidth: 43, matrixHeight: 43, tileWidth: 256, tileHeight: 256, metersPerPixel: 10 })]);
-    const coarse = mockDescriptor([mockLevel({ matrixWidth: 22, matrixHeight: 22, tileWidth: 256, tileHeight: 256, metersPerPixel: 20 })]);
-    const multi = createMultiTilesetDescriptor(new Map([["red", fine], ["swir", coarse]]));
+    const fine = mockDescriptor([
+      mockLevel({
+        matrixWidth: 43,
+        matrixHeight: 43,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 10,
+      }),
+    ]);
+    const coarse = mockDescriptor([
+      mockLevel({
+        matrixWidth: 22,
+        matrixHeight: 22,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 20,
+      }),
+    ]);
+    const multi = createMultiTilesetDescriptor(
+      new Map([
+        ["red", fine],
+        ["swir", coarse],
+      ]),
+    );
     expect(multi.secondaries.has("red")).toBe(false);
   });
 });
@@ -87,9 +161,27 @@ describe("createMultiTilesetDescriptor", () => {
 describe("selectSecondaryLevel", () => {
   it("picks the finest level that is >= primary metersPerPixel", () => {
     const levels = [
-      mockLevel({ matrixWidth: 1, matrixHeight: 1, tileWidth: 256, tileHeight: 256, metersPerPixel: 200 }),
-      mockLevel({ matrixWidth: 5, matrixHeight: 5, tileWidth: 256, tileHeight: 256, metersPerPixel: 60 }),
-      mockLevel({ matrixWidth: 22, matrixHeight: 22, tileWidth: 256, tileHeight: 256, metersPerPixel: 20 }),
+      mockLevel({
+        matrixWidth: 1,
+        matrixHeight: 1,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 200,
+      }),
+      mockLevel({
+        matrixWidth: 5,
+        matrixHeight: 5,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 60,
+      }),
+      mockLevel({
+        matrixWidth: 22,
+        matrixHeight: 22,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 20,
+      }),
     ];
     const selected = selectSecondaryLevel(levels, 10);
     expect(selected).toBe(levels[2]);
@@ -97,8 +189,20 @@ describe("selectSecondaryLevel", () => {
 
   it("returns the finest level when all are coarser than primary", () => {
     const levels = [
-      mockLevel({ matrixWidth: 1, matrixHeight: 1, tileWidth: 256, tileHeight: 256, metersPerPixel: 200 }),
-      mockLevel({ matrixWidth: 3, matrixHeight: 3, tileWidth: 256, tileHeight: 256, metersPerPixel: 60 }),
+      mockLevel({
+        matrixWidth: 1,
+        matrixHeight: 1,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 200,
+      }),
+      mockLevel({
+        matrixWidth: 3,
+        matrixHeight: 3,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 60,
+      }),
     ];
     const selected = selectSecondaryLevel(levels, 10);
     expect(selected).toBe(levels[1]);
@@ -106,9 +210,27 @@ describe("selectSecondaryLevel", () => {
 
   it("selects a coarser level when primary is zoomed out", () => {
     const levels = [
-      mockLevel({ matrixWidth: 1, matrixHeight: 1, tileWidth: 256, tileHeight: 256, metersPerPixel: 200 }),
-      mockLevel({ matrixWidth: 5, matrixHeight: 5, tileWidth: 256, tileHeight: 256, metersPerPixel: 60 }),
-      mockLevel({ matrixWidth: 22, matrixHeight: 22, tileWidth: 256, tileHeight: 256, metersPerPixel: 20 }),
+      mockLevel({
+        matrixWidth: 1,
+        matrixHeight: 1,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 200,
+      }),
+      mockLevel({
+        matrixWidth: 5,
+        matrixHeight: 5,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 60,
+      }),
+      mockLevel({
+        matrixWidth: 22,
+        matrixHeight: 22,
+        tileWidth: 256,
+        tileHeight: 256,
+        metersPerPixel: 20,
+      }),
     ];
     const selected = selectSecondaryLevel(levels, 100);
     expect(selected).toBe(levels[1]);

--- a/packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
+++ b/packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMultiTilesetDescriptor,
+  selectSecondaryLevel,
+  tilesetLevelsEqual,
+} from "../../src/multi-raster-tileset/multi-tileset-descriptor.js";
+import type {
+  TilesetDescriptor,
+  TilesetLevel,
+} from "../../src/raster-tileset/tileset-interface.js";
+import type { Corners, Point } from "../../src/raster-tileset/types.js";
+
+/** Helper: create a mock TilesetLevel */
+function mockLevel(opts: {
+  matrixWidth: number;
+  matrixHeight: number;
+  tileWidth: number;
+  tileHeight: number;
+  metersPerPixel: number;
+}): TilesetLevel {
+  return {
+    ...opts,
+    projectedTileCorners: (_col: number, _row: number): Corners => ({
+      topLeft: [0, 1] as Point,
+      topRight: [1, 1] as Point,
+      bottomLeft: [0, 0] as Point,
+      bottomRight: [1, 0] as Point,
+    }),
+    crsBoundsToTileRange: () => ({
+      minCol: 0,
+      maxCol: 0,
+      minRow: 0,
+      maxRow: 0,
+    }),
+  };
+}
+
+/** Helper: create a mock TilesetDescriptor */
+function mockDescriptor(levels: TilesetLevel[]): TilesetDescriptor {
+  const identity = (x: number, y: number): [number, number] => [x, y];
+  return {
+    levels,
+    projectTo3857: identity,
+    projectTo4326: identity,
+    projectedBounds: [600000, 7890000, 710000, 8000000],
+  };
+}
+
+describe("tilesetLevelsEqual", () => {
+  it("returns true for levels with same grid parameters", () => {
+    const a = mockLevel({ matrixWidth: 43, matrixHeight: 43, tileWidth: 256, tileHeight: 256, metersPerPixel: 10 });
+    const b = mockLevel({ matrixWidth: 43, matrixHeight: 43, tileWidth: 256, tileHeight: 256, metersPerPixel: 10 });
+    expect(tilesetLevelsEqual(a, b)).toBe(true);
+  });
+
+  it("returns false for levels with different grid parameters", () => {
+    const a = mockLevel({ matrixWidth: 43, matrixHeight: 43, tileWidth: 256, tileHeight: 256, metersPerPixel: 10 });
+    const b = mockLevel({ matrixWidth: 22, matrixHeight: 22, tileWidth: 256, tileHeight: 256, metersPerPixel: 20 });
+    expect(tilesetLevelsEqual(a, b)).toBe(false);
+  });
+});
+
+describe("createMultiTilesetDescriptor", () => {
+  it("selects the finest-resolution tileset as primary", () => {
+    const fine = mockDescriptor([
+      mockLevel({ matrixWidth: 1, matrixHeight: 1, tileWidth: 256, tileHeight: 256, metersPerPixel: 100 }),
+      mockLevel({ matrixWidth: 43, matrixHeight: 43, tileWidth: 256, tileHeight: 256, metersPerPixel: 10 }),
+    ]);
+    const coarse = mockDescriptor([
+      mockLevel({ matrixWidth: 1, matrixHeight: 1, tileWidth: 256, tileHeight: 256, metersPerPixel: 200 }),
+      mockLevel({ matrixWidth: 22, matrixHeight: 22, tileWidth: 256, tileHeight: 256, metersPerPixel: 20 }),
+    ]);
+    const multi = createMultiTilesetDescriptor(new Map([["red", fine], ["swir", coarse]]));
+    expect(multi.primary).toBe(fine);
+    expect(multi.secondaries.size).toBe(1);
+    expect(multi.secondaries.get("swir")).toBe(coarse);
+  });
+
+  it("does not include the primary key in secondaries", () => {
+    const fine = mockDescriptor([mockLevel({ matrixWidth: 43, matrixHeight: 43, tileWidth: 256, tileHeight: 256, metersPerPixel: 10 })]);
+    const coarse = mockDescriptor([mockLevel({ matrixWidth: 22, matrixHeight: 22, tileWidth: 256, tileHeight: 256, metersPerPixel: 20 })]);
+    const multi = createMultiTilesetDescriptor(new Map([["red", fine], ["swir", coarse]]));
+    expect(multi.secondaries.has("red")).toBe(false);
+  });
+});
+
+describe("selectSecondaryLevel", () => {
+  it("picks the finest level that is >= primary metersPerPixel", () => {
+    const levels = [
+      mockLevel({ matrixWidth: 1, matrixHeight: 1, tileWidth: 256, tileHeight: 256, metersPerPixel: 200 }),
+      mockLevel({ matrixWidth: 5, matrixHeight: 5, tileWidth: 256, tileHeight: 256, metersPerPixel: 60 }),
+      mockLevel({ matrixWidth: 22, matrixHeight: 22, tileWidth: 256, tileHeight: 256, metersPerPixel: 20 }),
+    ];
+    const selected = selectSecondaryLevel(levels, 10);
+    expect(selected).toBe(levels[2]);
+  });
+
+  it("returns the finest level when all are coarser than primary", () => {
+    const levels = [
+      mockLevel({ matrixWidth: 1, matrixHeight: 1, tileWidth: 256, tileHeight: 256, metersPerPixel: 200 }),
+      mockLevel({ matrixWidth: 3, matrixHeight: 3, tileWidth: 256, tileHeight: 256, metersPerPixel: 60 }),
+    ];
+    const selected = selectSecondaryLevel(levels, 10);
+    expect(selected).toBe(levels[1]);
+  });
+
+  it("selects a coarser level when primary is zoomed out", () => {
+    const levels = [
+      mockLevel({ matrixWidth: 1, matrixHeight: 1, tileWidth: 256, tileHeight: 256, metersPerPixel: 200 }),
+      mockLevel({ matrixWidth: 5, matrixHeight: 5, tileWidth: 256, tileHeight: 256, metersPerPixel: 60 }),
+      mockLevel({ matrixWidth: 22, matrixHeight: 22, tileWidth: 256, tileHeight: 256, metersPerPixel: 20 }),
+    ];
+    const selected = selectSecondaryLevel(levels, 100);
+    expect(selected).toBe(levels[1]);
+  });
+});

--- a/packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts
+++ b/packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts
@@ -16,11 +16,22 @@ function gridLevel(opts: {
   matrixWidth: number;
   matrixHeight: number;
 }): TilesetLevel {
-  const { originX, originY, cellSize, tileWidth, tileHeight, matrixWidth, matrixHeight } = opts;
+  const {
+    originX,
+    originY,
+    cellSize,
+    tileWidth,
+    tileHeight,
+    matrixWidth,
+    matrixHeight,
+  } = opts;
   const tileCrsWidth = tileWidth * cellSize;
   const tileCrsHeight = tileHeight * cellSize;
   return {
-    matrixWidth, matrixHeight, tileWidth, tileHeight,
+    matrixWidth,
+    matrixHeight,
+    tileWidth,
+    tileHeight,
     metersPerPixel: cellSize,
     projectedTileCorners: (col: number, row: number): Corners => {
       const minX = originX + col * tileCrsWidth;
@@ -28,11 +39,18 @@ function gridLevel(opts: {
       const maxY = originY - row * tileCrsHeight;
       const minY = maxY - tileCrsHeight;
       return {
-        topLeft: [minX, maxY] as Point, topRight: [maxX, maxY] as Point,
-        bottomLeft: [minX, minY] as Point, bottomRight: [maxX, minY] as Point,
+        topLeft: [minX, maxY] as Point,
+        topRight: [maxX, maxY] as Point,
+        bottomLeft: [minX, minY] as Point,
+        bottomRight: [maxX, minY] as Point,
       };
     },
-    crsBoundsToTileRange: (projectedMinX: number, projectedMinY: number, projectedMaxX: number, projectedMaxY: number) => {
+    crsBoundsToTileRange: (
+      projectedMinX: number,
+      projectedMinY: number,
+      projectedMaxX: number,
+      projectedMaxY: number,
+    ) => {
       // Use ceil-1 for both min and max so that exact tile boundaries are treated
       // as inclusive on the left tile (the boundary point belongs to the tile ending there).
       let minCol = Math.ceil((projectedMinX - originX) / tileCrsWidth) - 1;
@@ -53,8 +71,24 @@ describe("resolveSecondaryTiles", () => {
   // Primary: 10m, 256px tiles → each tile covers 2560m
   // Secondary: 20m, 256px tiles → each tile covers 5120m
   const origin = { x: 600000, y: 8000000 };
-  const primaryLevel = gridLevel({ originX: origin.x, originY: origin.y, cellSize: 10, tileWidth: 256, tileHeight: 256, matrixWidth: 43, matrixHeight: 43 });
-  const secondaryLevel = gridLevel({ originX: origin.x, originY: origin.y, cellSize: 20, tileWidth: 256, tileHeight: 256, matrixWidth: 22, matrixHeight: 22 });
+  const primaryLevel = gridLevel({
+    originX: origin.x,
+    originY: origin.y,
+    cellSize: 10,
+    tileWidth: 256,
+    tileHeight: 256,
+    matrixWidth: 43,
+    matrixHeight: 43,
+  });
+  const secondaryLevel = gridLevel({
+    originX: origin.x,
+    originY: origin.y,
+    cellSize: 20,
+    tileWidth: 256,
+    tileHeight: 256,
+    matrixWidth: 22,
+    matrixHeight: 22,
+  });
 
   it("returns correct UV transform when primary tile is fully inside one secondary tile", () => {
     // Primary tile (0,0) covers [600000, 7997440] to [602560, 8000000]

--- a/packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts
+++ b/packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { resolveSecondaryTiles } from "../../src/multi-raster-tileset/secondary-tile-resolver.js";
+import type { TilesetLevel } from "../../src/raster-tileset/tileset-interface.js";
+import type { Corners, Point } from "../../src/raster-tileset/types.js";
+
+/**
+ * Create a mock TilesetLevel backed by a regular grid.
+ * originX/originY is the top-left corner. cellSize is CRS units per pixel.
+ */
+function gridLevel(opts: {
+  originX: number;
+  originY: number;
+  cellSize: number;
+  tileWidth: number;
+  tileHeight: number;
+  matrixWidth: number;
+  matrixHeight: number;
+}): TilesetLevel {
+  const { originX, originY, cellSize, tileWidth, tileHeight, matrixWidth, matrixHeight } = opts;
+  const tileCrsWidth = tileWidth * cellSize;
+  const tileCrsHeight = tileHeight * cellSize;
+  return {
+    matrixWidth, matrixHeight, tileWidth, tileHeight,
+    metersPerPixel: cellSize,
+    projectedTileCorners: (col: number, row: number): Corners => {
+      const minX = originX + col * tileCrsWidth;
+      const maxX = minX + tileCrsWidth;
+      const maxY = originY - row * tileCrsHeight;
+      const minY = maxY - tileCrsHeight;
+      return {
+        topLeft: [minX, maxY] as Point, topRight: [maxX, maxY] as Point,
+        bottomLeft: [minX, minY] as Point, bottomRight: [maxX, minY] as Point,
+      };
+    },
+    crsBoundsToTileRange: (projectedMinX: number, projectedMinY: number, projectedMaxX: number, projectedMaxY: number) => {
+      // Use ceil-1 for both min and max so that exact tile boundaries are treated
+      // as inclusive on the left tile (the boundary point belongs to the tile ending there).
+      let minCol = Math.ceil((projectedMinX - originX) / tileCrsWidth) - 1;
+      let maxCol = Math.ceil((projectedMaxX - originX) / tileCrsWidth) - 1;
+      let minRow = Math.ceil((originY - projectedMaxY) / tileCrsHeight) - 1;
+      let maxRow = Math.ceil((originY - projectedMinY) / tileCrsHeight) - 1;
+      minCol = Math.max(0, Math.min(matrixWidth - 1, minCol));
+      maxCol = Math.max(0, Math.min(matrixWidth - 1, maxCol));
+      minRow = Math.max(0, Math.min(matrixHeight - 1, minRow));
+      maxRow = Math.max(0, Math.min(matrixHeight - 1, maxRow));
+      return { minCol, maxCol, minRow, maxRow };
+    },
+  };
+}
+
+describe("resolveSecondaryTiles", () => {
+  // Both grids share origin (600000, 8000000), top-left convention.
+  // Primary: 10m, 256px tiles → each tile covers 2560m
+  // Secondary: 20m, 256px tiles → each tile covers 5120m
+  const origin = { x: 600000, y: 8000000 };
+  const primaryLevel = gridLevel({ originX: origin.x, originY: origin.y, cellSize: 10, tileWidth: 256, tileHeight: 256, matrixWidth: 43, matrixHeight: 43 });
+  const secondaryLevel = gridLevel({ originX: origin.x, originY: origin.y, cellSize: 20, tileWidth: 256, tileHeight: 256, matrixWidth: 22, matrixHeight: 22 });
+
+  it("returns correct UV transform when primary tile is fully inside one secondary tile", () => {
+    // Primary tile (0,0) covers [600000, 7997440] to [602560, 8000000]
+    // Secondary tile (0,0) covers [600000, 7994880] to [605120, 8000000]
+    const result = resolveSecondaryTiles(primaryLevel, 0, 0, secondaryLevel);
+    expect(result.tileIndices).toEqual([{ col: 0, row: 0 }]);
+    // scaleX = 2560 / 5120 = 0.5, offsetX = 0, offsetY = 0
+    expect(result.uvTransform[0]).toBeCloseTo(0);
+    expect(result.uvTransform[1]).toBeCloseTo(0);
+    expect(result.uvTransform[2]).toBeCloseTo(0.5);
+    expect(result.uvTransform[3]).toBeCloseTo(0.5);
+  });
+
+  it("computes correct UV offset for non-origin primary tile", () => {
+    // Primary tile (1,0): covers [602560, 7997440] to [605120, 8000000]
+    // Still inside secondary tile (0,0): [600000, 7994880] to [605120, 8000000]
+    const result = resolveSecondaryTiles(primaryLevel, 1, 0, secondaryLevel);
+    expect(result.tileIndices).toEqual([{ col: 0, row: 0 }]);
+    // offsetX = (602560 - 600000) / 5120 = 0.5
+    expect(result.uvTransform[0]).toBeCloseTo(0.5);
+    expect(result.uvTransform[1]).toBeCloseTo(0);
+    expect(result.uvTransform[2]).toBeCloseTo(0.5);
+    expect(result.uvTransform[3]).toBeCloseTo(0.5);
+  });
+
+  it("handles primary tile spanning two secondary tiles", () => {
+    // Primary tile (2,0): covers [605120, 7997440] to [607680, 8000000]
+    // Crosses boundary between secondary (0,0) and (1,0)
+    const result = resolveSecondaryTiles(primaryLevel, 2, 0, secondaryLevel);
+    expect(result.tileIndices.length).toBe(2);
+    // Stitched: [600000..610240], width=10240
+    // scaleX = 2560 / 10240 = 0.25, offsetX = (605120-600000)/10240 = 0.5
+    expect(result.uvTransform[2]).toBeCloseTo(0.25);
+    expect(result.uvTransform[0]).toBeCloseTo(0.5);
+  });
+
+  it("returns identity-like transform when grids align exactly", () => {
+    const result = resolveSecondaryTiles(primaryLevel, 0, 0, primaryLevel);
+    expect(result.tileIndices).toEqual([{ col: 0, row: 0 }]);
+    expect(result.uvTransform[0]).toBeCloseTo(0);
+    expect(result.uvTransform[1]).toBeCloseTo(0);
+    expect(result.uvTransform[2]).toBeCloseTo(1);
+    expect(result.uvTransform[3]).toBeCloseTo(1);
+  });
+});

--- a/packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts
+++ b/packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts
@@ -59,8 +59,8 @@ describe("resolveSecondaryTiles", () => {
   it("returns correct UV transform when primary tile is fully inside one secondary tile", () => {
     // Primary tile (0,0) covers [600000, 7997440] to [602560, 8000000]
     // Secondary tile (0,0) covers [600000, 7994880] to [605120, 8000000]
-    const result = resolveSecondaryTiles(primaryLevel, 0, 0, secondaryLevel);
-    expect(result.tileIndices).toEqual([{ col: 0, row: 0 }]);
+    const result = resolveSecondaryTiles(primaryLevel, 0, 0, secondaryLevel, 0);
+    expect(result.tileIndices).toEqual([{ x: 0, y: 0 }]);
     // scaleX = 2560 / 5120 = 0.5, offsetX = 0, offsetY = 0
     expect(result.uvTransform[0]).toBeCloseTo(0);
     expect(result.uvTransform[1]).toBeCloseTo(0);
@@ -71,8 +71,8 @@ describe("resolveSecondaryTiles", () => {
   it("computes correct UV offset for non-origin primary tile", () => {
     // Primary tile (1,0): covers [602560, 7997440] to [605120, 8000000]
     // Still inside secondary tile (0,0): [600000, 7994880] to [605120, 8000000]
-    const result = resolveSecondaryTiles(primaryLevel, 1, 0, secondaryLevel);
-    expect(result.tileIndices).toEqual([{ col: 0, row: 0 }]);
+    const result = resolveSecondaryTiles(primaryLevel, 1, 0, secondaryLevel, 0);
+    expect(result.tileIndices).toEqual([{ x: 0, y: 0 }]);
     // offsetX = (602560 - 600000) / 5120 = 0.5
     expect(result.uvTransform[0]).toBeCloseTo(0.5);
     expect(result.uvTransform[1]).toBeCloseTo(0);
@@ -83,7 +83,7 @@ describe("resolveSecondaryTiles", () => {
   it("handles primary tile spanning two secondary tiles", () => {
     // Primary tile (2,0): covers [605120, 7997440] to [607680, 8000000]
     // Crosses boundary between secondary (0,0) and (1,0)
-    const result = resolveSecondaryTiles(primaryLevel, 2, 0, secondaryLevel);
+    const result = resolveSecondaryTiles(primaryLevel, 2, 0, secondaryLevel, 0);
     expect(result.tileIndices.length).toBe(2);
     // Stitched: [600000..610240], width=10240
     // scaleX = 2560 / 10240 = 0.25, offsetX = (605120-600000)/10240 = 0.5
@@ -92,8 +92,8 @@ describe("resolveSecondaryTiles", () => {
   });
 
   it("returns identity-like transform when grids align exactly", () => {
-    const result = resolveSecondaryTiles(primaryLevel, 0, 0, primaryLevel);
-    expect(result.tileIndices).toEqual([{ col: 0, row: 0 }]);
+    const result = resolveSecondaryTiles(primaryLevel, 0, 0, primaryLevel, 0);
+    expect(result.tileIndices).toEqual([{ x: 0, y: 0 }]);
     expect(result.uvTransform[0]).toBeCloseTo(0);
     expect(result.uvTransform[1]).toBeCloseTo(0);
     expect(result.uvTransform[2]).toBeCloseTo(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,58 @@ importers:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  examples/sentinel-2:
+    dependencies:
+      '@deck.gl/core':
+        specifier: ^9.2.11
+        version: 9.2.11
+      '@deck.gl/geo-layers':
+        specifier: ^9.2.11
+        version: 9.2.11(@deck.gl/core@9.2.11)(@deck.gl/extensions@9.2.5(@deck.gl/core@9.2.11)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6))))(@deck.gl/layers@9.2.11(@deck.gl/core@9.2.11)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6))))(@deck.gl/mesh-layers@9.2.11(@deck.gl/core@9.2.11)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/gltf@9.2.6(@luma.gl/constants@9.2.6)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@loaders.gl/core@4.3.4)(@luma.gl/constants@9.2.6)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))
+      '@deck.gl/layers':
+        specifier: ^9.2.11
+        version: 9.2.11(@deck.gl/core@9.2.11)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))
+      '@deck.gl/mapbox':
+        specifier: ^9.2.11
+        version: 9.2.11(@deck.gl/core@9.2.11)(@luma.gl/constants@9.2.6)(@luma.gl/core@9.2.6)(@math.gl/web-mercator@4.1.0)
+      '@deck.gl/mesh-layers':
+        specifier: ^9.2.11
+        version: 9.2.11(@deck.gl/core@9.2.11)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/gltf@9.2.6(@luma.gl/constants@9.2.6)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6))
+      '@developmentseed/deck.gl-geotiff':
+        specifier: workspace:^
+        version: link:../../packages/deck.gl-geotiff
+      '@developmentseed/deck.gl-raster':
+        specifier: workspace:^
+        version: link:../../packages/deck.gl-raster
+      '@luma.gl/core':
+        specifier: ^9.2.6
+        version: 9.2.6
+      maplibre-gl:
+        specifier: ^5.19.0
+        version: 5.19.0
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      react-map-gl:
+        specifier: ^8.1.0
+        version: 8.1.0(maplibre-gl@5.19.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.4
+        version: 5.1.4(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   examples/zarr-sentinel2-tci:
     dependencies:
       '@deck.gl/core':
@@ -1401,10 +1453,6 @@ packages:
 
   '@babel/runtime-corejs3@7.29.0':
     resolution: {integrity: sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.2':
@@ -8825,8 +8873,6 @@ snapshots:
     dependencies:
       core-js-pure: 3.48.0
 
-  '@babel/runtime@7.28.6': {}
-
   '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
@@ -9389,7 +9435,7 @@ snapshots:
       '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@babel/runtime-corejs3': 7.29.0
       '@babel/traverse': 7.29.0
       '@docusaurus/logger': 3.9.2
@@ -15301,7 +15347,7 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.105.4(esbuild@0.27.2)):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.4)'
       webpack: 5.105.4(esbuild@0.27.2)
 
@@ -15318,13 +15364,13 @@ snapshots:
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 19.2.4
       react-router: 5.3.4(react@19.2.4)
 
   react-router-dom@5.3.4(react@19.2.4):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -15335,7 +15381,7 @@ snapshots:
 
   react-router@5.3.4(react@19.2.4):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0


### PR DESCRIPTION
For https://github.com/developmentseed/deck.gl-raster/issues/142, related to https://github.com/developmentseed/deck.gl-raster/issues/147

### Change list

- Write out a claude-brainstormed spec and claude-brainstormed implementation plan into `dev-docs`
- Write out helper documentation into `gpu-modules.md` from claude's brainstorming
- Create MultiCOGLayer
- Create **`CompositeBands`** shader module that attempts to render textures across multiple resolutions
- Create **`LinearRescale`** shader module to rescale from a `[min, max]` range to `[0, 1]`
- Create `MultiTilesetDescriptor` interface to manage multiple tilesets across the same extent but with different tile grids with different resolutions.
	- This has a `primary` descriptor, which is the highest-resolution source, which defines the tile grid,
	- And one or more "secondary" descriptors for other sources that don't match up with the primary tile grid.
- Create Sentinel-2 example application that supports multiple band combinations across multiple resolutions


### Future work:

- revamp api for customizing rendering of multi-band sources
- debug view for MultiCOGLayer (#410 )
- One possible issue for the Sentinel 2 source is that the tile size **isn't the same for the full resolution as for the overviews**. (Fixed in #411)
- Unit tests with actual sentinel 2 grid from real files. Make sure to test the above.
- fix `byteLength` not defined in tile data errors (Fixed in #413)
- Refactor with/around #404 


<img width="1093" height="862" alt="image" src="https://github.com/user-attachments/assets/82119d5e-434c-4858-aadd-5929a012e1bd" />

<img width="1093" height="851" alt="image" src="https://github.com/user-attachments/assets/ada8dc07-5eb1-4d7e-81c7-6be755d1a328" />

<img width="1086" height="854" alt="image" src="https://github.com/user-attachments/assets/8670d99d-9614-4aff-866d-bc590f81aa1a" />
