### PR TITLE
fix: Define texture2darray precision in colormap module

### DIFF
--- a/dev-docs/gpu-modules.md
+++ b/dev-docs/gpu-modules.md
@@ -69,6 +69,28 @@ export const MyTextureModule = {
 
 **The prop key, `getUniforms` return key, and GLSL uniform name must all be identical.**
 
+### Non-default sampler precision (`sampler2DArray`, `sampler3D`, integer samplers)
+
+WebGL2 / GLSL ES 3.00 only defines a default precision for `sampler2D` (and `samplerCube`) in fragment shaders. Every other sampler type — `sampler2DArray`, `sampler3D`, `isampler*`, `usampler*`, shadow samplers — requires an **explicit** precision qualifier or the shader fails to compile with:
+
+```
+ERROR: 'sampler2DArray' : No precision specified
+```
+
+A module that uses one of these samplers must declare its own precision in its `fs:#decl` injection so the module is self-sufficient (it works no matter which other modules are or aren't in the pipeline):
+
+```ts
+inject: {
+  "fs:#decl": `\
+precision highp sampler2DArray;
+uniform sampler2DArray myArrayTex;
+`,
+  // ...
+},
+```
+
+Don't rely on a sibling module or the host layer's fragment shader to declare the precision — the module would silently break the moment it's used in isolation or in a different layer. Multiple `precision` declarations at global scope are legal in GLSL ES 3.00, so duplication across modules is harmless.
+
 ### Mixing Textures and Scalars
 
 A single module can use both paths. Textures go through `inject` + `getUniforms`; scalars go through `fs:` uniform block + `uniformTypes` + `getUniforms`. The `getUniforms` function returns both textures and scalars together.
@@ -87,6 +109,7 @@ See `CompositeBands` for a working example of this pattern.
 - **Uniform is always 0**: Missing `uniformTypes` or `fs:` uniform block declaration
 - **Texture not bound / "Binding not found"**: Prop key doesn't match GLSL uniform name, or texture declared in uniform block instead of `inject`
 - **All textures sample the same value**: Textures declared but not actually bound — check that `getUniforms` returns them with matching keys
+- **`'samplerXXX' : No precision specified`**: Module uses a sampler type other than `sampler2D` (e.g. `sampler2DArray`, `sampler3D`, `isampler2D`) without declaring `precision highp samplerXXX;` in `fs:#decl`. See the non-default sampler precision section above.
 
 ## Existing Module Patterns
 

--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -8,6 +8,7 @@ import type {
 import {
   Colormap,
   CreateTexture,
+  createColormapTexture,
 } from "@developmentseed/deck.gl-raster/gpu-modules";
 import type { Overview } from "@developmentseed/geotiff";
 import { GeoTIFF } from "@developmentseed/geotiff";
@@ -299,20 +300,7 @@ export default function App() {
 
   useEffect(() => {
     if (!device) return;
-
-    // Create colormap texture
-    const texture = device.createTexture({
-      data: colormap.data,
-      width: colormap.width,
-      height: colormap.height,
-      format: "rgba8unorm",
-      sampler: {
-        addressModeU: "clamp-to-edge",
-        addressModeV: "clamp-to-edge",
-      },
-    });
-
-    setColormapTexture(texture);
+    setColormapTexture(createColormapTexture(device, colormap));
   }, [device]);
 
   const layers = [];

--- a/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
@@ -256,15 +256,19 @@ function photometricInterpretationToRGB({
       }
       const { data, width, height } = parseColormap(colorMap);
       const cmapTexture = device.createTexture({
+        dimension: "2d-array",
         data,
         format: "rgba8unorm",
         width,
         height,
+        depth: 1,
+        mipLevels: 1,
         sampler: {
           minFilter: "nearest",
           magFilter: "nearest",
           addressModeU: "clamp-to-edge",
           addressModeV: "clamp-to-edge",
+          addressModeW: "clamp-to-edge",
         },
       });
       return {

--- a/packages/deck.gl-geotiff/tests/render-pipeline.test.ts
+++ b/packages/deck.gl-geotiff/tests/render-pipeline.test.ts
@@ -31,7 +31,12 @@ describe("land cover, single-band uint8", async () => {
     expect(renderPipeline[1]?.props?.value).toEqual(250 / 255.0);
 
     expect(renderPipeline[2]?.module.name).toEqual("colormap");
-    expect(renderPipeline[2]?.props?.colormapTexture).toBeDefined();
+    const cmapTexture = renderPipeline[2]?.props?.colormapTexture as any;
+    expect(cmapTexture).toBeDefined();
+    // Colormap shader module samples a sampler2DArray, so the texture must be
+    // created as a 2d-array (with depth=1 for a single Palette colormap).
+    expect(cmapTexture.dimension).toEqual("2d-array");
+    expect(cmapTexture.depth).toEqual(1);
   });
 });
 

--- a/packages/deck.gl-raster/src/gpu-modules/colormap.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/colormap.ts
@@ -7,6 +7,8 @@ export type ColormapProps = {
    * The colormap sprite as a 2D array texture. Each layer of the array is
    * one 256×1 RGBA8 colormap. Build from the shipped `colormaps.png` with
    * `decodeColormapSprite` + `createColormapTexture`, or bring your own.
+   *
+   * Note this must be a Texture2DArray, not a Texture2D.
    */
   colormapTexture: Texture;
   /**

--- a/packages/deck.gl-raster/src/gpu-modules/colormap.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/colormap.ts
@@ -37,7 +37,10 @@ uniform ${MODULE_NAME}Uniforms {
 } ${MODULE_NAME};
 `,
   inject: {
-    "fs:#decl": `uniform sampler2DArray colormapTexture;`,
+    "fs:#decl": `\
+precision highp sampler2DArray;
+uniform sampler2DArray colormapTexture;
+`,
     "fs:DECKGL_FILTER_COLOR": /* glsl */ `
       float idx = mix(color.r, 1.0 - color.r, ${MODULE_NAME}.reversed);
       color = texture(

--- a/packages/deck.gl-raster/tests/gpu-modules/colormap.test.ts
+++ b/packages/deck.gl-raster/tests/gpu-modules/colormap.test.ts
@@ -9,6 +9,12 @@ describe("Colormap", () => {
     );
   });
 
+  it("declares precision for sampler2DArray in fs:#decl", () => {
+    expect(Colormap.inject["fs:#decl"]).toContain(
+      "precision highp sampler2DArray;",
+    );
+  });
+
   it("declares colormapIndex and reversed in the uniform block", () => {
     expect(Colormap.fs).toContain("int colormapIndex;");
     expect(Colormap.fs).toContain("float reversed;");


### PR DESCRIPTION
### Change list

- Ensure that `colormap` module declares `precision highp sampler2DArray`
- Fix naip-mosaic example to use `createColormapTexture` to build a texture2darray
- Fix `inferRenderPipeline` to create texture2darray and not texture2d
- Update `gpu-modules.md` in dev docs to inform future users/agents to include precision qualifier as needed

Closes #458 