### PR TITLE
feat: Filter out nodata pixels in Sentinel-2 example

### DIFF
--- a/examples/sentinel-2/src/App.tsx
+++ b/examples/sentinel-2/src/App.tsx
@@ -1,7 +1,10 @@
 import type { MapboxOverlayProps } from "@deck.gl/mapbox";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import { MultiCOGLayer } from "@developmentseed/deck.gl-geotiff";
-import { LinearRescale } from "@developmentseed/deck.gl-raster/gpu-modules";
+import {
+  FilterNoDataVal,
+  LinearRescale,
+} from "@developmentseed/deck.gl-raster/gpu-modules";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useRef, useState } from "react";
 import type { MapRef } from "react-map-gl/maplibre";
@@ -83,6 +86,7 @@ export default function App() {
     debugOpacity,
     debugLevel,
     renderPipeline: [
+      { module: FilterNoDataVal, props: { noDataValue: 0 } },
       { module: LinearRescale, props: { rescaleMin: 0, rescaleMax: 0.05 } },
     ],
   });


### PR DESCRIPTION
Discard any nodata pixels from rendering, to remove the black borders around the image.