### PR TITLE
docs: inject Plausible analytics into example sites via CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,12 @@ jobs:
             cp -r "$dir/dist/." "docs/static/examples/$example/"
           done
 
+      - name: Inject Plausible into examples
+        run: |
+          find docs/static/examples -name "index.html" | while read f; do
+            sed -i 's|</head>|<script async src="https://plausible.io/js/pa-GXbpwCRHPm1QSDOLNB_on.js"></script><script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()</script></head>|' "$f"
+          done
+
       - name: Build docs
         working-directory: docs
         run: pnpm build


### PR DESCRIPTION
This adds a CI step that injects the same Plausible script already used on the docs site into every example index.html after build. New examples added in the future are covered automatically with no additional changes required.

To verify, after deploy: 
- [ ] Check page source on any example (e.g. /deck.gl-raster/examples/cog-basic/) for the <script async src="https://plausible.io/js/pa-..."> tag
- [ ] Confirm pageviews appear in the Plausible dashboard.