### PR TITLE
chore: Update to uuid v14

### DIFF
--- a/packages/geotiff/package.json
+++ b/packages/geotiff/package.json
@@ -61,6 +61,6 @@
     "@developmentseed/morecantile": "workspace:^",
     "fzstd": "^0.1.1",
     "lerc": "^4.1.1",
-    "uuid": "^13.0.0"
+    "uuid": "^14.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,8 +800,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       uuid:
-        specifier: ^13.0.0
-        version: 13.0.0
+        specifier: ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@chunkd/source-file':
         specifier: ^11.2.0
@@ -7917,8 +7917,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uuid@8.3.2:
@@ -9931,7 +9931,7 @@ snapshots:
       postcss-preset-env: 10.6.1(postcss@8.5.6)
       terser-webpack-plugin: 5.3.17(esbuild@0.27.2)(webpack@5.106.2(esbuild@0.27.2))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.105.4(esbuild@0.27.2)))(webpack@5.106.2(esbuild@0.27.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(esbuild@0.27.2)))(webpack@5.106.2(esbuild@0.27.2))
       webpack: 5.106.2(esbuild@0.27.2)
       webpackbar: 6.0.1(webpack@5.106.2(esbuild@0.27.2))
     transitivePeerDependencies:
@@ -10034,7 +10034,7 @@ snapshots:
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.106.2(esbuild@0.27.2))
+      file-loader: 6.2.0(webpack@5.105.4(esbuild@0.27.2))
       fs-extra: 11.3.3
       image-size: 2.0.2
       mdast-util-mdx: 3.0.0
@@ -10050,7 +10050,7 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.105.4(esbuild@0.27.2)))(webpack@5.106.2(esbuild@0.27.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(esbuild@0.27.2)))(webpack@5.106.2(esbuild@0.27.2))
       vfile: 6.0.3
       webpack: 5.106.2(esbuild@0.27.2)
     transitivePeerDependencies:
@@ -10660,7 +10660,7 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.105.4(esbuild@0.27.2)))(webpack@5.106.2(esbuild@0.27.2))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.106.2(esbuild@0.27.2)))(webpack@5.106.2(esbuild@0.27.2))
       utility-types: 3.11.0
       webpack: 5.106.2(esbuild@0.27.2)
     transitivePeerDependencies:
@@ -13595,6 +13595,12 @@ snapshots:
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  file-loader@6.2.0(webpack@5.105.4(esbuild@0.27.2)):
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.3.0
+      webpack: 5.105.4(esbuild@0.27.2)
 
   file-loader@6.2.0(webpack@5.106.2(esbuild@0.27.2)):
     dependencies:
@@ -17111,14 +17117,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.105.4(esbuild@0.27.2)))(webpack@5.106.2(esbuild@0.27.2)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.106.2(esbuild@0.27.2)))(webpack@5.106.2(esbuild@0.27.2)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
       webpack: 5.106.2(esbuild@0.27.2)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.106.2(esbuild@0.27.2))
+      file-loader: 6.2.0(webpack@5.105.4(esbuild@0.27.2))
 
   util-deprecate@1.0.2: {}
 
@@ -17128,7 +17134,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@13.0.0: {}
+  uuid@14.0.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
Versions of uuid prior to 14.0.0 have a vulnerability: https://github.com/advisories/GHSA-w5hq-g745-h8pq