### PR TITLE
feat: Debug view for MultiCOGLayer

### DIFF
--- a/examples/sentinel-2/src/App.tsx
+++ b/examples/sentinel-2/src/App.tsx
@@ -69,6 +69,9 @@ const PRESETS: CompositePreset[] = [
 export default function App() {
   const mapRef = useRef<MapRef>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [debug, setDebug] = useState(false);
+  const [debugOpacity, setDebugOpacity] = useState(0.25);
+  const [debugLevel, setDebugLevel] = useState<1 | 2 | 3>(1);
 
   const preset = PRESETS[selectedIndex];
 
@@ -76,6 +79,9 @@ export default function App() {
     id: "sentinel-2-multi",
     sources: preset.sources,
     composite: preset.composite,
+    debug,
+    debugOpacity,
+    debugLevel,
     renderPipeline: [
       { module: LinearRescale, props: { rescaleMin: 0, rescaleMax: 0.05 } },
     ],
@@ -141,6 +147,58 @@ export default function App() {
               </option>
             ))}
           </select>
+          <div style={{ marginTop: "8px" }}>
+            <label style={{ fontSize: "13px", cursor: "pointer" }}>
+              <input
+                type="checkbox"
+                checked={debug}
+                onChange={(e) => setDebug(e.target.checked)}
+                style={{ marginRight: "6px" }}
+              />
+              Debug overlay
+            </label>
+          </div>
+          {debug && (
+            <>
+              <div style={{ marginTop: "4px" }}>
+                <label style={{ fontSize: "12px", color: "#666" }}>
+                  Detail level:{" "}
+                  <select
+                    value={debugLevel}
+                    onChange={(e) =>
+                      setDebugLevel(Number(e.target.value) as 1 | 2 | 3)
+                    }
+                    style={{ padding: "2px", cursor: "pointer" }}
+                  >
+                    <option value={1}>1 — Compact</option>
+                    <option value={2}>2 — Detailed</option>
+                    <option value={3}>3 — Verbose</option>
+                  </select>
+                </label>
+              </div>
+              <div style={{ marginTop: "4px" }}>
+                <label
+                  style={{
+                    fontSize: "12px",
+                    color: "#666",
+                  }}
+                >
+                  Debug Opacity: {debugOpacity.toFixed(2)}
+                  <input
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.01"
+                    value={debugOpacity}
+                    onChange={(e) =>
+                      setDebugOpacity(parseFloat(e.target.value))
+                    }
+                    style={{ width: "100%", cursor: "pointer" }}
+                  />
+                </label>
+              </div>
+            </>
+          )}
           <p style={{ margin: "8px 0 0 0", fontSize: "11px", color: "#999" }}>
             Bands:{" "}
             {Object.entries(preset.sources)

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -13,6 +13,7 @@ import type {
   _Tileset2DProps as Tileset2DProps,
 } from "@deck.gl/geo-layers";
 import { TileLayer } from "@deck.gl/geo-layers";
+import { PathLayer, TextLayer } from "@deck.gl/layers";
 import type {
   Corners,
   MultiTilesetDescriptor,
@@ -72,6 +73,23 @@ const WEB_MERCATOR_METER_CIRCUMFERENCE = 40075016.686;
  */
 const WEB_MERCATOR_TO_WORLD_SCALE =
   TILE_SIZE / WEB_MERCATOR_METER_CIRCUMFERENCE;
+
+/**
+ * Color palette for debug overlays.
+ *
+ * Index 0 is the primary tileset (red outline, white text).
+ * Indices 1+ cycle through distinct colors for secondary tilesets.
+ */
+const DEBUG_COLORS: {
+  outline: [number, number, number, number];
+  text: [number, number, number, number];
+}[] = [
+  { outline: [255, 0, 0, 255], text: [255, 255, 255, 255] }, // primary: red outline, white text
+  { outline: [0, 255, 255, 255], text: [0, 255, 255, 255] }, // cyan
+  { outline: [255, 255, 0, 255], text: [255, 255, 0, 255] }, // yellow
+  { outline: [255, 0, 255, 255], text: [255, 0, 255, 255] }, // magenta
+  { outline: [0, 255, 128, 255], text: [0, 255, 128, 255] }, // lime
+];
 
 /** Data returned per band from tile fetching. */
 interface BandTileData {
@@ -723,7 +741,168 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       }),
     );
 
-    return [rasterLayer];
+    const sublayers: Layer[] = [rasterLayer];
+
+    if (debug && props.data) {
+      sublayers.push(
+        ...this._renderDebugLayers(
+          props.id,
+          props.tile,
+          props.data,
+          forwardTo4326,
+        ),
+      );
+    }
+
+    return sublayers;
+  }
+
+  /**
+   * Render debug overlay layers for a single tile: colored outlines for
+   * primary and secondary tile boundaries, and tiered text labels.
+   *
+   * @param tileId - Base id for sub-layer naming.
+   * @param tile - The tile header with index info.
+   * @param data - The fetched multi-tile result containing debug info.
+   * @param forwardTo4326 - Projection function for converting CRS corners to WGS84.
+   * @returns Array of PathLayer and TextLayer sub-layers.
+   */
+  private _renderDebugLayers(
+    tileId: string,
+    tile: Tile2DHeader<MultiTileResult>,
+    data: MultiTileResult,
+    forwardTo4326: ReprojectionFns["forwardReproject"],
+  ): Layer[] {
+    const layers: Layer[] = [];
+    const debugLevel = this.props.debugLevel ?? 1;
+    const { multiDescriptor } = this.state;
+    if (!multiDescriptor) return layers;
+
+    const { x, y, z } = tile.index;
+    const primaryLevel = multiDescriptor.primary.levels[z];
+    if (!primaryLevel) return layers;
+
+    // --- Primary tile outline and label ---
+    const primaryCrsCorners = primaryLevel.projectedTileCorners(x, y);
+    const { path: primaryPath, center: primaryCenter } = cornersToWgs84Path(
+      primaryCrsCorners,
+      forwardTo4326,
+    );
+
+    const primaryColor = DEBUG_COLORS[0]!;
+
+    layers.push(
+      new PathLayer({
+        id: `${tileId}-debug-primary-outline`,
+        data: [primaryPath],
+        getPath: (d) => d,
+        getColor: primaryColor.outline,
+        getWidth: 2,
+        widthUnits: "pixels",
+        pickable: false,
+      }),
+    );
+
+    // Build primary label text
+    let primaryText = `x=${x} y=${y} z=${z}`;
+    if (debugLevel >= 2) {
+      primaryText += `  ${data.width}x${data.height}`;
+    }
+    if (debugLevel >= 3) {
+      primaryText += `  ${primaryLevel.metersPerPixel.toFixed(1)}m/px`;
+    }
+
+    // Count total label lines for vertical stacking
+    const secondaryNames = data.debugInfo
+      ? [...data.debugInfo.bands.keys()]
+      : [];
+    const totalLines = 1 + secondaryNames.length;
+    const lineSpacing = 18; // pixels
+    const topOffset = ((totalLines - 1) * lineSpacing) / 2;
+
+    layers.push(
+      new TextLayer({
+        id: `${tileId}-debug-primary-label`,
+        data: [
+          {
+            position: primaryCenter,
+            text: primaryText,
+          },
+        ],
+        getColor: primaryColor.text,
+        getSize: 14,
+        getPixelOffset: [0, -topOffset],
+        sizeUnits: "pixels",
+        outlineWidth: 3,
+        outlineColor: [0, 0, 0, 255],
+        fontSettings: { sdf: true },
+      }),
+    );
+
+    // --- Secondary tile outlines and labels ---
+    if (!data.debugInfo) return layers;
+
+    let secondaryIdx = 0;
+    for (const [name, info] of data.debugInfo.bands) {
+      const colorEntry =
+        DEBUG_COLORS[1 + (secondaryIdx % (DEBUG_COLORS.length - 1))]!;
+
+      // Draw outline for each secondary tile
+      for (let i = 0; i < info.secondaryTileCorners.length; i++) {
+        const { path: secondaryPath } = cornersToWgs84Path(
+          info.secondaryTileCorners[i]!,
+          forwardTo4326,
+        );
+
+        layers.push(
+          new PathLayer({
+            id: `${tileId}-debug-${name}-outline-${i}`,
+            data: [secondaryPath],
+            getPath: (d) => d,
+            getColor: colorEntry.outline,
+            getWidth: 2,
+            widthUnits: "pixels",
+            pickable: false,
+          }),
+        );
+      }
+
+      // Build secondary label text
+      const mpp = info.metersPerPixel.toFixed(1);
+      let labelText = `${name}: ${mpp}m z=${info.secondaryZ}`;
+      if (debugLevel >= 2) {
+        const uv = info.uvTransform;
+        labelText += `  uv=[${uv.map((v) => v.toFixed(2)).join(",")}]  ${info.tileCount} tiles`;
+      }
+      if (debugLevel >= 3) {
+        labelText += `  stitch=${info.stitchedWidth}x${info.stitchedHeight}`;
+      }
+
+      const lineOffset = -topOffset + (1 + secondaryIdx) * lineSpacing;
+
+      layers.push(
+        new TextLayer({
+          id: `${tileId}-debug-${name}-label`,
+          data: [
+            {
+              position: primaryCenter,
+              text: labelText,
+            },
+          ],
+          getColor: colorEntry.text,
+          getSize: 12,
+          getPixelOffset: [0, lineOffset],
+          sizeUnits: "pixels",
+          outlineWidth: 2,
+          outlineColor: [0, 0, 0, 255],
+          fontSettings: { sdf: true },
+        }),
+      );
+
+      secondaryIdx++;
+    }
+
+    return layers;
   }
 
   /**
@@ -872,4 +1051,36 @@ function createBandTexture(device: Device, array: RasterArray): Texture {
     height,
     sampler: { minFilter: "linear", magFilter: "linear" },
   });
+}
+
+/**
+ * Project CRS tile corners to WGS84 and return a closed path suitable for
+ * PathLayer, plus the center point for label placement.
+ *
+ * @param corners - Tile corners in the source CRS.
+ * @param projectTo4326 - Projection function from source CRS to WGS84.
+ * @returns A closed `[topLeft, topRight, bottomRight, bottomLeft, topLeft]`
+ *   path and the geographic center.
+ */
+function cornersToWgs84Path(
+  corners: Corners,
+  projectTo4326: ReprojectionFns["forwardReproject"],
+): { path: [number, number][]; center: [number, number] } {
+  const topLeft = projectTo4326(corners.topLeft[0], corners.topLeft[1]);
+  const topRight = projectTo4326(corners.topRight[0], corners.topRight[1]);
+  const bottomRight = projectTo4326(
+    corners.bottomRight[0],
+    corners.bottomRight[1],
+  );
+  const bottomLeft = projectTo4326(
+    corners.bottomLeft[0],
+    corners.bottomLeft[1],
+  );
+  return {
+    path: [topLeft, topRight, bottomRight, bottomLeft, topLeft],
+    center: [
+      (topLeft[0] + bottomRight[0]) / 2,
+      (topLeft[1] + bottomRight[1]) / 2,
+    ],
+  };
 }

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -18,6 +18,7 @@ import type {
   RasterModule,
   TilesetDescriptor,
   TilesetLevel,
+  UvTransform,
 } from "@developmentseed/deck.gl-raster";
 import {
   createMultiTilesetDescriptor,
@@ -70,34 +71,6 @@ const WEB_MERCATOR_METER_CIRCUMFERENCE = 40075016.686;
  */
 const WEB_MERCATOR_TO_WORLD_SCALE =
   TILE_SIZE / WEB_MERCATOR_METER_CIRCUMFERENCE;
-
-/**
- * UV transform mapping primary tile UV space to the correct sub-region of a
- * band texture.
- *
- * Applied in the shader as: `sampledUV = uv * [scaleX, scaleY] + [offsetX, offsetY]`
- *
- * For primary-grid bands this is the identity `[0, 0, 1, 1]`.
- * For secondary bands it accounts for resolution and alignment differences.
- */
-interface UvTransform {
-  /** Horizontal offset: left edge of the primary tile within the band texture, in UV units. */
-  offsetX: number;
-  /** Vertical offset: top edge of the primary tile within the band texture, in UV units. */
-  offsetY: number;
-  /** Horizontal scale: fraction of the band texture width covered by the primary tile. */
-  scaleX: number;
-  /** Vertical scale: fraction of the band texture height covered by the primary tile. */
-  scaleY: number;
-}
-
-/**
- * Convert the `[offsetX, offsetY, scaleX, scaleY]` tuple returned by
- * {@link resolveSecondaryTiles} into the named {@link UvTransform} form.
- */
-function tupleToUvTransform(t: [number, number, number, number]): UvTransform {
-  return { offsetX: t[0], offsetY: t[1], scaleX: t[2], scaleY: t[3] };
-}
 
 /** Data returned per band from tile fetching. */
 interface BandTileData {
@@ -463,7 +436,7 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       name,
       {
         texture,
-        uvTransform: { offsetX: 0, offsetY: 0, scaleX: 1, scaleY: 1 },
+        uvTransform: [0, 0, 1, 1],
         width: tile.array.width,
         height: tile.array.height,
       },
@@ -544,7 +517,7 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       name,
       {
         texture,
-        uvTransform: tupleToUvTransform(resolution.uvTransform),
+        uvTransform: resolution.uvTransform,
         width: assembled.width,
         height: assembled.height,
       },

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -184,11 +184,41 @@ export type MultiCOGLayerProps = CompositeLayerProps &
      * AbortSignal to cancel loading of all sources.
      */
     signal?: AbortSignal;
+
+    /**
+     * Enable debug overlay showing tile boundaries and metadata labels
+     * for all tilesets.
+     *
+     * @default false
+     */
+    debug?: boolean;
+
+    /**
+     * Opacity of the reprojection mesh debug overlay. Only used when
+     * `debug` is `true`. Forwarded to the underlying {@link RasterLayer}.
+     *
+     * @default 0.5
+     */
+    debugOpacity?: number;
+
+    /**
+     * Controls how much detail is shown in debug text labels.
+     *
+     * - `1`: tile index and resolution only
+     * - `2`: adds UV transform and tile count
+     * - `3`: adds stitched dimensions and meters/pixel
+     *
+     * @default 1
+     */
+    debugLevel?: 1 | 2 | 3;
   };
 
 const defaultProps = {
   epsgResolver: { type: "accessor" as const, value: defaultEpsgResolver },
   maxError: { type: "number" as const, value: 0.125 },
+  debug: { type: "boolean" as const, value: false },
+  debugOpacity: { type: "number" as const, value: 0.5 },
+  debugLevel: { type: "number" as const, value: 1 },
 };
 
 /**
@@ -543,7 +573,7 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
     forwardTo3857: ReprojectionFns["forwardReproject"],
     inverseFrom3857: ReprojectionFns["inverseReproject"],
   ): Layer | LayersList | null {
-    const { maxError } = this.props;
+    const { maxError, debug, debugOpacity } = this.props;
 
     if (!props.data) {
       return null;
@@ -622,6 +652,8 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
         renderPipeline,
         maxError,
         reprojectionFns,
+        debug,
+        debugOpacity,
         ...deckProjectionProps,
       }),
     );

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -14,6 +14,7 @@ import type {
 } from "@deck.gl/geo-layers";
 import { TileLayer } from "@deck.gl/geo-layers";
 import type {
+  Corners,
   MultiTilesetDescriptor,
   RasterModule,
   TilesetDescriptor,
@@ -84,6 +85,30 @@ interface BandTileData {
   height: number;
 }
 
+/** Debug metadata for a secondary band, collected during tile fetching. */
+interface BandDebugInfo {
+  /** CRS corners of each secondary tile fetched (for drawing outlines). */
+  secondaryTileCorners: Corners[];
+  /** Secondary zoom level index selected. */
+  secondaryZ: number;
+  /** UV transform applied to this band. */
+  uvTransform: UvTransform;
+  /** Stitched texture width in pixels. */
+  stitchedWidth: number;
+  /** Stitched texture height in pixels. */
+  stitchedHeight: number;
+  /** Number of secondary tiles fetched. */
+  tileCount: number;
+  /** Meters per pixel at the selected secondary level. */
+  metersPerPixel: number;
+}
+
+/** Debug info for all bands of a single primary tile. */
+interface MultiTileDebugInfo {
+  /** Per-band debug metadata, keyed by source name. Only secondary bands. */
+  bands: Map<string, BandDebugInfo>;
+}
+
 /** Result of {@link MultiCOGLayer._getTileData} -- all band textures plus reprojection functions. */
 interface MultiTileResult {
   /** Per-band texture data, keyed by source name. */
@@ -96,6 +121,8 @@ interface MultiTileResult {
   width: number;
   /** Height of the primary tile in pixels. */
   height: number;
+  /** Only present when `debug: true`. */
+  debugInfo?: MultiTileDebugInfo;
 }
 
 /**
@@ -378,7 +405,9 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
     const primaryLevel = multiDescriptor!.primary.levels[z]!;
 
     // Collect fetch promises for all bands
-    const bandPromises: Array<Promise<[string, BandTileData]>> = [];
+    const bandPromises: Array<
+      Promise<[string, BandTileData, BandDebugInfo | null]>
+    > = [];
 
     for (const [name, sourceState] of sources!) {
       const descriptor =
@@ -417,13 +446,26 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
             pool,
             signal: combinedSignal,
             device,
+            debug: this.props.debug ?? false,
           }),
         );
       }
     }
 
     const bandEntries = await Promise.all(bandPromises);
-    const bands = new Map(bandEntries);
+    const bands = new Map(bandEntries.map(([name, data]) => [name, data]));
+
+    // Collect debug info from secondary bands
+    let debugInfo: MultiTileDebugInfo | undefined;
+    if (this.props.debug) {
+      const debugBands = new Map<string, BandDebugInfo>();
+      for (const [name, , bandDebug] of bandEntries) {
+        if (bandDebug) {
+          debugBands.set(name, bandDebug);
+        }
+      }
+      debugInfo = { bands: debugBands };
+    }
 
     return {
       bands,
@@ -431,13 +473,15 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       inverseTransform,
       width: primaryLevel.tileWidth,
       height: primaryLevel.tileHeight,
+      debugInfo,
     };
   }
 
   /**
    * Fetch a single tile for a source that shares the primary tile grid.
    *
-   * @returns A `[name, BandTileData]` tuple with identity UV transform.
+   * @returns A `[name, BandTileData, null]` tuple with identity UV transform
+   *   and no debug info (primary bands don't need it).
    */
   private async _fetchPrimaryBand(
     name: string,
@@ -450,7 +494,7 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       signal: AbortSignal | undefined;
       device: Device;
     },
-  ): Promise<[string, BandTileData]> {
+  ): Promise<[string, BandTileData, BandDebugInfo | null]> {
     const { x, y, z, pool, signal, device } = opts;
     const image = selectImage(sourceState.geotiff, z);
 
@@ -470,6 +514,7 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
         width: tile.array.width,
         height: tile.array.height,
       },
+      null,
     ];
   }
 
