### PR TITLE
feat: Support reversing colormaps on the GPU

### DIFF
--- a/docs/superpowers/specs/2026-04-20-colormap-reversed-design.md
+++ b/docs/superpowers/specs/2026-04-20-colormap-reversed-design.md
@@ -48,9 +48,11 @@ color = texture(colormapTexture, vec2(idx, 0.));
 ```ts
 getUniforms: (props: Partial<ColormapProps>) => ({
   colormapTexture: props.colormapTexture,
-  reversed: props.reversed ? 1.0 : 0.0,
+  reversed: props.reversed ?? false,
 })
 ```
+
+The return is a boolean, not `1.0 / 0.0`, because `ShaderModule<PropsT>` derives the uniform return type from `PropsT` via `PickUniforms` — so a `boolean` prop forces a `boolean` return. luma.gl accepts booleans for `f32` uniforms and coerces them to 0.0/1.0 at runtime; this matches luma.gl's own `picking` module (`isActive: false` with `uniformTypes.isActive: "f32"`).
 
 ## Tests
 
@@ -60,9 +62,9 @@ New file `packages/deck.gl-raster/tests/gpu-modules/colormap.test.ts`, matching 
 - `inject["fs:#decl"]` declares the `colormapTexture` sampler.
 - `inject["fs:DECKGL_FILTER_COLOR"]` contains the `mix(...)` expression and the `texture(colormapTexture, ...)` call.
 - `uniformTypes.reversed === "f32"`.
-- `getUniforms({ reversed: true }).reversed === 1.0`.
-- `getUniforms({ reversed: false }).reversed === 0.0`.
-- `getUniforms({}).reversed === 0.0` (default).
+- `getUniforms({ reversed: true }).reversed === true`.
+- `getUniforms({ reversed: false }).reversed === false`.
+- `getUniforms({}).reversed === false` (default).
 - `colormapTexture` is passed through unchanged.
 
 ## Non-goals

