### PR TITLE
chore: Enforce `.js` extensions on relative imports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,8 @@
       "!!packages/geozarr/geo-proj",
       "!!packages/geozarr/multiscales",
       "!!packages/geozarr/spatial",
-      "!!packages/morecantile/spec"
+      "!!packages/morecantile/spec",
+      "!!docs/api-sidebars"
     ]
   },
   "formatter": {
@@ -41,6 +42,19 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "correctness": {
+        "useImportExtensions": {
+          "level": "error",
+          "options": {
+            "extensionMappings": {
+              "ts": "js",
+              "tsx": "js",
+              "mts": "mjs",
+              "cts": "cjs"
+            }
+          }
+        }
+      },
       "style": {
         "noNonNullAssertion": "off",
         "useBlockStatements": "error",

--- a/examples/aef-mosaic/src/main.tsx
+++ b/examples/aef-mosaic/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App";
+import App from "./App.js";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/examples/cog-basic/src/main.tsx
+++ b/examples/cog-basic/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App";
+import App from "./App.js";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/examples/dynamical-zarr-ecmwf/src/main.tsx
+++ b/examples/dynamical-zarr-ecmwf/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App";
+import App from "./App.js";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/examples/land-cover/src/App.tsx
+++ b/examples/land-cover/src/App.tsx
@@ -8,8 +8,8 @@ import { parseWkt } from "@developmentseed/proj";
 import { useRef, useState } from "react";
 import type { MapRef } from "react-map-gl/maplibre";
 import { Map as MaplibreMap, useControl } from "react-map-gl/maplibre";
-import { InfoPanel } from "./components/InfoPanel";
-import { UIOverlay } from "./components/UIOverlay";
+import { InfoPanel } from "./components/InfoPanel.js";
+import { UIOverlay } from "./components/UIOverlay.js";
 
 function DeckGLOverlay(props: MapboxOverlayProps) {
   const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));

--- a/examples/land-cover/src/components/InfoPanel.tsx
+++ b/examples/land-cover/src/components/InfoPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { HelpIcon } from "./HelpIcon";
-import { Legend } from "./Legend";
+import { HelpIcon } from "./HelpIcon.js";
+import { Legend } from "./Legend.js";
 
 interface InfoPanelProps {
   debug: boolean;

--- a/examples/land-cover/src/main.tsx
+++ b/examples/land-cover/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App";
+import App from "./App.js";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -22,12 +22,12 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { MapRef } from "react-map-gl/maplibre";
 import { Map as MaplibreMap, useControl } from "react-map-gl/maplibre";
-import type { GetTileDataOptions } from "../../../packages/deck.gl-geotiff/dist/cog-layer";
-import type { ColormapId } from "./colormap-choices";
-import { COLORMAP_CHOICES, DEFAULT_COLORMAP_ID } from "./colormap-choices";
-import "./proj";
+import type { GetTileDataOptions } from "../../../packages/deck.gl-geotiff/dist/cog-layer.js";
+import type { ColormapId } from "./colormap-choices.js";
+import { COLORMAP_CHOICES, DEFAULT_COLORMAP_ID } from "./colormap-choices.js";
+import "./proj.js";
 import STAC_DATA from "./minimal_stac.json";
-import { epsgResolver } from "./proj";
+import { epsgResolver } from "./proj.js";
 
 /** Bounding box query passed to Microsoft Planetary Computer STAC API */
 const STAC_BBOX = [-106.6059, 38.7455, -104.5917, 40.4223];

--- a/examples/naip-mosaic/src/main.tsx
+++ b/examples/naip-mosaic/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App";
+import App from "./App.js";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/examples/sentinel-2/src/main.tsx
+++ b/examples/sentinel-2/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App";
+import App from "./App.js";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/examples/usgs-topo-cutline/src/App.tsx
+++ b/examples/usgs-topo-cutline/src/App.tsx
@@ -16,7 +16,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import { useRef, useState } from "react";
 import type { MapRef } from "react-map-gl/maplibre";
 import { Map as MaplibreMap, useControl } from "react-map-gl/maplibre";
-import type { GetTileDataOptions } from "../../../packages/deck.gl-geotiff/dist/cog-layer";
+import type { GetTileDataOptions } from "../../../packages/deck.gl-geotiff/dist/cog-layer.js";
 
 function DeckGLOverlay(props: MapboxOverlayProps) {
   const overlay = useControl<MapboxOverlay>(() => new MapboxOverlay(props));

--- a/examples/usgs-topo-cutline/src/main.tsx
+++ b/examples/usgs-topo-cutline/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App";
+import App from "./App.js";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/examples/zarr-sentinel2-tci/src/main.tsx
+++ b/examples/zarr-sentinel2-tci/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App";
+import App from "./App.js";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/packages/affine/src/index.ts
+++ b/packages/affine/src/index.ts
@@ -1,2 +1,2 @@
-export type { Affine } from "./affine";
-export * from "./affine";
+export type { Affine } from "./affine.js";
+export * from "./affine.js";

--- a/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
@@ -14,9 +14,9 @@ import {
 import type { GeoTIFF, Overview } from "@developmentseed/geotiff";
 import { parseColormap } from "@developmentseed/geotiff";
 import type { Device, SamplerProps, Texture } from "@luma.gl/core";
-import type { GetTileDataOptions } from "../cog-layer";
-import { addAlphaChannel } from "./geotiff";
-import { inferTextureFormat } from "./texture";
+import type { GetTileDataOptions } from "../cog-layer.js";
+import { addAlphaChannel } from "./geotiff.js";
+import { inferTextureFormat } from "./texture.js";
 
 export type TextureDataT = {
   height: number;

--- a/packages/deck.gl-geotiff/src/index.ts
+++ b/packages/deck.gl-geotiff/src/index.ts
@@ -10,7 +10,7 @@ export { MosaicLayer } from "./mosaic-layer/mosaic-layer.js";
 export {
   type MosaicSource,
   MosaicTileset2D,
-} from "./mosaic-layer/mosaic-tileset-2d";
+} from "./mosaic-layer/mosaic-tileset-2d.js";
 // Don't export GeoTIFF Layer for now; nudge people towards COGLayer
 // export type { GeoTIFFLayerProps } from "./geotiff-layer.js";
 // export { GeoTIFFLayer } from "./geotiff-layer.js";

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
@@ -2,8 +2,8 @@ import type { CompositeLayerProps, Layer, LayersList } from "@deck.gl/core";
 import { CompositeLayer } from "@deck.gl/core";
 import type { TileLayerProps } from "@deck.gl/geo-layers";
 import { TileLayer } from "@deck.gl/geo-layers";
-import type { MosaicSource } from "./mosaic-tileset-2d";
-import { MosaicTileset2D } from "./mosaic-tileset-2d";
+import type { MosaicSource } from "./mosaic-tileset-2d.js";
+import { MosaicTileset2D } from "./mosaic-tileset-2d.js";
 
 export type MosaicLayerProps<
   MosaicT extends MosaicSource = MosaicSource,

--- a/packages/deck.gl-geotiff/tests/render-pipeline.test.ts
+++ b/packages/deck.gl-geotiff/tests/render-pipeline.test.ts
@@ -1,7 +1,7 @@
 import type { RasterModule } from "@developmentseed/deck.gl-raster";
 import type { GeoTIFF } from "@developmentseed/geotiff";
 import { describe, expect, it } from "vitest";
-import { inferRenderPipeline } from "../src/geotiff/render-pipeline";
+import { inferRenderPipeline } from "../src/geotiff/render-pipeline.js";
 import { loadGeoTIFF } from "./helpers.js";
 
 const MOCK_DEVICE = {

--- a/packages/deck.gl-geotiff/vitest.config.ts
+++ b/packages/deck.gl-geotiff/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, mergeConfig } from "vitest/config";
-import baseConfig from "../../vitest.config";
+import baseConfig from "../../vitest.config.js";
 
 export default mergeConfig(
   baseConfig,

--- a/packages/deck.gl-raster/src/gpu-modules/color/index.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/color/index.ts
@@ -1,5 +1,5 @@
-export { BlackIsZero } from "./black-is-zero";
-export { cieLabToRGB } from "./cielab";
-export { CMYKToRGB } from "./cmyk";
-export { WhiteIsZero } from "./white-is-zero";
-export { YCbCrToRGB } from "./ycbcr";
+export { BlackIsZero } from "./black-is-zero.js";
+export { cieLabToRGB } from "./cielab.js";
+export { CMYKToRGB } from "./cmyk.js";
+export { WhiteIsZero } from "./white-is-zero.js";
+export { YCbCrToRGB } from "./ycbcr.js";

--- a/packages/deck.gl-raster/src/gpu-modules/index.ts
+++ b/packages/deck.gl-raster/src/gpu-modules/index.ts
@@ -4,7 +4,7 @@ export {
   cieLabToRGB,
   WhiteIsZero,
   YCbCrToRGB,
-} from "./color";
+} from "./color/index.js";
 export type { ColormapProps } from "./colormap.js";
 export { Colormap } from "./colormap.js";
 export {
@@ -17,13 +17,13 @@ export {
   CompositeBands,
 } from "./composite-bands.js";
 export { createColormapTexture } from "./create-colormap-texture.js";
-export { CreateTexture } from "./create-texture";
+export { CreateTexture } from "./create-texture.js";
 export type { CutlineBboxProps } from "./cutline-bbox.js";
 export { CutlineBbox, lngLatToMercator } from "./cutline-bbox.js";
 export type { ColormapSpriteSource } from "./decode-colormap-sprite.js";
 export { decodeColormapSprite } from "./decode-colormap-sprite.js";
-export { FilterNoDataVal } from "./filter-nodata";
+export { FilterNoDataVal } from "./filter-nodata.js";
 export type { LinearRescaleProps } from "./linear-rescale.js";
 export { LinearRescale } from "./linear-rescale.js";
-export { MaskTexture } from "./mask-texture";
-export type { RasterModule } from "./types";
+export { MaskTexture } from "./mask-texture.js";
+export type { RasterModule } from "./types.js";

--- a/packages/deck.gl-raster/src/layer-utils.ts
+++ b/packages/deck.gl-raster/src/layer-utils.ts
@@ -1,7 +1,7 @@
 import type { _Tile2DHeader as Tile2DHeader } from "@deck.gl/geo-layers";
 import { PathLayer, TextLayer } from "@deck.gl/layers";
 import type { ReprojectionFns } from "@developmentseed/raster-reproject";
-import type { TileMetadata } from "./raster-tileset";
+import type { TileMetadata } from "./raster-tileset/index.js";
 
 export function renderDebugTileOutline(
   id: string,

--- a/packages/deck.gl-raster/src/raster-layer.ts
+++ b/packages/deck.gl-raster/src/raster-layer.ts
@@ -9,8 +9,8 @@ import { CompositeLayer } from "@deck.gl/core";
 import { PolygonLayer } from "@deck.gl/layers";
 import type { ReprojectionFns } from "@developmentseed/raster-reproject";
 import { RasterReprojector } from "@developmentseed/raster-reproject";
-import type { RasterModule } from "./gpu-modules/types";
-import { MeshTextureLayer } from "./mesh-layer/mesh-layer";
+import type { RasterModule } from "./gpu-modules/types.js";
+import { MeshTextureLayer } from "./mesh-layer/mesh-layer.js";
 
 const DEFAULT_MAX_ERROR = 0.125;
 

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
@@ -14,15 +14,15 @@ import type {
 import { _Tileset2D as Tileset2D } from "@deck.gl/geo-layers";
 import { transformBounds } from "@developmentseed/proj";
 import type { Matrix4 } from "@math.gl/core";
-import { getTileIndices } from "./raster-tile-traversal";
-import type { TilesetDescriptor } from "./tileset-interface";
+import { getTileIndices } from "./raster-tile-traversal.js";
+import type { TilesetDescriptor } from "./tileset-interface.js";
 import type {
   Bounds,
   Corners,
   ProjectedBoundingBox,
   TileIndex,
   ZRange,
-} from "./types";
+} from "./types.js";
 
 /** Type returned by `getTileMetadata` */
 export type TileMetadata = {

--- a/packages/deck.gl-raster/src/raster-tileset/tile-matrix-set.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/tile-matrix-set.ts
@@ -1,8 +1,8 @@
 import * as affine from "@developmentseed/affine";
 import type { TileMatrix, TileMatrixSet } from "@developmentseed/morecantile";
 import { tileTransform, xy_bounds } from "@developmentseed/morecantile";
-import type { TilesetDescriptor, TilesetLevel } from "./tileset-interface";
-import type { Bounds, Corners, ProjectionFunction } from "./types";
+import type { TilesetDescriptor, TilesetLevel } from "./tileset-interface.js";
+import type { Bounds, Corners, ProjectionFunction } from "./types.js";
 
 // 0.28 mm per pixel — OGC TMS 2.0 standard screen pixel size
 // https://docs.ogc.org/is/17-083r4/17-083r4.html#toc15

--- a/packages/geotiff/src/codecs/zstd.ts
+++ b/packages/geotiff/src/codecs/zstd.ts
@@ -1,5 +1,5 @@
 import { decompress } from "fzstd";
-import { copyIfViewNotFullBuffer } from "./utils";
+import { copyIfViewNotFullBuffer } from "./utils.js";
 
 export async function decode(bytes: ArrayBuffer): Promise<ArrayBuffer> {
   const result = decompress(new Uint8Array(bytes));

--- a/packages/geotiff/src/fetch.ts
+++ b/packages/geotiff/src/fetch.ts
@@ -7,8 +7,8 @@ import type { DecodedPixels, DecoderMetadata } from "./decode.js";
 import { decode } from "./decode.js";
 import type { CachedTags } from "./ifd.js";
 import type { DecoderPool } from "./pool/pool.js";
-import type { Tile } from "./tile";
-import type { HasTransform } from "./transform";
+import type { Tile } from "./tile.js";
+import type { HasTransform } from "./transform.js";
 
 /** Protocol for objects that hold a TIFF reference and can request tiles. */
 interface HasTiffReference extends HasTransform {

--- a/packages/geotiff/vitest.config.ts
+++ b/packages/geotiff/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, mergeConfig } from "vitest/config";
-import baseConfig from "../../vitest.config";
+import baseConfig from "../../vitest.config.js";
 
 export default mergeConfig(
   baseConfig,

--- a/packages/morecantile/src/tile.ts
+++ b/packages/morecantile/src/tile.ts
@@ -1,7 +1,7 @@
 import * as affine from "@developmentseed/affine";
-import { tileTransform } from "./transform";
-import type { BoundingBox, TileMatrix, TileMatrixSet } from "./types";
-import { narrowTileMatrixSet } from "./utils";
+import { tileTransform } from "./transform.js";
+import type { BoundingBox, TileMatrix, TileMatrixSet } from "./types/index.js";
+import { narrowTileMatrixSet } from "./utils.js";
 
 /**
  * Return the bounding box of the tile in the TMS's native coordinate reference

--- a/packages/morecantile/src/types/index.ts
+++ b/packages/morecantile/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { DBoundingBox as BoundingBox } from "./spec/2DBoundingBox";
-export type { CRS } from "./spec/crs";
-export type { TileMatrix } from "./spec/tileMatrix";
-export type { TileMatrixSetDefinition as TileMatrixSet } from "./spec/tileMatrixSet";
+export type { DBoundingBox as BoundingBox } from "./spec/2DBoundingBox.js";
+export type { CRS } from "./spec/crs.js";
+export type { TileMatrix } from "./spec/tileMatrix.js";
+export type { TileMatrixSetDefinition as TileMatrixSet } from "./spec/tileMatrixSet.js";

--- a/packages/morecantile/src/utils.ts
+++ b/packages/morecantile/src/utils.ts
@@ -1,4 +1,4 @@
-import type { TileMatrix, TileMatrixSet } from "./types";
+import type { TileMatrix, TileMatrixSet } from "./types/index.js";
 
 export function narrowTileMatrixSet(
   obj: TileMatrix | TileMatrixSet,

--- a/packages/morecantile/tests/transform.test.ts
+++ b/packages/morecantile/tests/transform.test.ts
@@ -7,8 +7,8 @@ import _GNOSIS from "../spec/schemas/tms/2.0/json/examples/tilematrixset/GNOSISG
 import _UTM31 from "../spec/schemas/tms/2.0/json/examples/tilematrixset/UTM31WGS84Quad.json";
 import _WebMercator from "../spec/schemas/tms/2.0/json/examples/tilematrixset/WebMercatorQuad.json";
 import _WorldCRS84 from "../spec/schemas/tms/2.0/json/examples/tilematrixset/WorldCRS84Quad.json";
-import { matrixTransform, tileTransform } from "../src/transform";
-import type { TileMatrix, TileMatrixSet } from "../src/types/index";
+import { matrixTransform, tileTransform } from "../src/transform.js";
+import type { TileMatrix, TileMatrixSet } from "../src/types/index.js";
 
 const CDB1 = _CDB1 as TileMatrixSet;
 const GNOSIS = _GNOSIS as TileMatrixSet;

--- a/packages/proj/src/registry.ts
+++ b/packages/proj/src/registry.ts
@@ -1,6 +1,6 @@
-import type { ProjectionDefinition } from "./parse-wkt";
-import { parseWkt } from "./parse-wkt";
-import type { ProjJson } from "./projjson";
+import type { ProjectionDefinition } from "./parse-wkt.js";
+import { parseWkt } from "./parse-wkt.js";
+import type { ProjJson } from "./projjson.js";
 
 /**
  * A global registry holding parsed projection definitions.

--- a/packages/proj/tests/meters-per-unit.test.ts
+++ b/packages/proj/tests/meters-per-unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { metersPerUnit } from "../../proj/src";
+import { metersPerUnit } from "../../proj/src/index.js";
 
 describe("metersPerUnit", () => {
   it("handles lowercase us survey foot", () => {


### PR DESCRIPTION
## Summary

- Enables Biome's `correctness/useImportExtensions` as an error.
- Configures `extensionMappings` to rewrite `.ts`/`.tsx` → `.js` and `.mts`/`.cts` → `.mjs`/`.cjs`. Does NOT rewrite `.json` imports.
- Excludes `docs/api-sidebars/` from Biome (generated files).
- Autofix appended `.js` (or `.mjs`/`.cjs`) to every relative import across packages and examples.

Targeting `titiler-example` rather than `main` so the titiler-cog example files get the extensions from the same change.

## Test plan

- [ ] `pnpm -r --filter '!docs' typecheck` passes (docs has a pre-existing `baseUrl` deprecation error unrelated to this change).
- [ ] `pnpm biome check .` passes with no remaining diagnostics.
- [ ] Spot-check a few files (e.g. `packages/morecantile/src/tile.ts`, `examples/cog-basic/src/App.tsx`) to confirm extensions look right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)