@@ -477,7 +522,8 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
    * Fetch covering tiles for a secondary source and stitch them into a
    * single texture using {@link assembleTiles}.
    *
-   * @returns A `[name, BandTileData]` tuple with the computed UV transform.
+   * @returns A `[name, BandTileData, BandDebugInfo | null]` tuple with the
+   *   computed UV transform and optional debug metadata.
    */
   private async _fetchSecondaryBand(
     name: string,
@@ -491,8 +537,9 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       pool: DecoderPool;
       signal: AbortSignal | undefined;
       device: Device;
+      debug: boolean;
     },
-  ): Promise<[string, BandTileData]> {
+  ): Promise<[string, BandTileData, BandDebugInfo | null]> {
     const {
       descriptor,
       primaryLevel,
@@ -518,6 +565,23 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       secondaryLevel,
       secondaryZ,
     );
+
+    // Collect debug info if requested
+    let debugInfo: BandDebugInfo | null = null;
+    if (opts.debug) {
+      const secondaryTileCorners = resolution.tileIndices.map((idx) =>
+        secondaryLevel.projectedTileCorners(idx.x, idx.y),
+      );
+      debugInfo = {
+        secondaryTileCorners,
+        secondaryZ,
+        uvTransform: resolution.uvTransform,
+        stitchedWidth: resolution.stitchedWidth,
+        stitchedHeight: resolution.stitchedHeight,
+        tileCount: resolution.tileIndices.length,
+        metersPerPixel: secondaryLevel.metersPerPixel,
+      };
+    }
 
     // Fetch all covering tiles via fetchTiles
     const image = selectImage(sourceState.geotiff, secondaryZ);
@@ -551,6 +615,7 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
         width: assembled.width,
         height: assembled.height,
       },
