### PR TITLE
fix: Handle EPSG:4326 projection with missing `units`

### DIFF
--- a/packages/proj/src/parse-wkt.ts
+++ b/packages/proj/src/parse-wkt.ts
@@ -59,5 +59,14 @@ export interface ProjectionDefinition {
  * This is a typed wrapper around the `wkt-parser` package.
  */
 export function parseWkt(input: string | ProjJson): ProjectionDefinition {
-  return wktParser(input);
+  const def = wktParser(input);
+
+  // wkt-parser doesn't always resolve per-axis units from GeographicCRS
+  // PROJJSON, leaving units: "unknown". longlat is always degrees by definition.
+  if (def.projName === "longlat" && (!def.units || def.units === "unknown")) {
+    def.units = "degree";
+    def.to_meter = undefined;
+  }
+
+  return def;
 }

--- a/packages/proj/src/registry.ts
+++ b/packages/proj/src/registry.ts
@@ -11,8 +11,6 @@ export type EpsgResolver = (epsg: number) => Promise<ProjectionDefinition>;
 
 export async function epsgResolver(epsg: number) {
   const key = `EPSG:${epsg}`;
-  // TODO: override global proj4 EPSG:4326 definition because it doesn't include
-  // semi major axis
   const cachedProj = PROJECTION_REGISTRY.get(key);
   if (cachedProj !== undefined) {
     return cachedProj;

--- a/packages/proj/tests/parse-wkt.test.ts
+++ b/packages/proj/tests/parse-wkt.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseWkt } from "../../proj/src/index.js";
+
+describe("parseWkt", () => {
+  it("produces degree units for EPSG:4326 PROJJSON (from epsg.io)", () => {
+    // Literal response body from https://epsg.io/4326.json. Units are declared
+    // per-axis on coordinate_system.axis[].unit, not at the top level. When
+    // wkt-parser fails to resolve that, parseWkt normalizes longlat to degree.
+    const projjson = {
+      $schema: "https://proj.org/schemas/v0.7/projjson.schema.json",
+      type: "GeographicCRS",
+      name: "WGS 84",
+      datum_ensemble: {
+        name: "World Geodetic System 1984 ensemble",
+        ellipsoid: {
+          name: "WGS 84",
+          semi_major_axis: 6378137,
+          inverse_flattening: 298.257223563,
+        },
+        id: { authority: "EPSG", code: 6326 },
+      },
+      coordinate_system: {
+        subtype: "ellipsoidal",
+        axis: [
+          {
+            name: "Geodetic latitude",
+            abbreviation: "Lat",
+            direction: "north",
+            unit: "degree",
+          },
+          {
+            name: "Geodetic longitude",
+            abbreviation: "Lon",
+            direction: "east",
+            unit: "degree",
+          },
+        ],
+      },
+      id: { authority: "EPSG", code: 4326 },
+    } as const;
+
+    const def = parseWkt(projjson);
+
+    expect(def.projName).toBe("longlat");
+    expect(def.units).toBe("degree");
+    expect(def.a).toBe(6378137);
+  });
+
+  it("normalizes longlat with units 'unknown' to degree", () => {
+    // GEOGCS WKT without a UNIT directive can cause wkt-parser to emit
+    // units: "unknown", to_meter: null. This verifies the fallback.
+    const wkt =
+      'GEOGCS["WGS 84",' +
+      'DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],' +
+      'PRIMEM["Greenwich",0],' +
+      'AXIS["Latitude",NORTH],AXIS["Longitude",EAST]]';
+
+    const def = parseWkt(wkt);
+
+    expect(def.projName).toBe("longlat");
+    expect(def.units).toBe("degree");
+  });
+});

--- a/packages/proj/tests/parse-wkt.test.ts
+++ b/packages/proj/tests/parse-wkt.test.ts
@@ -1,23 +1,25 @@
 import { describe, expect, it } from "vitest";
+import type { ProjJson } from "../../proj/src/index.js";
 import { parseWkt } from "../../proj/src/index.js";
 
 describe("parseWkt", () => {
   it("produces degree units for EPSG:4326 PROJJSON (from epsg.io)", () => {
-    // Literal response body from https://epsg.io/4326.json. Units are declared
-    // per-axis on coordinate_system.axis[].unit, not at the top level. When
-    // wkt-parser fails to resolve that, parseWkt normalizes longlat to degree.
-    const projjson = {
+    // Simplified response body from https://epsg.io/4326.json. Units are
+    // declared per-axis on coordinate_system.axis[].unit, not at the top level.
+    // When wkt-parser fails to resolve that, parseWkt normalizes longlat to
+    // degree.
+    const projjson: ProjJson = {
       $schema: "https://proj.org/schemas/v0.7/projjson.schema.json",
       type: "GeographicCRS",
       name: "WGS 84",
       datum_ensemble: {
         name: "World Geodetic System 1984 ensemble",
+        members: [],
         ellipsoid: {
           name: "WGS 84",
           semi_major_axis: 6378137,
           inverse_flattening: 298.257223563,
         },
-        id: { authority: "EPSG", code: 6326 },
       },
       coordinate_system: {
         subtype: "ellipsoidal",
@@ -36,8 +38,7 @@ describe("parseWkt", () => {
           },
         ],
       },
-      id: { authority: "EPSG", code: 4326 },
-    } as const;
+    };
 
     const def = parseWkt(projjson);
 
@@ -48,7 +49,7 @@ describe("parseWkt", () => {
 
   it("normalizes longlat with units 'unknown' to degree", () => {
     // GEOGCS WKT without a UNIT directive can cause wkt-parser to emit
-    // units: "unknown", to_meter: null. This verifies the fallback.
+    // units: "unknown" or undefined. This verifies the fallback.
     const wkt =
       'GEOGCS["WGS 84",' +
       'DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],' +


### PR DESCRIPTION
When rendering 
```
https://cngsandbox.org/storage/datasets/d425d937-5a79-44f2-8c9c-8872d7dbafec/converted/Annual_NLCD_LndCov_2023_CU_C1V1.tif
```

there's a console error:

```
Uncaught (in promise) Error: Unsupported CRS units: unknown when computing metersPerUnit.
    at metersPerUnit (meters-per-unit.ts:51:9)
    at generateTileMatrixSet (tile-matrix-set.ts:112:15)
    at COGLayer._parseGeoTIFF (cog-layer.ts:202:17)
```

This is because the parsed WKT object is:

```ts
{
    "projName": "longlat",
    "name": "WGS 84",
    "srsCode": "WGS 84",
    "ellps": "WGS 84",
    "a": 6378137,
    "rf": 298.257223563,
    "axis": "neu",
    "units": "unknown",
    "to_meter": null,
    "title": "EPSG:4326"
}
```
and `units: unknown` means that we error when computing `metersPerPixel`

To fix this, we hard-code that `projname`: `longlat` maps to `units: degree`