### PR TITLE
fix: Turn off lighting/`material` by default

### DIFF
--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -25,6 +25,13 @@ const defaultProps: DefaultProps<
   // labels in interleaved mode 🤷‍♂️
   // image: { type: "image", value: null, async: true },
   renderPipeline: { type: "array", value: [], compare: true },
+  // Disable lighting by default (avoids darkening raster)
+  material: {
+    ambient: 1.0,
+    diffuse: 0.0,
+    shininess: 0,
+    specularColor: [0, 0, 0],
+  },
 };
 
 /**


### PR DESCRIPTION
Closes https://github.com/developmentseed/deck.gl-raster/issues/420

Thanks for the hint @rkaravia.

Before and after:

<img width="1499" height="913" alt="image" src="https://github.com/user-attachments/assets/f2499271-4173-4c36-8389-5524ef445802" />