+      debugInfo,
     ];
   }
 

--- a/packages/deck.gl-raster/src/gpu-modules/composite-bands.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/composite-bands.ts
@@ -1,5 +1,6 @@
 import type { Texture } from "@luma.gl/core";
 import type { ShaderModule } from "@luma.gl/shadertools";
+import type { UvTransform } from "../multi-raster-tileset/index.js";
 
 /**
  * Maximum number of band texture slots supported by {@link CompositeBands}.
@@ -17,10 +18,10 @@ export type CompositeBandsProps = {
   band1: Texture;
   band2: Texture;
   band3: Texture;
-  uvTransform0: [number, number, number, number];
-  uvTransform1: [number, number, number, number];
-  uvTransform2: [number, number, number, number];
-  uvTransform3: [number, number, number, number];
+  uvTransform0: UvTransform;
+  uvTransform1: UvTransform;
+  uvTransform2: UvTransform;
+  uvTransform3: UvTransform;
   channelMap: [number, number, number, number];
 };
 
@@ -122,12 +123,7 @@ export function buildCompositeBandsProps(
     string,
     {
       texture: Texture;
-      uvTransform: {
-        offsetX: number;
-        offsetY: number;
-        scaleX: number;
-        scaleY: number;
-      };
+      uvTransform: UvTransform;
     }
   >,
 ): Partial<CompositeBandsProps> {
@@ -174,14 +170,8 @@ export function buildCompositeBandsProps(
     if (!band) {
       throw new Error(`Band "${name}" not found in fetched bands`);
     }
-    const uv = band.uvTransform;
     props[`band${slot}`] = band.texture;
-    props[`uvTransform${slot}`] = [
-      uv.offsetX,
-      uv.offsetY,
-      uv.scaleX,
-      uv.scaleY,
-    ];
+    props[`uvTransform${slot}`] = band.uvTransform;
   }
 
   // Fill unused slots with the first texture as a placeholder

--- a/packages/deck.gl-raster/src/index.ts
+++ b/packages/deck.gl-raster/src/index.ts
@@ -5,6 +5,7 @@ export type {
   MultiTilesetDescriptor,
   SecondaryTileIndex,
   SecondaryTileResolution,
+  UvTransform,
 } from "./multi-raster-tileset/index.js";
 export {
   createMultiTilesetDescriptor,

--- a/packages/deck.gl-raster/src/multi-raster-tileset/index.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/index.ts
@@ -10,5 +10,6 @@ export {
 export type {
   SecondaryTileIndex,
   SecondaryTileResolution,
+  UvTransform,
 } from "./secondary-tile-resolver.js";
 export { resolveSecondaryTiles } from "./secondary-tile-resolver.js";

--- a/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
@@ -1,6 +1,27 @@
 import type { TilesetLevel } from "../raster-tileset/tileset-interface.js";
 
 /**
+ * UV transform mapping primary tile UV space to the correct sub-region of a
+ * band texture.
+ *
+ * Applied in the shader as: `sampledUV = uv * [scaleX, scaleY] + [offsetX, offsetY]`
+ *
+ * Defined as a tuple so it can be uploaded directly to the GPU as a vec4 uniform.
+ *
+ * Elements:
+ * - `offsetX` — horizontal offset: left edge of the primary tile within the band texture, in UV units
+ * - `offsetY` — vertical offset: top edge of the primary tile within the band texture, in UV units
+ * - `scaleX` — horizontal scale: fraction of the band texture width covered by the primary tile
+ * - `scaleY` — vertical scale: fraction of the band texture height covered by the primary tile
+ */
+export type UvTransform = [
+  offsetX: number,
+  offsetY: number,
+  scaleX: number,
+  scaleY: number,
+];
+
+/**
  * A tile index in a secondary tileset.
  *
  * Uses `x`/`y` naming to match {@link TileIndex} convention.
@@ -42,7 +63,7 @@ export interface SecondaryTileResolution {
    * - `scaleX`, `scaleY`: fraction of the stitched texture covered by the
    *   primary tile.
    */
