### PR TITLE
ci: deploy docs only on release tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,10 @@ name: Deploy Docs
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
+      - "!v*-alpha*"
+      - "!v*-beta*"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Only deploy docs on non-alpha/beta release tags.

Closes https://github.com/developmentseed/deck.gl-raster/issues/416