--- a/docs/superpowers/specs/2026-04-20-colormap-reversed-design.md
+++ b/docs/superpowers/specs/2026-04-20-colormap-reversed-design.md
@@ -24,7 +24,9 @@ export type ColormapProps = {
 
 ### Shader
 
-Add a uniform block exposing a `float reversed` (0.0 / 1.0). This follows the UBO pattern already used in `linear-rescale.ts` and `filter-nodata.ts`. A float is used rather than a bool to avoid std140 layout quirks with GLSL booleans.
+Add a uniform block exposing a `float reversed` (0.0 / 1.0). This follows the UBO pattern already used in `linear-rescale.ts` and `filter-nodata.ts`.
+
+luma.gl v9.3's `uniformTypes` has no `"bool"` option — a boolean must be declared as `"f32"`, `"i32"`, or `"u32"` (see `UniformLeafType` in `@luma.gl/shadertools/dist/lib/utils/uniform-types.d.ts`). `f32` is the simplest of the three because it plugs directly into GLSL `mix()` without a cast; `i32`/`u32` would require `mix(..., float(colormap.reversed))`.
 
 ```glsl
 uniform colormapUniforms {

--- a/docs/superpowers/specs/2026-04-20-colormap-reversed-design.md
+++ b/docs/superpowers/specs/2026-04-20-colormap-reversed-design.md
@@ -1,0 +1,69 @@
+# Colormap `reversed` Prop
+
+## Goal
+
+Add an optional `reversed` boolean to the `Colormap` GPU module. When true, the colormap texture is sampled at `1.0 - color.r` instead of `color.r`, matching matplotlib's `_r` suffix convention (e.g. `viridis_r`).
+
+## Scope
+
+Single file: [packages/deck.gl-raster/src/gpu-modules/colormap.ts](../../../packages/deck.gl-raster/src/gpu-modules/colormap.ts). Plus a new test file.
+
+## Design
+
+### Props
+
+```ts
+export type ColormapProps = {
+  colormapTexture: Texture;
+  /** When true, samples the colormap in reverse (matches matplotlib's `_r` suffix). */
+  reversed?: boolean;
+};
+```
+
+`reversed` is optional. Default is `false` so existing callers (geotiff render-pipeline, naip-mosaic example) are unaffected.
+
+### Shader
+
+Add a uniform block exposing a `float reversed` (0.0 / 1.0). This follows the UBO pattern already used in `linear-rescale.ts` and `filter-nodata.ts`. A float is used rather than a bool to avoid std140 layout quirks with GLSL booleans.
+
+```glsl
+uniform colormapUniforms {
+  float reversed;
+} colormap;
+```
+
+GLSL in `DECKGL_FILTER_COLOR`:
+
+```glsl
+float idx = mix(color.r, 1.0 - color.r, colormap.reversed);
+color = texture(colormapTexture, vec2(idx, 0.));
+```
+
+`mix` is branchless and correct for both endpoints: `mix(a, b, 0.0) == a`, `mix(a, b, 1.0) == b`.
+
+### `getUniforms`
+
+```ts
+getUniforms: (props: Partial<ColormapProps>) => ({
+  colormapTexture: props.colormapTexture,
+  reversed: props.reversed ? 1.0 : 0.0,
+})
+```
+
+## Tests
+
+New file `packages/deck.gl-raster/tests/gpu-modules/colormap.test.ts`, matching the pattern in `composite-bands.test.ts`:
+
+- The `fs` uniform block declares `reversed`.
+- `inject["fs:#decl"]` declares the `colormapTexture` sampler.
+- `inject["fs:DECKGL_FILTER_COLOR"]` contains the `mix(...)` expression and the `texture(colormapTexture, ...)` call.
+- `uniformTypes.reversed === "f32"`.
+- `getUniforms({ reversed: true }).reversed === 1.0`.
+- `getUniforms({ reversed: false }).reversed === 0.0`.
+- `getUniforms({}).reversed === 0.0` (default).
+- `colormapTexture` is passed through unchanged.
+
+## Non-goals
+
+- No changes to callers. `reversed` is optional.
+- No matplotlib-style `_r` name lookup in the colormap generation script — callers opt in via the prop.

--- a/packages/deck.gl-raster/src/gpu-modules/colormap.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/colormap.ts
@@ -1,26 +1,44 @@
 import type { Texture } from "@luma.gl/core";
 import type { ShaderModule } from "@luma.gl/shadertools";
 
-// Props expected by the Colormap shader module
+/** Props for the {@link Colormap} shader module. */
 export type ColormapProps = {
+  /** The 1D colormap texture to sample. */
   colormapTexture: Texture;
+  /**
+   * When true, samples the colormap in reverse — equivalent to matplotlib's
+   * `_r` suffix (e.g. `viridis_r`). Defaults to false.
+   */
+  reversed?: boolean;
 };
+
+const MODULE_NAME = "colormap";
 
 /**
  * A shader module that injects a unorm texture and uses a sampler2D to assign
  * to a color.
  */
 export const Colormap = {
-  name: "colormap",
+  name: MODULE_NAME,
+  fs: `\
+uniform ${MODULE_NAME}Uniforms {
+  float reversed;
+} ${MODULE_NAME};
+`,
   inject: {
     "fs:#decl": `uniform sampler2D colormapTexture;`,
     "fs:DECKGL_FILTER_COLOR": /* glsl */ `
-      color = texture(colormapTexture, vec2(color.r, 0.));
+      float idx = mix(color.r, 1.0 - color.r, ${MODULE_NAME}.reversed);
+      color = texture(colormapTexture, vec2(idx, 0.));
     `,
+  },
+  uniformTypes: {
+    reversed: "f32",
   },
   getUniforms: (props: Partial<ColormapProps>) => {
     return {
       colormapTexture: props.colormapTexture,
+      reversed: props.reversed ?? false,
     };
   },
 } as const satisfies ShaderModule<ColormapProps>;

--- a/packages/deck.gl-raster/tests/gpu-modules/colormap.test.ts
+++ b/packages/deck.gl-raster/tests/gpu-modules/colormap.test.ts
@@ -1,0 +1,55 @@
+import type { Texture } from "@luma.gl/core";
+import { describe, expect, it } from "vitest";
+import { Colormap } from "../../src/gpu-modules/colormap.js";
+
+describe("Colormap", () => {
+  it("declares the colormapTexture sampler in fs:#decl", () => {
+    expect(Colormap.inject["fs:#decl"]).toContain(
+      "uniform sampler2D colormapTexture;",
+    );
+  });
+
+  it("declares a `reversed` float in the uniform block", () => {
+    expect(Colormap.fs).toContain("float reversed;");
+  });
+
+  it("reverses the sample index via mix() when reversed is 1.0", () => {
+    const filter = Colormap.inject["fs:DECKGL_FILTER_COLOR"];
+    expect(filter).toContain("mix(color.r, 1.0 - color.r, colormap.reversed)");
+    expect(filter).toContain("texture(colormapTexture");
+  });
+
+  it("declares `reversed` as f32 in uniformTypes", () => {
+    expect(Colormap.uniformTypes.reversed).toBe("f32");
+  });
+
+  describe("getUniforms", () => {
+    const mockTexture = { id: "cmap" } as unknown as Texture;
+
+    it("passes colormapTexture through", () => {
+      const uniforms = Colormap.getUniforms({ colormapTexture: mockTexture });
+      expect(uniforms.colormapTexture).toBe(mockTexture);
+    });
+
+    it("passes reversed=true through", () => {
+      const uniforms = Colormap.getUniforms({
+        colormapTexture: mockTexture,
+        reversed: true,
+      });
+      expect(uniforms.reversed).toBe(true);
+    });
+
+    it("passes reversed=false through", () => {
+      const uniforms = Colormap.getUniforms({
+        colormapTexture: mockTexture,
+        reversed: false,
+      });
+      expect(uniforms.reversed).toBe(false);
+    });
+
+    it("defaults reversed to false when omitted", () => {
+      const uniforms = Colormap.getUniforms({ colormapTexture: mockTexture });
+      expect(uniforms.reversed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Matplotlib has a way to reverse colormaps by reading them with the `_r` suffix. https://matplotlib.org/stable/gallery/color/colormap_reference.html

Instead of storing twice the number of colormaps, instead we just add a `reversed` boolean that reverses the lookup on the GPU

### Change list

- Add `reversed` boolean uniform for reversing colormap lookup