-  uvTransform: [number, number, number, number];
+  uvTransform: UvTransform;
 
   /**
    * The total stitched texture width in pixels.

--- a/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
@@ -14,7 +14,7 @@ import type { TilesetLevel } from "../raster-tileset/tileset-interface.js";
  * - `scaleX` — horizontal scale: fraction of the band texture width covered by the primary tile
  * - `scaleY` — vertical scale: fraction of the band texture height covered by the primary tile
  */
-export type UvTransform = [
+export type UvTransform = readonly [
   offsetX: number,
   offsetY: number,
   scaleX: number,

--- a/packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts
+++ b/packages/deck.gl-raster/tests/gpu-modules/composite-bands.test.ts
@@ -35,7 +35,7 @@ describe("CompositeBands", () => {
 
 describe("buildCompositeBandsProps", () => {
   const mockTexture = (id: string) => ({ id }) as unknown as Texture;
-  const identityUv = { offsetX: 0, offsetY: 0, scaleX: 1, scaleY: 1 };
+  const identityUv = [0, 0, 1, 1] as const;
 
   it("maps RGB bands to slots 0, 1, 2", () => {
     const bands = new Map([
@@ -74,12 +74,7 @@ describe("buildCompositeBandsProps", () => {
   });
 
   it("passes UV transforms to correct slots", () => {
-    const customUv = {
-      offsetX: 0.1,
-      offsetY: 0.2,
-      scaleX: 0.5,
-      scaleY: 0.5,
-    };
+    const customUv = [0.1, 0.2, 0.5, 0.5] as const;
     const bands = new Map([
       ["nir", { texture: mockTexture("nir"), uvTransform: customUv }],
       ["red", { texture: mockTexture("red"), uvTransform: identityUv }],


### PR DESCRIPTION
For https://github.com/developmentseed/deck.gl-raster/issues/142, related to https://github.com/developmentseed/deck.gl-raster/issues/147


### Change list

- Introduce `UvTransform` named tuple type (`readonly [offsetX, offsetY, scaleX, scaleY]`) as a shared type in `deck.gl-raster`
	- This replaces the bare `[number, number, number, number]` type, which makes it hard to know what each item is doing.
- Add `debug`, `debugOpacity`, and `debugLevel` props to `MultiCOGLayer`
- Preserve secondary tile CRS corners and metadata during fetch when `debug: true`
- Render color-coded tile boundary outlines per tileset (red for primary, cyan/yellow/magenta/lime for secondaries) using PathLayer
- Render tiered text labels at tile centers using TextLayer, with 3 verbosity levels:
  - Level 1: tile index + resolution
  - Level 2: + UV transform + tile count
  - Level 3: + stitched dimensions + meters/pixel
- Forward `debug`/`debugOpacity` to RasterLayer for reprojection mesh overlay
- Add debug toggle checkbox, detail level selector, and opacity slider to Sentinel-2 example app

### Future work

- UV transform sub-region visualizer
- Interactive toggling of individual tileset overlays


<img width="1221" height="854" alt="image" src="https://github.com/user-attachments/assets/b3616631-a7c2-4081-af95-49ba020ec372" />

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/503d9bb4-35ba-4074-bd00-5cd361b91d19" />

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/e72ffa57-8ed8-45b2-b0ea-9cbb8f440873" />

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/58ebc5a1-ce06-429b-a068-572a5b83de43" />

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/aebf670e-cdad-4543-9d8f-0928e4883cd5" />
