### PR TITLE
fix: Fix edge tile rendering in MultiCOGLayer

### DIFF
--- a/dev-docs/boundless-tiles.md
+++ b/dev-docs/boundless-tiles.md
@@ -2,7 +2,7 @@
 
 ## Preference: `boundless: true`
 
-When fetching tiles from GeoTIFFs, we prefer `boundless: true` so that all tiles — including edge tiles — are returned at the full nominal tile size (e.g., 1024x1024). Edge tiles that extend beyond the image extent are zero-padded.
+When fetching tiles from GeoTIFFs, we prefer `boundless: true` so that all tiles — including edge tiles — are returned at the full nominal tile size (e.g., 1024x1024). Edge tiles that extend beyond the image extent are padded by the COG encoder, typically with the nodata value or accompanied by an internal nodata mask.
 
 ## Why
 
@@ -13,7 +13,7 @@ With `boundless: false`, edge tiles are clipped to the valid pixel region (e.g.,
 
 ## Nodata Masking
 
-With `boundless: true`, padding pixels contain zeros (or whatever fill value the TIFF uses). These must be masked out during rendering so they don't appear as black borders.
+With `boundless: true`, padding pixels in edge tiles are filled by the COG encoder — typically with the declared nodata value, or marked as invalid via an internal mask IFD. These must be masked out during rendering so they don't appear as visible borders.
 
 Two mechanisms exist for this:
 

--- a/dev-docs/boundless-tiles.md
+++ b/dev-docs/boundless-tiles.md
@@ -1,0 +1,23 @@
+# Boundless Tile Fetching
+
+## Preference: `boundless: true`
+
+When fetching tiles from GeoTIFFs, we prefer `boundless: true` so that all tiles — including edge tiles — are returned at the full nominal tile size (e.g., 1024x1024). Edge tiles that extend beyond the image extent are zero-padded.
+
+## Why
+
+With `boundless: false`, edge tiles are clipped to the valid pixel region (e.g., 740x1024 for a 10980px image with 1024px tiles). This creates problems:
+
+- **Uniform tile dimensions simplify UV transforms.** Cross-resolution stitching in `MultiCOGLayer` assumes consistent tile sizes when computing UV transforms between primary and secondary tilesets. Variable edge tile sizes would require per-tile special-casing.
+- **The reprojection mesh expects tiles to match `tileWidth`/`tileHeight`.** The affine transform from `tileTransform` maps pixel coordinates to CRS coordinates assuming the full tile size. A clipped tile creates a mismatch between the texture dimensions and the mesh extent.
+
+## Nodata Masking
+
+With `boundless: true`, padding pixels contain zeros (or whatever fill value the TIFF uses). These must be masked out during rendering so they don't appear as black borders.
+
+Two mechanisms exist for this:
+
+1. **Nodata value filtering** — The `FilterNoDataVal` GPU module discards pixels matching a scalar nodata value. Used when the GeoTIFF declares a nodata value in its metadata.
+2. **Internal mask (alpha band)** — Some GeoTIFFs include a separate mask IFD. The mask band is sampled alongside the data and used to set pixel alpha to 0 for invalid regions.
+
+`COGLayer` already implements both of these in its render pipeline (`render-pipeline.ts`). `MultiCOGLayer` does not yet have nodata masking — edge tiles currently render with a visible black border.

--- a/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
@@ -222,7 +222,6 @@ function createUnormPipeline(
     };
   };
   const renderTile = (tileData: TextureDataT): RenderTileResult => {
-    console.log("renderPipeline renderTile", renderPipeline);
     return {
       renderPipeline: renderPipeline.map((m, _i) => resolveModule(m, tileData)),
     };

--- a/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
@@ -155,7 +155,7 @@ function createUnormPipeline(
   ) => {
     const { device, x, y, signal, pool } = options;
     const tile = await image.fetchTile(x, y, {
-      boundless: true,
+      boundless: false,
       pool,
       signal,
     });
@@ -222,6 +222,7 @@ function createUnormPipeline(
     };
   };
   const renderTile = (tileData: TextureDataT): RenderTileResult => {
+    console.log("renderPipeline renderTile", renderPipeline);
     return {
       renderPipeline: renderPipeline.map((m, _i) => resolveModule(m, tileData)),
     };

--- a/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
@@ -155,7 +155,7 @@ function createUnormPipeline(
   ) => {
     const { device, x, y, signal, pool } = options;
     const tile = await image.fetchTile(x, y, {
-      boundless: false,
+      boundless: true,
       pool,
       signal,
     });

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -517,7 +517,7 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
     const image = selectImage(sourceState.geotiff, z);
 
     const tile = await image.fetchTile(x, y, {
-      boundless: false,
+      boundless: true,
       pool,
       signal,
     });
@@ -608,7 +608,7 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       idx.y,
     ]);
     const tiles = await image.fetchTiles(xy, {
-      boundless: false,
+      boundless: true,
       pool,
       signal,
     });


### PR DESCRIPTION
For https://github.com/developmentseed/deck.gl-raster/issues/142, related to https://github.com/developmentseed/deck.gl-raster/issues/147


### Change list

- Set `boundless: true` in `MultiCOGLayer` fetches. This ensures that the `uvTransform` is accurate across the last tile, instead of being clipped. This is why the screenshots in https://github.com/developmentseed/deck.gl-raster/pull/410 looked so bad. 
- Added context about using `boundless: true` in the dev doc

In the future we'll have to add support for nodata filtering and mask filtering, etc, for these multi-cog datasets

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/0dc2ebae-01b6-413e-8b96-0534ac462006" />

<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/ace05478-3ae7-49e4-a406-919c782977dc" />
