### PR TITLE
fix: Ensure we reset state when changing sources in MultiCOGLayer

### DIFF
--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -307,8 +307,19 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
     });
   }
 
-  override updateState({ changeFlags }: UpdateParameters<this>): void {
-    if (changeFlags.dataChanged || changeFlags.propsChanged) {
+  override updateState({
+    changeFlags,
+    props,
+    oldProps,
+  }: UpdateParameters<this>): void {
+    if (changeFlags.dataChanged || props.sources !== oldProps.sources) {
+      // Reset state so renderLayers() returns null while we re-open COGs.
+      // Without this, the TileLayer renders with new props but stale state,
+      // caching tiles with the wrong bands.
+      this.setState({
+        sources: null,
+        multiDescriptor: null,
+      });
       this._parseAllSources();
     }
   }
@@ -492,6 +503,10 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
     const byteLength = [...bands.values()].reduce(
       (sum, band) => sum + band.byteLength,
       0,
+    );
+
+    console.log(
+      `Tile (${x}, ${y}, ${z}): fetched bands [${[...bands.keys()].join(", ")}], total byte length: ${byteLength}`,
     );
 
     return {


### PR DESCRIPTION
For https://github.com/developmentseed/deck.gl-raster/issues/142, related to https://github.com/developmentseed/deck.gl-raster/issues/147


Previously, switching sources rendered old data. Now, we correctly render the latest data whenever we switch sources.

https://github.com/user-attachments/assets/a59f8b29-de48-4328-9345-bfab56d66235

**Root cause:** `_parseAllSources()` is async, but `renderLayers()` runs synchronously after `updateState`. The new `TileLayer` was created with new props-derived `sourceUrls` in its id/updateTriggers, causing tile re-fetches. But `_getTileData` read band data from `this.state.sources` which still held the **old** source map. Tiles were cached under the new `TileLayer` with wrong band names, and when `_parseAllSources` finally completed, the cached tiles persisted — causing `_renderSubLayers` to return `null` (required bands missing).
