### PR TITLE
ci: Apply typechecking to source packages on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - run: |
           pnpm install
           pnpm build
-          pnpm -r --filter="./examples/*" typecheck
+          pnpm -r --filter="!docs" typecheck
           pnpm test
           pnpm publint
 

--- a/packages/deck.gl-geotiff/package.json
+++ b/packages/deck.gl-geotiff/package.json
@@ -40,6 +40,7 @@
     "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
   },
   "devDependencies": {
+    "@chunkd/source-file": "^11.0.2",
     "@types/node": "^25.3.3",
     "jsdom": "^28.1.0",
     "typescript": "^6.0.2",

--- a/packages/deck.gl-geotiff/tests/helpers.ts
+++ b/packages/deck.gl-geotiff/tests/helpers.ts
@@ -1,12 +1,10 @@
-// This file is duplicated in packages/deck.gl-geotiff/tests/helpers.ts. We
-// can't share it across packages because composite project references
-// require every imported file to have an emitted .d.ts in the referenced
-// project's outDir, and tsconfig.build.json excludes tests/ from emission.
+// This file is duplicated from packages/geotiff/tests/helpers.ts. We can't
+// share it across packages because composite project references require
+// every imported file to have an emitted .d.ts in the referenced project's
+// outDir, and tsconfig.build.json excludes tests/ from emission.
 import { resolve } from "node:path";
 import { SourceFile } from "@chunkd/source-file";
 import { GeoTIFF } from "@developmentseed/geotiff";
-
-// ── Fixture helpers ─────────────────────────────────────────────────────
 
 const FIXTURES_DIR = resolve(
   import.meta.dirname,

--- a/packages/deck.gl-geotiff/tests/render-pipeline.test.ts
+++ b/packages/deck.gl-geotiff/tests/render-pipeline.test.ts
@@ -1,8 +1,8 @@
 import type { RasterModule } from "@developmentseed/deck.gl-raster";
 import type { GeoTIFF } from "@developmentseed/geotiff";
 import { describe, expect, it } from "vitest";
-import { loadGeoTIFF } from "../../geotiff/tests/helpers.js";
 import { inferRenderPipeline } from "../src/geotiff/render-pipeline";
+import { loadGeoTIFF } from "./helpers.js";
 
 const MOCK_DEVICE = {
   createTexture: (x: any) => x,

--- a/packages/geotiff/tests/array.test.ts
+++ b/packages/geotiff/tests/array.test.ts
@@ -1,4 +1,5 @@
 import type { Affine } from "@developmentseed/affine";
+import type { GeographicCRS } from "@developmentseed/proj";
 import { describe, expect, it } from "vitest";
 import type {
   RasterArrayBandSeparate,
@@ -10,7 +11,6 @@ import {
   toBandSeparate,
   toPixelInterleaved,
 } from "../src/array.js";
-import type { GeographicCRS } from "../src/crs.js";
 
 const EPSG_4326: GeographicCRS = {
   $schema: "https://proj.org/schemas/v0.7/projjson.schema.json",

--- a/packages/geotiff/tests/crs.test.ts
+++ b/packages/geotiff/tests/crs.test.ts
@@ -100,7 +100,8 @@ describe("test GeoKey CRS parsing", () => {
 
     // Verify wkt-parser can consume our PROJJSON and extract the fields
     // needed for TileMatrixSet construction (semi-major axis, units).
-    if (typeof crs === "number") throw new Error("expected PROJJSON, got EPSG code");
+    if (typeof crs === "number")
+      throw new Error("expected PROJJSON, got EPSG code");
     const proj = parseWkt(crs);
     expect(proj.a).toBe(6378137);
     expect(proj.units).toBe("meter");

--- a/packages/geotiff/tests/crs.test.ts
+++ b/packages/geotiff/tests/crs.test.ts
@@ -100,6 +100,7 @@ describe("test GeoKey CRS parsing", () => {
 
     // Verify wkt-parser can consume our PROJJSON and extract the fields
     // needed for TileMatrixSet construction (semi-major axis, units).
+    if (typeof crs === "number") throw new Error("expected PROJJSON, got EPSG code");
     const proj = parseWkt(crs);
     expect(proj.a).toBe(6378137);
     expect(proj.units).toBe("meter");

--- a/packages/geotiff/tests/integration.test.ts
+++ b/packages/geotiff/tests/integration.test.ts
@@ -9,11 +9,11 @@
  * are intentionally omitted here.
  */
 
+import type { GeoTIFF } from "@developmentseed/geotiff";
 import type { GeoTIFFImage, GeoTIFF as GeotiffJs } from "geotiff";
 import { fromFile } from "geotiff";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { toBandSeparate } from "../src/array.js";
-import type { GeoTIFF } from "../src/geotiff.js";
 import { fixturePath, loadGeoTIFF } from "./helpers.js";
 
 const FIXTURES = [

--- a/packages/geotiff/tests/tile-matrix-set.test.ts
+++ b/packages/geotiff/tests/tile-matrix-set.test.ts
@@ -1,12 +1,11 @@
+import { GeoTIFF, generateTileMatrixSet } from "@developmentseed/geotiff";
 import { parseWkt } from "@developmentseed/proj";
 import { describe, expect, it } from "vitest";
-import { GeoTIFF } from "../src/geotiff.js";
-import { generateTileMatrixSet } from "../src/tile-matrix-set.js";
 import { loadGeoTIFF } from "./helpers.js";
 
 const EPSG_4326 = {
   $schema: "https://proj.org/schemas/v0.7/projjson.schema.json",
-  type: "GeographicCRS",
+  type: "GeographicCRS" as const,
   name: "WGS 84",
   datum_ensemble: {
     name: "World Geodetic System 1984 ensemble",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,9 @@ importers:
         specifier: ^2.20.8
         version: 2.20.8
     devDependencies:
+      '@chunkd/source-file':
+        specifier: ^11.0.2
+        version: 11.0.2
       '@types/node':
         specifier: ^25.3.3
         version: 25.3.3


### PR DESCRIPTION
https://github.com/developmentseed/deck.gl-raster/pull/427 applied typechecking on CI to examples but we also need to type-check source packages.