### PR TITLE
feat: Split COG tile traversal off TileMatrixSet

### DIFF
--- a/dev-docs/specs/2026-04-27-affine-tileset-design.md
+++ b/dev-docs/specs/2026-04-27-affine-tileset-design.md
@@ -1,0 +1,129 @@
+# Affine Tileset Design
+
+## Problem
+
+The COG rendering path in `@developmentseed/deck.gl-geotiff` converts every COG into an OGC `TileMatrixSet` (via `generateTileMatrixSet` in [`packages/geotiff/src/tile-matrix-set.ts`](../../packages/geotiff/src/tile-matrix-set.ts)) and then wraps that TMS in a `TileMatrixSetAdaptor` to satisfy `TilesetDescriptor`. TMS is the wrong intermediate abstraction for COGs in two directions:
+
+- **Too narrow** — TMS requires axis-aligned grids and a single scalar `cellSize`. COGs with rotated / skewed geotransforms hit a hard `throw` ([issue #327](https://github.com/developmentseed/deck.gl-raster/issues/327)), and COGs with non-square pixels render incorrectly because the second axis scale is silently dropped ([issue #375](https://github.com/developmentseed/deck.gl-raster/issues/375)).
+- **Too broad** — TMS supports variable-size grids within a single resolution level (per-row tile widths, etc.) that no COG or GeoZarr source ever produces.
+
+The `@developmentseed/deck.gl-zarr` package already proves the right shape for the common case: [`ZarrTilesetLevel`](../../packages/deck.gl-zarr/src/zarr-tileset.ts) implements `TilesetLevel` directly from `{ affine, arrayWidth, arrayHeight, tileWidth, tileHeight, mpu }`. This handles rotation, skew, and non-square pixels naturally. The same shape would fix both COG bugs and eliminate ~150 lines of near-duplicate code.
+
+## Goals
+
+- Introduce a generic affine-based `TilesetLevel` / `TilesetDescriptor` pair in `@developmentseed/deck.gl-raster` so that any source describable by `(affine, tile size, array size)` can render without per-source traversal code.
+- Migrate the COG layer (`COGLayer`, `MultiCOGLayer`) off the TMS intermediate, fixing issues #327 and #375.
+- Migrate the existing inline `ZarrTilesetLevel` to the shared primitive.
+- Preserve the public API: `TileMatrixSetAdaptor` stays exported for users who actually feed real OGC TMS data; `generateTileMatrixSet` stays in the source tree (it may be needed again later) but is removed from `packages/geotiff`'s public exports.
+
+## Non-Goals
+
+- Removing or deprecating `TileMatrixSetAdaptor`. It is the right abstraction for true OGC TMS sources and remains exported.
+- Deleting `generateTileMatrixSet`. It stays as internal code so it can be revived if a future use case calls for synthesizing a TMS from a COG.
+- Supporting non-affine COGs / GeoZarr (GCPs, RPCs). The `TilesetLevel` interface is already polymorphic enough to accept future implementations alongside `AffineTilesetLevel`; no such implementation is part of this work.
+
+## Design
+
+### 1. New primitive: `AffineTilesetLevel`
+
+**Location**: `packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts`
+
+A class implementing `TilesetLevel`, parameterized by exactly the state described in the discussion-quote — affine transform plus tile and array size:
+
+```ts
+new AffineTilesetLevel({
+  affine: Affine,        // pixel → CRS
+  arrayWidth: number,    // full level width in pixels
+  arrayHeight: number,   // full level height in pixels
+  tileWidth: number,
+  tileHeight: number,
+  mpu: number,           // meters per CRS unit
+});
+```
+
+All four `TilesetLevel` methods derive from these inputs, lifted from the current `ZarrTilesetLevel` implementation:
+
+- `matrixWidth` / `matrixHeight` = `ceil(arraySize / tileSize)`.
+- `metersPerPixel` = `sqrt(|a · e|) · mpu` — geometric mean of the two pixel-edge scales. Handles non-square pixels (#375).
+- `projectedTileCorners(col, row)` — four `affine.apply` calls on `(col·tw, row·th)`, `((col+1)·tw, row·th)`, etc. Handles rotation/skew (#327).
+- `tileTransform(col, row)` — `compose(affine, translation(col·tw, row·th))` plus its inverse.
+- `crsBoundsToTileRange(minX, minY, maxX, maxY)` — inverse-affine the four CRS corners, take pixel-space bbox, divide by tile size, clamp to matrix bounds.
+
+### 2. New primitive: `AffineTileset`
+
+**Location**: `packages/deck.gl-raster/src/raster-tileset/affine-tileset.ts`
+
+A class implementing `TilesetDescriptor`, parameterized by the levels and projection functions:
+
+```ts
+new AffineTileset({
+  levels: AffineTilesetLevel[],   // coarsest first
+  projectTo3857, projectFrom3857,
+  projectTo4326, projectFrom4326,
+});
+```
+
+Two responsibilities on top of the inputs:
+
+1. Expose `levels` and the four projection functions to satisfy `TilesetDescriptor`.
+2. Derive `projectedBounds` from the coarsest level's affine applied to its four array corners (`(0,0)`, `(W,0)`, `(0,H)`, `(W,H)`), taking the bbox. This is the same logic currently inlined at the bottom of `geoZarrToDescriptor`.
+
+### 3. COG glue: `geoTiffToDescriptor`
+
+**Location**: `packages/deck.gl-geotiff/src/geotiff-tileset.ts` (new file)
+
+A factory function that builds an `AffineTileset` from a `GeoTIFF`:
+
+```ts
+export function geoTiffToDescriptor(
+  geotiff: GeoTIFF,
+  opts: {
+    projectTo3857: ProjectionFunction;
+    projectFrom3857: ProjectionFunction;
+    projectTo4326: ProjectionFunction;
+    projectFrom4326: ProjectionFunction;
+    mpu: number;
+  },
+): AffineTileset;
+```
+
+Implementation iterates `[...geotiff.overviews].reverse().concat(geotiff)` (coarsest first, full resolution last — matching the existing `generateTileMatrixSet` ordering), creating one `AffineTilesetLevel` per `Overview` from `overview.transform`, `overview.tileWidth/Height`, `overview.width/height`, and the supplied `mpu`. Returns `new AffineTileset({ levels, ...projections })`.
+
+The `mpu` calculation (`metersPerUnit(crs.units, { semiMajorAxis })`) currently lives inside `generateTileMatrixSet`. It moves to the caller (`cog-layer.ts` / `multi-cog-layer.ts`), which already holds the parsed `sourceProjection` needed to compute it. This mirrors Zarr's existing API where `mpu` is supplied by the caller.
+
+### 4. Zarr migration
+
+`packages/deck.gl-zarr/src/zarr-tileset.ts` deletes its inline `ZarrTilesetLevel` class and the inline `projectedBounds` derivation. `geoZarrToDescriptor` becomes a thin glue function with the same shape as `geoTiffToDescriptor`: build `AffineTilesetLevel`s from `meta.levels` + `chunkSizes`, return an `AffineTileset`.
+
+### 5. COG layer migration
+
+`packages/deck.gl-geotiff/src/cog-layer.ts` and `packages/deck.gl-geotiff/src/multi-cog-layer.ts` replace `generateTileMatrixSet(...)` + `new TileMatrixSetAdaptor(tms, ...)` with a single `geoTiffToDescriptor(geotiff, { ...projections, mpu })` call.
+
+`MultiCOGLayer`'s internal `SourceState` interface drops its `tms: TileMatrixSet` field (it's not exported, so this is a non-breaking change).
+
+### 6. Public API changes
+
+| Package | Change |
+|---|---|
+| `packages/geotiff/src/index.ts` | Remove `export { generateTileMatrixSet }`. The function and its file remain in the source tree. |
+| `packages/deck.gl-raster/src/raster-tileset/index.ts` | Add `export { AffineTilesetLevel, AffineTileset }`. `TileMatrixSetAdaptor` stays exported. |
+| `packages/deck.gl-geotiff/src/index.ts` | Add `export { geoTiffToDescriptor }`. |
+| `packages/deck.gl-zarr/src/index.ts` | Unchanged — `geoZarrToDescriptor` keeps its current export. |
+
+`packages/geotiff` retains its `morecantile` dependency since `generateTileMatrixSet` and its tests stay in the tree.
+
+### 7. Tests
+
+- New `packages/deck.gl-raster/tests/affine-tileset-level.test.ts` covering: axis-aligned square pixels (regression), non-square pixels (#375), rotated affines (#327), `crsBoundsToTileRange` clamping at matrix edges, `tileTransform` round-trip, `metersPerPixel` for non-square pixels.
+- New `packages/deck.gl-raster/tests/affine-tileset.test.ts` covering: `projectedBounds` derived from coarsest level for axis-aligned and rotated affines; passthrough of projection functions and levels.
+- New `packages/deck.gl-geotiff/tests/geotiff-tileset.test.ts` covering: descriptor built from a real (or mocked) `GeoTIFF` matches expected level count and ordering (coarsest first).
+- Existing `packages/geotiff/tests/tile-matrix-set.test.ts` stays — `generateTileMatrixSet` is still in the source.
+- Existing `packages/deck.gl-raster/tests/tileset-refinement.test.ts` and other traversal tests stay — they exercise `TilesetDescriptor`, which doesn't change.
+
+## Acceptance criteria
+
+- A COG with non-square pixels (the dataset attached to issue #375) renders correctly through `COGLayer`.
+- A COG with a rotated geotransform (e.g., the Umbra SAR sample referenced in issue #327) renders without throwing.
+- All existing tests in `packages/deck.gl-raster`, `packages/deck.gl-geotiff`, `packages/deck.gl-zarr`, and `packages/geotiff` pass.
+- `packages/geotiff` does not export `generateTileMatrixSet` from its `index.ts`.
+- `packages/deck.gl-zarr/src/zarr-tileset.ts` no longer contains a class that re-implements `TilesetLevel`.

--- a/packages/affine/src/affine.ts
+++ b/packages/affine/src/affine.ts
@@ -113,7 +113,7 @@ export function apply(
 }
 
 /**
- * Compose two affine transforms: A×B (apply B first, then A).
+ * Compose two affine transforms: A×B (apply B **first**, then A).
  *
  * This is equivalent to `a @ b` in Python's `affine` library, and is equivalent
  * to multiplying the 3×3 matrices:

--- a/packages/affine/src/affine.ts
+++ b/packages/affine/src/affine.ts
@@ -74,14 +74,45 @@ export function rotation(
   angle: number,
   pivot: readonly [number, number] = [0, 0],
 ): Affine {
-  const rad = (angle * Math.PI) / 180;
-  const ca = Math.cos(rad);
-  const sa = Math.sin(rad);
+  const [ca, sa] = cosSinDeg(angle);
   const [px, py] = pivot;
   if (px === 0 && py === 0) {
     return [ca, -sa, 0, sa, ca, 0];
   }
-  return [ca, -sa, px - px * ca + py * sa, sa, ca, py - px * sa - py * ca];
+  // biome-ignore format: array
+  return [
+    ca, -sa, px - px * ca + py * sa,
+    sa, ca, py - px * sa - py * ca,
+  ];
+}
+
+/**
+ * Return the cosine and sine of an angle in degrees, special-casing exact
+ * multiples of 90° so right angles produce exact 0 / ±1 instead of the
+ * floating-point error that `Math.cos(Math.PI/2)` etc. would emit.
+ *
+ * Ported from the Python `affine` library's `cos_sin_deg`.
+ */
+function cosSinDeg(deg: number): [number, number] {
+  // JS `%` preserves the dividend's sign (`-90 % 360 === -90`), unlike
+  // Python's modulo which normalizes to [0, 360). The `+ 360) % 360`
+  // dance gives us Python-style wrapping so the right-angle short-circuits
+  // below also fire for negative angles like `-90`.
+  const wrapped = ((deg % 360) + 360) % 360;
+  if (wrapped === 0) {
+    return [1, 0];
+  }
+  if (wrapped === 90) {
+    return [0, 1];
+  }
+  if (wrapped === 180) {
+    return [-1, 0];
+  }
+  if (wrapped === 270) {
+    return [0, -1];
+  }
+  const rad = (wrapped * Math.PI) / 180;
+  return [Math.cos(rad), Math.sin(rad)];
 }
 
 /**

--- a/packages/affine/src/affine.ts
+++ b/packages/affine/src/affine.ts
@@ -59,6 +59,32 @@ export function scale(sx: number, sy: number = sx): Affine {
 }
 
 /**
+ * Create a rotation transform.
+ *
+ * Rotates counter-clockwise by `angle` degrees about the given pivot point
+ * (defaults to the origin `(0, 0)`). Ported from the Python
+ * [`affine`](https://github.com/rasterio/affine) library.
+ *
+ * @param angle  Rotation angle in degrees, counter-clockwise about the pivot.
+ * @param pivot  Optional pivot point `[px, py]`. Defaults to `[0, 0]`.
+ *
+ * @return Transform that applies the given rotation.
+ */
+export function rotation(
+  angle: number,
+  pivot: readonly [number, number] = [0, 0],
+): Affine {
+  const rad = (angle * Math.PI) / 180;
+  const ca = Math.cos(rad);
+  const sa = Math.sin(rad);
+  const [px, py] = pivot;
+  if (px === 0 && py === 0) {
+    return [ca, -sa, 0, sa, ca, 0];
+  }
+  return [ca, -sa, px - px * ca + py * sa, sa, ca, py - px * sa - py * ca];
+}
+
+/**
  * Apply a geotransform to a coordinate.
  *
  * That is, we apply this series of equations:

--- a/packages/affine/src/index.ts
+++ b/packages/affine/src/index.ts
@@ -2,10 +2,7 @@
  * 2D affine transformations for georeferenced raster data.
  *
  * A TypeScript port of the Python
- * [`affine`](https://github.com/rasterio/affine) library, focused on the
- * subset needed for pixel ↔ CRS conversions: construction (`identity`,
- * `translation`, `scale`, `rotation`), composition (`compose`), inversion
- * (`invert`), and application to coordinates (`apply`).
+ * [`affine`](https://github.com/rasterio/affine) library.
  *
  * An {@link Affine} is a flat 6-element tuple `[a, b, c, d, e, f]` representing
  * the matrix
@@ -16,14 +13,7 @@
  *   | 0 0 1 |
  * ```
  *
- * which maps `(x, y) → (a*x + b*y + c, d*x + e*y + f)`. The first two
- * rows match the GDAL geotransform convention (with `[c, a, b, f, d, e]`
- * reordered to row-major form).
- *
- * `compose(A, B)` matches Python's `A @ B`: B is applied first, then A. So
- * to express the pixel-to-CRS pipeline "scale, then rotate, then
- * translate", write
- * `compose(translation(...), compose(rotation(...), scale(...)))`.
+ * which maps `(x, y) → (a*x + b*y + c, d*x + e*y + f)`.
  */
 
 export type { Affine } from "./affine.js";

--- a/packages/affine/src/index.ts
+++ b/packages/affine/src/index.ts
@@ -1,2 +1,30 @@
+/**
+ * 2D affine transformations for georeferenced raster data.
+ *
+ * A TypeScript port of the Python
+ * [`affine`](https://github.com/rasterio/affine) library, focused on the
+ * subset needed for pixel ↔ CRS conversions: construction (`identity`,
+ * `translation`, `scale`, `rotation`), composition (`compose`), inversion
+ * (`invert`), and application to coordinates (`apply`).
+ *
+ * An {@link Affine} is a flat 6-element tuple `[a, b, c, d, e, f]` representing
+ * the matrix
+ *
+ * ```
+ *   | a b c |
+ *   | d e f |
+ *   | 0 0 1 |
+ * ```
+ *
+ * which maps `(x, y) → (a*x + b*y + c, d*x + e*y + f)`. The first two
+ * rows match the GDAL geotransform convention (with `[c, a, b, f, d, e]`
+ * reordered to row-major form).
+ *
+ * `compose(A, B)` matches Python's `A @ B`: B is applied first, then A. So
+ * to express the pixel-to-CRS pipeline "scale, then rotate, then
+ * translate", write
+ * `compose(translation(...), compose(rotation(...), scale(...)))`.
+ */
+
 export type { Affine } from "./affine.js";
 export * from "./affine.js";

--- a/packages/affine/tests/affine.test.ts
+++ b/packages/affine/tests/affine.test.ts
@@ -5,6 +5,7 @@ import {
   compose,
   identity,
   invert,
+  rotation,
   scale,
   translation,
 } from "../src/affine.js";
@@ -71,5 +72,44 @@ describe("compose", () => {
     const t = translation(10, 20);
     const s = scale(2, 3);
     expect(compose(t, s)).not.toEqual(compose(s, t));
+  });
+});
+
+describe("rotation", () => {
+  it("rotates 90° CCW about the origin", () => {
+    const r = rotation(90);
+    const [x, y] = apply(r, 1, 0);
+    expect(x).toBeCloseTo(0, 10);
+    expect(y).toBeCloseTo(1, 10);
+  });
+
+  it("rotates 180° about the origin", () => {
+    const r = rotation(180);
+    const [x, y] = apply(r, 3, 4);
+    expect(x).toBeCloseTo(-3, 10);
+    expect(y).toBeCloseTo(-4, 10);
+  });
+
+  it("identity at 0°", () => {
+    const r = rotation(0);
+    const [x, y] = apply(r, 7, 11);
+    expect(x).toBeCloseTo(7, 10);
+    expect(y).toBeCloseTo(11, 10);
+  });
+
+  it("rotates about a non-origin pivot", () => {
+    // 90° CCW about (5, 5): point (5, 6) should go to (4, 5).
+    const r = rotation(90, [5, 5]);
+    const [x, y] = apply(r, 5, 6);
+    expect(x).toBeCloseTo(4, 10);
+    expect(y).toBeCloseTo(5, 10);
+  });
+
+  it("leaves the pivot point fixed", () => {
+    const pivot: [number, number] = [3, 7];
+    const r = rotation(45, pivot);
+    const [x, y] = apply(r, ...pivot);
+    expect(x).toBeCloseTo(pivot[0], 10);
+    expect(y).toBeCloseTo(pivot[1], 10);
   });
 });

--- a/packages/affine/tests/affine.test.ts
+++ b/packages/affine/tests/affine.test.ts
@@ -83,6 +83,17 @@ describe("rotation", () => {
     expect(y).toBeCloseTo(1, 10);
   });
 
+  it("returns exact 0/±1 entries for right-angle rotations", () => {
+    // Math.cos(Math.PI / 2) is ~6e-17, not 0; cosSinDeg short-circuits these
+    // multiples of 90° so the resulting matrix has exact zeros. Slots derived
+    // from `-sa` carry `-0` when `sa === 0`, matching upstream Python `affine`.
+    expect(rotation(90)).toEqual([0, -1, 0, 1, 0, 0]);
+    expect(rotation(180)).toEqual([-1, -0, 0, 0, -1, 0]);
+    expect(rotation(270)).toEqual([0, 1, 0, -1, 0, 0]);
+    expect(rotation(360)).toEqual([1, -0, 0, 0, 1, 0]);
+    expect(rotation(-90)).toEqual([0, 1, 0, -1, 0, 0]);
+  });
+
   it("rotates 180° about the origin", () => {
     const r = rotation(180);
     const [x, y] = apply(r, 3, 4);

--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -283,12 +283,13 @@ export class COGLayer<
     >;
     const wrapped: RasterGetTileData = async (tile, options) => {
       const { x, y, z } = tile.index;
-      // TODO: should be able to (micro) optimize this to not create the array
-      // Something like:
-      // const image = z === geotiff.overviews.length - 1 ? geotiff :
-      //   geotiff.overviews[geotiff.overviews.length - 1 - z]!;
-      const images = [geotiff, ...geotiff.overviews];
-      const image = images[images.length - 1 - z]!;
+      // Levels are emitted coarsest-first with the full-res geotiff appended
+      // last, so z === overviews.length picks the full-res image and lower z
+      // picks the corresponding overview from the finest-first list.
+      const image =
+        z === geotiff.overviews.length
+          ? geotiff
+          : geotiff.overviews[geotiff.overviews.length - 1 - z]!;
       return userFn(image, {
         device: options.device,
         x,

--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -220,10 +220,8 @@ export class COGLayer<
         "Source projection is missing 'units' property, cannot compute meters per unit",
       );
     }
-    const semiMajorAxis: number | undefined =
-      sourceProjection.datum?.a ?? sourceProjection.a;
     const mpu = metersPerUnit(units as Parameters<typeof metersPerUnit>[0], {
-      semiMajorAxis,
+      semiMajorAxis: sourceProjection.datum?.a ?? sourceProjection.a,
     });
 
     const tilesetDescriptor = geoTiffToDescriptor(geotiff, {

--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -6,19 +6,14 @@ import type {
   RenderTileResult,
   TilesetDescriptor,
 } from "@developmentseed/deck.gl-raster";
-import {
-  RasterTileLayer,
-  TileMatrixSetAdaptor,
-} from "@developmentseed/deck.gl-raster";
+import { RasterTileLayer } from "@developmentseed/deck.gl-raster";
 import type { DecoderPool, GeoTIFF, Overview } from "@developmentseed/geotiff";
-import {
-  defaultDecoderPool,
-  generateTileMatrixSet,
-} from "@developmentseed/geotiff";
+import { defaultDecoderPool } from "@developmentseed/geotiff";
 import type { EpsgResolver, ProjectionDefinition } from "@developmentseed/proj";
 import {
   epsgResolver,
   makeClampedForwardTo3857,
+  metersPerUnit,
   parseWkt,
 } from "@developmentseed/proj";
 import type { Texture } from "@luma.gl/core";
@@ -26,6 +21,7 @@ import proj4 from "proj4";
 import { fetchGeoTIFF, getGeographicBounds } from "./geotiff/geotiff.js";
 import type { TextureDataT } from "./geotiff/render-pipeline.js";
 import { inferRenderPipeline } from "./geotiff/render-pipeline.js";
+import { geoTiffToDescriptor } from "./geotiff-tileset.js";
 
 export type { MinimalTileData } from "@developmentseed/deck.gl-raster";
 
@@ -199,8 +195,6 @@ export class COGLayer<
         ? await this.props.epsgResolver!(crs)
         : parseWkt(crs);
 
-    const tms = generateTileMatrixSet(geotiff, sourceProjection);
-
     // @ts-expect-error - proj4 typings are incomplete and don't support
     // wkt-parser input
     const converter4326 = proj4(sourceProjection, "EPSG:4326");
@@ -220,11 +214,24 @@ export class COGLayer<
     const projectFrom3857 = (x: number, y: number) =>
       converter3857.inverse<[number, number]>([x, y], false);
 
-    const tilesetDescriptor = new TileMatrixSetAdaptor(tms, {
+    const units = sourceProjection.units;
+    if (!units) {
+      throw new Error(
+        "Source projection is missing 'units' property, cannot compute meters per unit",
+      );
+    }
+    const semiMajorAxis: number | undefined =
+      sourceProjection.datum?.a ?? sourceProjection.a;
+    const mpu = metersPerUnit(units as Parameters<typeof metersPerUnit>[0], {
+      semiMajorAxis,
+    });
+
+    const tilesetDescriptor = geoTiffToDescriptor(geotiff, {
       projectTo4326,
       projectFrom4326,
       projectTo3857,
       projectFrom3857,
+      mpu,
     });
 
     if (this.props.onGeoTIFFLoad) {

--- a/packages/deck.gl-geotiff/src/geotiff-tileset.ts
+++ b/packages/deck.gl-geotiff/src/geotiff-tileset.ts
@@ -1,0 +1,58 @@
+import type { ProjectionFunction } from "@developmentseed/deck.gl-raster";
+import {
+  AffineTileset,
+  AffineTilesetLevel,
+} from "@developmentseed/deck.gl-raster";
+import type { GeoTIFF, Overview } from "@developmentseed/geotiff";
+
+/**
+ * Build an {@link AffineTileset} {@link TilesetDescriptor} from a {@link GeoTIFF}.
+ *
+ * Produces one {@link AffineTilesetLevel} per overview plus a final entry for
+ * the full-resolution image. Levels are emitted coarsest first.
+ *
+ * Replaces the previous `generateTileMatrixSet` + `TileMatrixSetAdaptor`
+ * pipeline. Because {@link AffineTilesetLevel} is parameterized by an
+ * arbitrary affine, this works correctly for COGs with rotated, skewed, or
+ * non-square-pixel geotransforms.
+ *
+ * @param geotiff  The opened GeoTIFF.
+ * @param opts     Projection functions and meters-per-CRS-unit.
+ */
+export function geoTiffToDescriptor(
+  geotiff: GeoTIFF,
+  opts: {
+    projectTo3857: ProjectionFunction;
+    projectFrom3857: ProjectionFunction;
+    projectTo4326: ProjectionFunction;
+    projectFrom4326: ProjectionFunction;
+    mpu: number;
+  },
+): AffineTileset {
+  // GeoTIFF.overviews is sorted finest-to-coarsest. Reverse for coarsest-first
+  // and append the full-resolution image as the finest level.
+  const images: Array<GeoTIFF | Overview> = [
+    ...[...geotiff.overviews].reverse(),
+    geotiff,
+  ];
+
+  const levels = images.map(
+    (img) =>
+      new AffineTilesetLevel({
+        affine: img.transform,
+        arrayWidth: img.width,
+        arrayHeight: img.height,
+        tileWidth: img.tileWidth,
+        tileHeight: img.tileHeight,
+        mpu: opts.mpu,
+      }),
+  );
+
+  return new AffineTileset({
+    levels,
+    projectTo3857: opts.projectTo3857,
+    projectFrom3857: opts.projectFrom3857,
+    projectTo4326: opts.projectTo4326,
+    projectFrom4326: opts.projectFrom4326,
+  });
+}

--- a/packages/deck.gl-geotiff/src/index.ts
+++ b/packages/deck.gl-geotiff/src/index.ts
@@ -5,7 +5,6 @@ export type {
 } from "./cog-layer.js";
 export { COGLayer } from "./cog-layer.js";
 export * as texture from "./geotiff/texture.js";
-export { geoTiffToDescriptor } from "./geotiff-tileset.js";
 export type { MosaicLayerProps } from "./mosaic-layer/mosaic-layer.js";
 export { MosaicLayer } from "./mosaic-layer/mosaic-layer.js";
 export {

--- a/packages/deck.gl-geotiff/src/index.ts
+++ b/packages/deck.gl-geotiff/src/index.ts
@@ -5,6 +5,7 @@ export type {
 } from "./cog-layer.js";
 export { COGLayer } from "./cog-layer.js";
 export * as texture from "./geotiff/texture.js";
+export { geoTiffToDescriptor } from "./geotiff-tileset.js";
 export type { MosaicLayerProps } from "./mosaic-layer/mosaic-layer.js";
 export { MosaicLayer } from "./mosaic-layer/mosaic-layer.js";
 export {

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -28,7 +28,6 @@ import {
   RasterTileset2D,
   resolveSecondaryTiles,
   selectSecondaryLevel,
-  TileMatrixSetAdaptor,
   tilesetLevelsEqual,
 } from "@developmentseed/deck.gl-raster";
 import {
@@ -41,24 +40,19 @@ import type {
   Overview,
   RasterArray,
 } from "@developmentseed/geotiff";
-import {
-  assembleTiles,
-  defaultDecoderPool,
-  generateTileMatrixSet,
-} from "@developmentseed/geotiff";
-import type { TileMatrixSet } from "@developmentseed/morecantile";
-import { tileTransform } from "@developmentseed/morecantile";
+import { assembleTiles, defaultDecoderPool } from "@developmentseed/geotiff";
 import type { EpsgResolver } from "@developmentseed/proj";
 import {
   epsgResolver as defaultEpsgResolver,
   makeClampedForwardTo3857,
+  metersPerUnit,
   parseWkt,
 } from "@developmentseed/proj";
 import type { ReprojectionFns } from "@developmentseed/raster-reproject";
 import type { Device, Texture, TextureFormat } from "@luma.gl/core";
 import proj4 from "proj4";
 import { fetchGeoTIFF, getGeographicBounds } from "./geotiff/geotiff.js";
-import { fromAffine } from "./geotiff-reprojection.js";
+import { geoTiffToDescriptor } from "./geotiff-tileset.js";
 
 /** Size of deck.gl's common coordinate space in world units. */
 const TILE_SIZE = 512;
@@ -161,7 +155,6 @@ export interface MultiCOGSourceConfig {
 /** Internal state for a single opened COG source. */
 interface SourceState {
   geotiff: GeoTIFF;
-  tms: TileMatrixSet;
 }
 
 /**
@@ -302,7 +295,7 @@ const defaultProps = {
  *
  * @see {@link MultiCOGLayerProps} for accepted props.
  * @see {@link createMultiTilesetDescriptor} for the grouping logic.
- * @see {@link TileMatrixSetAdaptor} for the per-source tileset adapter.
+ * @see {@link geoTiffToDescriptor} for the per-source tileset descriptor.
  */
 export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
   static override layerName = "MultiCOGLayer";
@@ -367,8 +360,7 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
           typeof crs === "number"
             ? await this.props.epsgResolver!(crs)
             : parseWkt(crs);
-        const tms = generateTileMatrixSet(geotiff, sourceProjection);
-        return { name, geotiff, tms, sourceProjection };
+        return { name, geotiff, sourceProjection };
       }),
     );
 
@@ -396,22 +388,32 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
     const inverseFrom3857 = (x: number, y: number) =>
       converter3857.inverse<[number, number]>([x, y], false);
 
+    const units = sourceProjection.units;
+    if (!units) {
+      throw new Error(
+        "Source projection is missing 'units' property, cannot compute meters per unit",
+      );
+    }
+    const semiMajorAxis: number | undefined =
+      sourceProjection.datum?.a ?? sourceProjection.a;
+    const mpu = metersPerUnit(units as Parameters<typeof metersPerUnit>[0], {
+      semiMajorAxis,
+    });
+
     // Build TilesetDescriptors
     const tilesetMap = new Map<string, TilesetDescriptor>();
     const sourceMap = new Map<string, SourceState>();
 
     for (const cogSource of cogSources) {
-      const descriptor = new TileMatrixSetAdaptor(cogSource.tms, {
+      const descriptor = geoTiffToDescriptor(cogSource.geotiff, {
         projectTo4326: forwardTo4326,
         projectFrom4326: inverseFrom4326,
         projectTo3857: forwardTo3857,
         projectFrom3857: inverseFrom3857,
+        mpu,
       });
       tilesetMap.set(cogSource.name, descriptor);
-      sourceMap.set(cogSource.name, {
-        geotiff: cogSource.geotiff,
-        tms: cogSource.tms,
-      });
+      sourceMap.set(cogSource.name, { geotiff: cogSource.geotiff });
     }
 
     const multiDescriptor = createMultiTilesetDescriptor(tilesetMap);
@@ -464,15 +466,13 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
         ? AbortSignal.any([signal, this.props.signal])
         : signal || this.props.signal;
 
-    // Compute reprojection transforms from the primary TMS
+    // Compute per-tile reprojection transforms from the primary descriptor
     const primaryKey = multiDescriptor!.primaryKey;
-    const primarySource = sources!.get(primaryKey)!;
-    const primaryTms = primarySource.tms;
-    const tileMatrix = primaryTms.tileMatrices[z]!;
-    const tileAffine = tileTransform(tileMatrix, { col: x, row: y });
-    const { forwardTransform, inverseTransform } = fromAffine(tileAffine);
-
     const primaryLevel = multiDescriptor!.primary.levels[z]!;
+    const { forwardTransform, inverseTransform } = primaryLevel.tileTransform(
+      x,
+      y,
+    );
 
     // Collect fetch promises for all bands
     const bandPromises: Array<

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -394,10 +394,8 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
         "Source projection is missing 'units' property, cannot compute meters per unit",
       );
     }
-    const semiMajorAxis: number | undefined =
-      sourceProjection.datum?.a ?? sourceProjection.a;
     const mpu = metersPerUnit(units as Parameters<typeof metersPerUnit>[0], {
-      semiMajorAxis,
+      semiMajorAxis: sourceProjection.datum?.a ?? sourceProjection.a,
     });
 
     // Build TilesetDescriptors

--- a/packages/deck.gl-geotiff/tests/geotiff-tileset.test.ts
+++ b/packages/deck.gl-geotiff/tests/geotiff-tileset.test.ts
@@ -1,0 +1,92 @@
+import type { GeoTIFF, Overview } from "@developmentseed/geotiff";
+import { describe, expect, it } from "vitest";
+import { geoTiffToDescriptor } from "../src/geotiff-tileset.js";
+
+const identityProjection = (x: number, y: number): [number, number] => [x, y];
+const PROJECTIONS = {
+  projectTo3857: identityProjection,
+  projectFrom3857: identityProjection,
+  projectTo4326: identityProjection,
+  projectFrom4326: identityProjection,
+};
+
+function makeOverview(
+  width: number,
+  height: number,
+  tileWidth: number,
+  tileHeight: number,
+  affine: readonly [number, number, number, number, number, number],
+): Overview {
+  return {
+    width,
+    height,
+    tileWidth,
+    tileHeight,
+    transform: affine,
+  } as unknown as Overview;
+}
+
+describe("geoTiffToDescriptor", () => {
+  it("creates one level per overview plus the full-resolution image, coarsest first", () => {
+    // GeoTIFF.overviews is sorted finest-to-coarsest. Reversed and with the
+    // full-res image appended, the levels emitted should be:
+    // coarser overview (200), finer overview (400), full-res (800).
+    const fullRes = makeOverview(800, 800, 256, 256, [10, 0, 0, 0, -10, 8000]);
+    const finerOverview = makeOverview(
+      400,
+      400,
+      256,
+      256,
+      [20, 0, 0, 0, -20, 8000],
+    );
+    const coarserOverview = makeOverview(
+      200,
+      200,
+      256,
+      256,
+      [40, 0, 0, 0, -40, 8000],
+    );
+    const geotiff = {
+      width: fullRes.width,
+      height: fullRes.height,
+      tileWidth: fullRes.tileWidth,
+      tileHeight: fullRes.tileHeight,
+      transform: fullRes.transform,
+      overviews: [finerOverview, coarserOverview],
+    } as unknown as GeoTIFF;
+
+    const descriptor = geoTiffToDescriptor(geotiff, {
+      ...PROJECTIONS,
+      mpu: 1,
+    });
+
+    expect(descriptor.levels).toHaveLength(3);
+    // Coarsest first: matrixWidth = ceil(200/256) = 1
+    expect(descriptor.levels[0]!.matrixWidth).toBe(1);
+    // Full-res last: matrixWidth = ceil(800/256) = 4
+    expect(descriptor.levels[2]!.matrixWidth).toBe(4);
+  });
+
+  it("propagates projection functions and computes projectedBounds from coarsest level", () => {
+    const fullRes = makeOverview(8, 8, 4, 4, [10, 0, 100, 0, -10, 200]);
+    const coarseOverview = makeOverview(4, 4, 4, 4, [20, 0, 100, 0, -20, 200]);
+    const geotiff = {
+      width: fullRes.width,
+      height: fullRes.height,
+      tileWidth: fullRes.tileWidth,
+      tileHeight: fullRes.tileHeight,
+      transform: fullRes.transform,
+      overviews: [coarseOverview],
+    } as unknown as GeoTIFF;
+
+    const descriptor = geoTiffToDescriptor(geotiff, {
+      ...PROJECTIONS,
+      mpu: 1,
+    });
+
+    expect(descriptor.projectTo3857).toBe(PROJECTIONS.projectTo3857);
+    // Coarsest 4×4 array, affine [20,0,100,0,-20,200]
+    // → corners (100,200), (180,200), (100,120), (180,120)
+    expect(descriptor.projectedBounds).toEqual([100, 120, 180, 200]);
+  });
+});

--- a/packages/deck.gl-raster/src/index.ts
+++ b/packages/deck.gl-raster/src/index.ts
@@ -22,6 +22,8 @@ export type {
 } from "./raster-tile-layer/index.js";
 export { RasterTileLayer } from "./raster-tile-layer/index.js";
 export type {
+  AffineTilesetLevelOptions,
+  AffineTilesetOptions,
   Bounds,
   CornerBounds,
   Corners,
@@ -31,6 +33,8 @@ export type {
   TilesetLevel,
 } from "./raster-tileset/index.js";
 export {
+  AffineTileset,
+  AffineTilesetLevel,
   RasterTileset2D,
   TileMatrixSetAdaptor,
 } from "./raster-tileset/index.js";

--- a/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
@@ -115,10 +115,14 @@ export class AffineTilesetLevel implements TilesetLevel {
     const maxColIdx = this.matrixWidth - 1;
     const maxRowIdx = this.matrixHeight - 1;
 
-    const minCol = Math.max(0, Math.min(maxColIdx, Math.floor(pixMinX / tw)));
-    const maxCol = Math.max(0, Math.min(maxColIdx, Math.floor(pixMaxX / tw)));
-    const minRow = Math.max(0, Math.min(maxRowIdx, Math.floor(pixMinY / th)));
-    const maxRow = Math.max(0, Math.min(maxRowIdx, Math.floor(pixMaxY / th)));
+    // Asymmetric clamping: only clamp minCol/minRow up from below and
+    // maxCol/maxRow down from above. If the bbox lies entirely outside the
+    // array, this produces an empty range (min > max) so the consumer's
+    // `for (i = min; i <= max; i++)` loop does nothing.
+    const minCol = Math.max(0, Math.floor(pixMinX / tw));
+    const maxCol = Math.min(maxColIdx, Math.floor(pixMaxX / tw));
+    const minRow = Math.max(0, Math.floor(pixMinY / th));
+    const maxRow = Math.min(maxRowIdx, Math.floor(pixMaxY / th));
 
     return { minCol, maxCol, minRow, maxRow };
   }

--- a/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
@@ -31,50 +31,32 @@ export interface AffineTilesetLevelOptions {
  * implementing {@link TilesetLevel} manually.
  */
 export class AffineTilesetLevel implements TilesetLevel {
+  readonly tileWidth: number;
+  readonly tileHeight: number;
+  readonly matrixWidth: number;
+  readonly matrixHeight: number;
+  readonly metersPerPixel: number;
+
   private readonly _affine: Affine;
   private readonly _invAffine: Affine;
-  private readonly _arrayWidth: number;
-  private readonly _arrayHeight: number;
-  private readonly _tileWidth: number;
-  private readonly _tileHeight: number;
-  private readonly _mpu: number;
 
   constructor(options: AffineTilesetLevelOptions) {
     this._affine = options.affine;
     this._invAffine = affine.invert(options.affine);
-    this._arrayWidth = options.arrayWidth;
-    this._arrayHeight = options.arrayHeight;
-    this._tileWidth = options.tileWidth;
-    this._tileHeight = options.tileHeight;
-    this._mpu = options.mpu;
-  }
+    this.tileWidth = options.tileWidth;
+    this.tileHeight = options.tileHeight;
+    this.matrixWidth = Math.ceil(options.arrayWidth / options.tileWidth);
+    this.matrixHeight = Math.ceil(options.arrayHeight / options.tileHeight);
 
-  get matrixWidth(): number {
-    return Math.ceil(this._arrayWidth / this._tileWidth);
-  }
-
-  get matrixHeight(): number {
-    return Math.ceil(this._arrayHeight / this._tileHeight);
-  }
-
-  get tileWidth(): number {
-    return this._tileWidth;
-  }
-
-  get tileHeight(): number {
-    return this._tileHeight;
-  }
-
-  get metersPerPixel(): number {
     // Geometric mean of the two pixel-edge scales handles non-square pixels.
-    const a = affine.a(this._affine);
-    const e = affine.e(this._affine);
-    return Math.sqrt(Math.abs(a * e)) * this._mpu;
+    const a = affine.a(options.affine);
+    const e = affine.e(options.affine);
+    this.metersPerPixel = Math.sqrt(Math.abs(a * e)) * options.mpu;
   }
 
   projectedTileCorners(col: number, row: number): Corners {
-    const tw = this._tileWidth;
-    const th = this._tileHeight;
+    const tw = this.tileWidth;
+    const th = this.tileHeight;
     const af = this._affine;
 
     return {
@@ -93,8 +75,8 @@ export class AffineTilesetLevel implements TilesetLevel {
     inverseTransform: (x: number, y: number) => [number, number];
   } {
     const tileOffset = affine.translation(
-      col * this._tileWidth,
-      row * this._tileHeight,
+      col * this.tileWidth,
+      row * this.tileHeight,
     );
     const tileAffine = affine.compose(this._affine, tileOffset);
     const invTileAffine = affine.invert(tileAffine);
@@ -128,8 +110,8 @@ export class AffineTilesetLevel implements TilesetLevel {
     const pixMinY = Math.min(...ys);
     const pixMaxY = Math.max(...ys);
 
-    const tw = this._tileWidth;
-    const th = this._tileHeight;
+    const tw = this.tileWidth;
+    const th = this.tileHeight;
     const maxColIdx = this.matrixWidth - 1;
     const maxRowIdx = this.matrixHeight - 1;
 

--- a/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
@@ -1,0 +1,143 @@
+import type { Affine } from "@developmentseed/affine";
+import * as affine from "@developmentseed/affine";
+import type { TilesetLevel } from "./tileset-interface.js";
+import type { Corners } from "./types.js";
+
+/**
+ * Constructor options for {@link AffineTilesetLevel}.
+ */
+export interface AffineTilesetLevelOptions {
+  /** Pixel → CRS affine transform for this resolution level. */
+  affine: Affine;
+  /** Full level width, in pixels. */
+  arrayWidth: number;
+  /** Full level height, in pixels. */
+  arrayHeight: number;
+  /** Tile width, in pixels. */
+  tileWidth: number;
+  /** Tile height, in pixels. */
+  tileHeight: number;
+  /** Meters per CRS unit (1 for metric CRSes, ≈111000 for WGS84). */
+  mpu: number;
+}
+
+/**
+ * A {@link TilesetLevel} described by a single affine transform plus tile and
+ * array sizes.
+ *
+ * This handles axis-aligned, rotated, skewed, and non-square-pixel grids
+ * uniformly. Sources that fit this shape (tiled GeoTIFF overviews, GeoZarr
+ * multiscales) can construct one of these per resolution level instead of
+ * implementing {@link TilesetLevel} manually.
+ */
+export class AffineTilesetLevel implements TilesetLevel {
+  private readonly _affine: Affine;
+  private readonly _invAffine: Affine;
+  private readonly _arrayWidth: number;
+  private readonly _arrayHeight: number;
+  private readonly _tileWidth: number;
+  private readonly _tileHeight: number;
+  private readonly _mpu: number;
+
+  constructor(options: AffineTilesetLevelOptions) {
+    this._affine = options.affine;
+    this._invAffine = affine.invert(options.affine);
+    this._arrayWidth = options.arrayWidth;
+    this._arrayHeight = options.arrayHeight;
+    this._tileWidth = options.tileWidth;
+    this._tileHeight = options.tileHeight;
+    this._mpu = options.mpu;
+  }
+
+  get matrixWidth(): number {
+    return Math.ceil(this._arrayWidth / this._tileWidth);
+  }
+
+  get matrixHeight(): number {
+    return Math.ceil(this._arrayHeight / this._tileHeight);
+  }
+
+  get tileWidth(): number {
+    return this._tileWidth;
+  }
+
+  get tileHeight(): number {
+    return this._tileHeight;
+  }
+
+  get metersPerPixel(): number {
+    // Geometric mean of the two pixel-edge scales handles non-square pixels.
+    const a = affine.a(this._affine);
+    const e = affine.e(this._affine);
+    return Math.sqrt(Math.abs(a * e)) * this._mpu;
+  }
+
+  projectedTileCorners(col: number, row: number): Corners {
+    const tw = this._tileWidth;
+    const th = this._tileHeight;
+    const af = this._affine;
+
+    return {
+      topLeft: affine.apply(af, col * tw, row * th),
+      topRight: affine.apply(af, (col + 1) * tw, row * th),
+      bottomLeft: affine.apply(af, col * tw, (row + 1) * th),
+      bottomRight: affine.apply(af, (col + 1) * tw, (row + 1) * th),
+    };
+  }
+
+  tileTransform(
+    col: number,
+    row: number,
+  ): {
+    forwardTransform: (x: number, y: number) => [number, number];
+    inverseTransform: (x: number, y: number) => [number, number];
+  } {
+    const tileOffset = affine.translation(
+      col * this._tileWidth,
+      row * this._tileHeight,
+    );
+    const tileAffine = affine.compose(this._affine, tileOffset);
+    const invTileAffine = affine.invert(tileAffine);
+    return {
+      forwardTransform: (x, y) => affine.apply(tileAffine, x, y),
+      inverseTransform: (x, y) => affine.apply(invTileAffine, x, y),
+    };
+  }
+
+  crsBoundsToTileRange(
+    projectedMinX: number,
+    projectedMinY: number,
+    projectedMaxX: number,
+    projectedMaxY: number,
+  ): { minCol: number; maxCol: number; minRow: number; maxRow: number } {
+    // Map all four CRS corners through the inverse affine to get pixel coords,
+    // then take the bbox in pixel space (handles rotation correctly).
+    const inv = this._invAffine;
+    const pixelCorners = [
+      affine.apply(inv, projectedMinX, projectedMinY),
+      affine.apply(inv, projectedMaxX, projectedMinY),
+      affine.apply(inv, projectedMinX, projectedMaxY),
+      affine.apply(inv, projectedMaxX, projectedMaxY),
+    ];
+
+    const xs = pixelCorners.map(([px]) => px);
+    const ys = pixelCorners.map(([, py]) => py);
+
+    const pixMinX = Math.min(...xs);
+    const pixMaxX = Math.max(...xs);
+    const pixMinY = Math.min(...ys);
+    const pixMaxY = Math.max(...ys);
+
+    const tw = this._tileWidth;
+    const th = this._tileHeight;
+    const maxColIdx = this.matrixWidth - 1;
+    const maxRowIdx = this.matrixHeight - 1;
+
+    const minCol = Math.max(0, Math.min(maxColIdx, Math.floor(pixMinX / tw)));
+    const maxCol = Math.max(0, Math.min(maxColIdx, Math.floor(pixMaxX / tw)));
+    const minRow = Math.max(0, Math.min(maxRowIdx, Math.floor(pixMinY / th)));
+    const maxRow = Math.max(0, Math.min(maxRowIdx, Math.floor(pixMaxY / th)));
+
+    return { minCol, maxCol, minRow, maxRow };
+  }
+}

--- a/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
@@ -1,7 +1,7 @@
 import type { Affine } from "@developmentseed/affine";
 import * as affine from "@developmentseed/affine";
 import type { TilesetLevel } from "./tileset-interface.js";
-import type { Corners } from "./types.js";
+import type { Bounds, Corners } from "./types.js";
 
 /**
  * Constructor options for {@link AffineTilesetLevel}.
@@ -36,6 +36,11 @@ export class AffineTilesetLevel implements TilesetLevel {
   readonly matrixWidth: number;
   readonly matrixHeight: number;
   readonly metersPerPixel: number;
+  /**
+   * Source-CRS bounding box of the level's array `[minX, minY, maxX, maxY]`.
+   * Computed from the affine applied to the four array corners.
+   */
+  readonly projectedBounds: Bounds;
 
   private readonly _affine: Affine;
   private readonly _invAffine: Affine;
@@ -52,6 +57,21 @@ export class AffineTilesetLevel implements TilesetLevel {
     const a = affine.a(options.affine);
     const e = affine.e(options.affine);
     this.metersPerPixel = Math.sqrt(Math.abs(a * e)) * options.mpu;
+
+    const corners = [
+      affine.apply(options.affine, 0, 0),
+      affine.apply(options.affine, options.arrayWidth, 0),
+      affine.apply(options.affine, 0, options.arrayHeight),
+      affine.apply(options.affine, options.arrayWidth, options.arrayHeight),
+    ];
+    const xs = corners.map(([x]) => x);
+    const ys = corners.map(([, y]) => y);
+    this.projectedBounds = [
+      Math.min(...xs),
+      Math.min(...ys),
+      Math.max(...xs),
+      Math.max(...ys),
+    ];
   }
 
   projectedTileCorners(col: number, row: number): Corners {

--- a/packages/deck.gl-raster/src/raster-tileset/affine-tileset.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/affine-tileset.ts
@@ -1,0 +1,46 @@
+import type { AffineTilesetLevel } from "./affine-tileset-level.js";
+import type { TilesetDescriptor } from "./tileset-interface.js";
+import type { Bounds, ProjectionFunction } from "./types.js";
+
+/**
+ * Constructor options for {@link AffineTileset}.
+ */
+export interface AffineTilesetOptions {
+  /** Resolution levels, ordered coarsest first. */
+  levels: AffineTilesetLevel[];
+  /** Forward projection function from source CRS to EPSG:3857. */
+  projectTo3857: ProjectionFunction;
+  /** Inverse projection function from EPSG:3857 to source CRS. */
+  projectFrom3857: ProjectionFunction;
+  /** Forward projection function from source CRS to EPSG:4326. */
+  projectTo4326: ProjectionFunction;
+  /** Inverse projection function from EPSG:4326 to source CRS. */
+  projectFrom4326: ProjectionFunction;
+}
+
+/**
+ * A {@link TilesetDescriptor} backed by per-level affine transforms.
+ *
+ * Derives `projectedBounds` from the coarsest level's array. Everything else
+ * is passed through from the constructor options.
+ */
+export class AffineTileset implements TilesetDescriptor {
+  readonly levels: AffineTilesetLevel[];
+  readonly projectTo3857: ProjectionFunction;
+  readonly projectFrom3857: ProjectionFunction;
+  readonly projectTo4326: ProjectionFunction;
+  readonly projectFrom4326: ProjectionFunction;
+  readonly projectedBounds: Bounds;
+
+  constructor(options: AffineTilesetOptions) {
+    if (options.levels.length === 0) {
+      throw new Error("AffineTileset requires at least one level");
+    }
+    this.levels = options.levels;
+    this.projectTo3857 = options.projectTo3857;
+    this.projectFrom3857 = options.projectFrom3857;
+    this.projectTo4326 = options.projectTo4326;
+    this.projectFrom4326 = options.projectFrom4326;
+    this.projectedBounds = options.levels[0]!.projectedBounds;
+  }
+}

--- a/packages/deck.gl-raster/src/raster-tileset/index.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/index.ts
@@ -1,3 +1,7 @@
+export type { AffineTilesetOptions } from "./affine-tileset.js";
+export { AffineTileset } from "./affine-tileset.js";
+export type { AffineTilesetLevelOptions } from "./affine-tileset-level.js";
+export { AffineTilesetLevel } from "./affine-tileset-level.js";
 export type { TileMetadata } from "./raster-tileset-2d.js";
 export { RasterTileset2D } from "./raster-tileset-2d.js";
 export { TileMatrixSetAdaptor } from "./tile-matrix-set.js";

--- a/packages/deck.gl-raster/tests/raster-tileset/affine-tileset-level.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/affine-tileset-level.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { AffineTilesetLevel } from "../../src/raster-tileset/affine-tileset-level.js";
+
+// Top-left origin, 10 CRS units per pixel, square pixels.
+// x = 10*col + 100, y = -10*row + 200
+const SQUARE_AFFINE = [10, 0, 100, 0, -10, 200] as const;
+
+// Non-square pixels: 10 CRS units wide, 5 CRS units tall.
+// x = 10*col + 100, y = -5*row + 200
+const NON_SQUARE_AFFINE = [10, 0, 100, 0, -5, 200] as const;
+
+// 30° rotation around origin, 10 unit scale.
+const ROT30 = (Math.PI * 30) / 180;
+const ROTATED_AFFINE = [
+  10 * Math.cos(ROT30),
+  -10 * Math.sin(ROT30),
+  100,
+  10 * Math.sin(ROT30),
+  10 * Math.cos(ROT30),
+  200,
+] as const;
+
+describe("AffineTilesetLevel", () => {
+  describe("matrix dimensions", () => {
+    it("computes matrixWidth and matrixHeight via ceil(arraySize / tileSize)", () => {
+      const level = new AffineTilesetLevel({
+        affine: SQUARE_AFFINE,
+        arrayWidth: 10,
+        arrayHeight: 12,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      expect(level.matrixWidth).toBe(3);
+      expect(level.matrixHeight).toBe(3);
+    });
+  });
+
+  describe("metersPerPixel", () => {
+    it("returns mpu * pixel size for square pixels", () => {
+      const level = new AffineTilesetLevel({
+        affine: SQUARE_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      expect(level.metersPerPixel).toBeCloseTo(10, 10);
+    });
+
+    it("returns geometric mean of pixel edges for non-square pixels", () => {
+      const level = new AffineTilesetLevel({
+        affine: NON_SQUARE_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      expect(level.metersPerPixel).toBeCloseTo(Math.sqrt(50), 10);
+    });
+
+    it("multiplies by mpu for non-meter CRS units", () => {
+      const level = new AffineTilesetLevel({
+        affine: SQUARE_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 111000,
+      });
+      expect(level.metersPerPixel).toBeCloseTo(10 * 111000, 5);
+    });
+  });
+
+  describe("projectedTileCorners", () => {
+    it("returns the four CRS corners of an axis-aligned tile", () => {
+      const level = new AffineTilesetLevel({
+        affine: SQUARE_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      const corners = level.projectedTileCorners(0, 0);
+      expect(corners.topLeft).toEqual([100, 200]);
+      expect(corners.topRight).toEqual([140, 200]);
+      expect(corners.bottomLeft).toEqual([100, 160]);
+      expect(corners.bottomRight).toEqual([140, 160]);
+    });
+
+    it("returns rotated quadrilateral corners for a rotated affine", () => {
+      const level = new AffineTilesetLevel({
+        affine: ROTATED_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      const corners = level.projectedTileCorners(0, 0);
+      expect(corners.topLeft[0]).toBeCloseTo(100, 10);
+      expect(corners.topLeft[1]).toBeCloseTo(200, 10);
+      expect(corners.topRight[0]).toBeCloseTo(
+        100 + 4 * 10 * Math.cos(ROT30),
+        10,
+      );
+      expect(corners.topRight[1]).toBeCloseTo(
+        200 + 4 * 10 * Math.sin(ROT30),
+        10,
+      );
+    });
+  });
+
+  describe("tileTransform", () => {
+    it("maps tile-local pixel (0,0) of tile (1,1) to the correct CRS coord", () => {
+      const level = new AffineTilesetLevel({
+        affine: SQUARE_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      const { forwardTransform } = level.tileTransform(1, 1);
+      const [x, y] = forwardTransform(0, 0);
+      expect(x).toBeCloseTo(140, 10);
+      expect(y).toBeCloseTo(160, 10);
+    });
+
+    it("round-trips through forward+inverse", () => {
+      const level = new AffineTilesetLevel({
+        affine: ROTATED_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      const { forwardTransform, inverseTransform } = level.tileTransform(1, 0);
+      const [cx, cy] = forwardTransform(2.5, 1.5);
+      const [px, py] = inverseTransform(cx, cy);
+      expect(px).toBeCloseTo(2.5, 10);
+      expect(py).toBeCloseTo(1.5, 10);
+    });
+  });
+
+  describe("crsBoundsToTileRange", () => {
+    it("maps a CRS bbox covering tile (1,1) only to that single tile", () => {
+      const level = new AffineTilesetLevel({
+        affine: SQUARE_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      const range = level.crsBoundsToTileRange(141, 121, 179, 159);
+      expect(range).toEqual({ minCol: 1, maxCol: 1, minRow: 1, maxRow: 1 });
+    });
+
+    it("clamps negative or out-of-range indices to matrix bounds", () => {
+      const level = new AffineTilesetLevel({
+        affine: SQUARE_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      const range = level.crsBoundsToTileRange(-10000, -10000, 10000, 10000);
+      expect(range).toEqual({ minCol: 0, maxCol: 1, minRow: 0, maxRow: 1 });
+    });
+
+    it("handles non-square pixels correctly", () => {
+      const level = new AffineTilesetLevel({
+        affine: NON_SQUARE_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      const range = level.crsBoundsToTileRange(101, 181, 139, 199);
+      expect(range).toEqual({ minCol: 0, maxCol: 0, minRow: 0, maxRow: 0 });
+    });
+  });
+});

--- a/packages/deck.gl-raster/tests/raster-tileset/affine-tileset-level.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/affine-tileset-level.test.ts
@@ -1,24 +1,19 @@
+import { compose, rotation, scale, translation } from "@developmentseed/affine";
 import { describe, expect, it } from "vitest";
 import { AffineTilesetLevel } from "../../src/raster-tileset/affine-tileset-level.js";
 
-// Top-left origin, 10 CRS units per pixel, square pixels.
-// x = 10*col + 100, y = -10*row + 200
-const SQUARE_AFFINE = [10, 0, 100, 0, -10, 200] as const;
+// Top-left origin, 10 CRS units per pixel, square pixels (Y axis flipped).
+const SQUARE_AFFINE = compose(translation(100, 200), scale(10, -10));
 
-// Non-square pixels: 10 CRS units wide, 5 CRS units tall.
-// x = 10*col + 100, y = -5*row + 200
-const NON_SQUARE_AFFINE = [10, 0, 100, 0, -5, 200] as const;
+// Non-square pixels: 10 CRS units wide, 5 CRS units tall (Y axis flipped).
+const NON_SQUARE_AFFINE = compose(translation(100, 200), scale(10, -5));
 
-// 30° rotation around origin, 10 unit scale.
-const ROT30 = (Math.PI * 30) / 180;
-const ROTATED_AFFINE = [
-  10 * Math.cos(ROT30),
-  -10 * Math.sin(ROT30),
-  100,
-  10 * Math.sin(ROT30),
-  10 * Math.cos(ROT30),
-  200,
-] as const;
+// 30° rotation around the origin, then 10× scale, translated to (100, 200).
+const ROT30_DEG = 30;
+const ROTATED_AFFINE = compose(
+  translation(100, 200),
+  compose(rotation(ROT30_DEG), scale(10)),
+);
 
 describe("AffineTilesetLevel", () => {
   describe("matrix dimensions", () => {
@@ -103,14 +98,9 @@ describe("AffineTilesetLevel", () => {
       const corners = level.projectedTileCorners(0, 0);
       expect(corners.topLeft[0]).toBeCloseTo(100, 10);
       expect(corners.topLeft[1]).toBeCloseTo(200, 10);
-      expect(corners.topRight[0]).toBeCloseTo(
-        100 + 4 * 10 * Math.cos(ROT30),
-        10,
-      );
-      expect(corners.topRight[1]).toBeCloseTo(
-        200 + 4 * 10 * Math.sin(ROT30),
-        10,
-      );
+      const rad = (ROT30_DEG * Math.PI) / 180;
+      expect(corners.topRight[0]).toBeCloseTo(100 + 4 * 10 * Math.cos(rad), 10);
+      expect(corners.topRight[1]).toBeCloseTo(200 + 4 * 10 * Math.sin(rad), 10);
     });
   });
 

--- a/packages/deck.gl-raster/tests/raster-tileset/affine-tileset-level.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/affine-tileset-level.test.ts
@@ -174,6 +174,23 @@ describe("AffineTilesetLevel", () => {
       expect(range).toEqual({ minCol: 0, maxCol: 1, minRow: 0, maxRow: 1 });
     });
 
+    it("returns an empty range (min > max) when the bbox lies entirely outside the array", () => {
+      const level = new AffineTilesetLevel({
+        affine: SQUARE_AFFINE,
+        arrayWidth: 8,
+        arrayHeight: 8,
+        tileWidth: 4,
+        tileHeight: 4,
+        mpu: 1,
+      });
+      // Array CRS extent: x ∈ [100, 180), y ∈ [200, 120). Pick a bbox far to
+      // the right of the array.
+      const range = level.crsBoundsToTileRange(1000, 1000, 2000, 2000);
+      // minCol > maxCol means the consumer's `for (col=min; col<=max)` loop
+      // emits no tiles — which is what we want for a non-overlapping bbox.
+      expect(range.minCol).toBeGreaterThan(range.maxCol);
+    });
+
     it("handles non-square pixels correctly", () => {
       const level = new AffineTilesetLevel({
         affine: NON_SQUARE_AFFINE,

--- a/packages/deck.gl-raster/tests/raster-tileset/affine-tileset-level.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/affine-tileset-level.test.ts
@@ -8,7 +8,7 @@ const SQUARE_AFFINE = compose(translation(100, 200), scale(10, -10));
 // Non-square pixels: 10 CRS units wide, 5 CRS units tall (Y axis flipped).
 const NON_SQUARE_AFFINE = compose(translation(100, 200), scale(10, -5));
 
-// 30° rotation around the origin, then 10× scale, translated to (100, 200).
+// Pixel → CRS: scale by 10, rotate 30° CCW about origin, translate to (100, 200).
 const ROT30_DEG = 30;
 const ROTATED_AFFINE = compose(
   translation(100, 200),

--- a/packages/deck.gl-raster/tests/raster-tileset/affine-tileset.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/affine-tileset.test.ts
@@ -1,0 +1,88 @@
+import { compose, scale, translation } from "@developmentseed/affine";
+import { describe, expect, it } from "vitest";
+import { AffineTileset } from "../../src/raster-tileset/affine-tileset.js";
+import { AffineTilesetLevel } from "../../src/raster-tileset/affine-tileset-level.js";
+
+const identityProjection = (x: number, y: number): [number, number] => [x, y];
+
+const PROJECTIONS = {
+  projectTo3857: identityProjection,
+  projectFrom3857: identityProjection,
+  projectTo4326: identityProjection,
+  projectFrom4326: identityProjection,
+};
+
+describe("AffineTileset", () => {
+  it("derives projectedBounds from the coarsest level (axis-aligned)", () => {
+    // Coarsest: 4×4 array, 20-units-per-pixel, top-left origin at (100, 200).
+    const coarsest = new AffineTilesetLevel({
+      affine: compose(translation(100, 200), scale(20, -20)),
+      arrayWidth: 4,
+      arrayHeight: 4,
+      tileWidth: 4,
+      tileHeight: 4,
+      mpu: 1,
+    });
+    const finest = new AffineTilesetLevel({
+      affine: compose(translation(100, 200), scale(10, -10)),
+      arrayWidth: 8,
+      arrayHeight: 8,
+      tileWidth: 4,
+      tileHeight: 4,
+      mpu: 1,
+    });
+    const tileset = new AffineTileset({
+      levels: [coarsest, finest],
+      ...PROJECTIONS,
+    });
+    expect(tileset.projectedBounds).toEqual([100, 120, 180, 200]);
+  });
+
+  it("derives projectedBounds correctly for a rotated coarsest level", () => {
+    // Affine [0, -1, 100, 1, 0, 200] rotates pixel (x,y) → CRS (-y+100, x+200).
+    // 4×4 array corners: (100,200), (100,204), (96,200), (96,204).
+    const coarsest = new AffineTilesetLevel({
+      affine: [0, -1, 100, 1, 0, 200],
+      arrayWidth: 4,
+      arrayHeight: 4,
+      tileWidth: 4,
+      tileHeight: 4,
+      mpu: 1,
+    });
+    const tileset = new AffineTileset({
+      levels: [coarsest],
+      ...PROJECTIONS,
+    });
+    expect(tileset.projectedBounds).toEqual([96, 200, 100, 204]);
+  });
+
+  it("exposes levels and projection functions verbatim", () => {
+    const level = new AffineTilesetLevel({
+      affine: compose(translation(0, 0), scale(10, -10)),
+      arrayWidth: 4,
+      arrayHeight: 4,
+      tileWidth: 4,
+      tileHeight: 4,
+      mpu: 1,
+    });
+    const tileset = new AffineTileset({
+      levels: [level],
+      ...PROJECTIONS,
+    });
+    expect(tileset.levels).toEqual([level]);
+    expect(tileset.projectTo3857).toBe(PROJECTIONS.projectTo3857);
+    expect(tileset.projectFrom3857).toBe(PROJECTIONS.projectFrom3857);
+    expect(tileset.projectTo4326).toBe(PROJECTIONS.projectTo4326);
+    expect(tileset.projectFrom4326).toBe(PROJECTIONS.projectFrom4326);
+  });
+
+  it("throws when constructed with no levels", () => {
+    expect(
+      () =>
+        new AffineTileset({
+          levels: [],
+          ...PROJECTIONS,
+        }),
+    ).toThrow();
+  });
+});

--- a/packages/deck.gl-zarr/src/zarr-tileset.ts
+++ b/packages/deck.gl-zarr/src/zarr-tileset.ts
@@ -1,145 +1,26 @@
-import * as affine from "@developmentseed/affine";
 import type {
-  Bounds,
-  Corners,
   ProjectionFunction,
   TilesetDescriptor,
-  TilesetLevel,
 } from "@developmentseed/deck.gl-raster";
-import type {
-  GeoZarrMetadata,
-  MultiscaleLevel,
-} from "@developmentseed/geozarr";
-
-class ZarrTilesetLevel implements TilesetLevel {
-  private level: MultiscaleLevel;
-  private _tileWidth: number;
-  private _tileHeight: number;
-  private _mpu: number;
-  private _invAffine: ReturnType<typeof affine.invert>;
-
-  constructor(
-    level: MultiscaleLevel,
-    tileWidth: number,
-    tileHeight: number,
-    mpu: number,
-  ) {
-    this.level = level;
-    this._tileWidth = tileWidth;
-    this._tileHeight = tileHeight;
-    this._mpu = mpu;
-    this._invAffine = affine.invert(level.affine);
-  }
-
-  get matrixWidth(): number {
-    return Math.ceil(this.level.arrayWidth / this._tileWidth);
-  }
-
-  get matrixHeight(): number {
-    return Math.ceil(this.level.arrayHeight / this._tileHeight);
-  }
-
-  get tileWidth(): number {
-    return this._tileWidth;
-  }
-
-  get tileHeight(): number {
-    return this._tileHeight;
-  }
-
-  get metersPerPixel(): number {
-    // Geometric mean of x and y pixel sizes handles non-square pixels
-    const [a, , , , e] = this.level.affine;
-    return Math.sqrt(Math.abs(a * e)) * this._mpu;
-  }
-
-  projectedTileCorners(col: number, row: number): Corners {
-    const tw = this._tileWidth;
-    const th = this._tileHeight;
-    const af = this.level.affine;
-
-    const topLeft = affine.apply(af, col * tw, row * th);
-    const topRight = affine.apply(af, (col + 1) * tw, row * th);
-    const bottomLeft = affine.apply(af, col * tw, (row + 1) * th);
-    const bottomRight = affine.apply(af, (col + 1) * tw, (row + 1) * th);
-
-    return { topLeft, topRight, bottomLeft, bottomRight };
-  }
-
-  /**
-   * Compute forward and inverse per-tile pixel↔CRS transforms for the tile at
-   * `(col, row)`. Composes the level affine with a pixel-offset translation so
-   * that pixel `(0, 0)` of the tile maps to the correct CRS coordinate.
-   */
-  tileTransform(
-    col: number,
-    row: number,
-  ): {
-    forwardTransform: (x: number, y: number) => [number, number];
-    inverseTransform: (x: number, y: number) => [number, number];
-  } {
-    const colStart = col * this._tileWidth;
-    const rowStart = row * this._tileHeight;
-    const tileOffset = affine.translation(colStart, rowStart);
-    const tileAffine = affine.compose(this.level.affine, tileOffset);
-    const invTileAffine = affine.invert(tileAffine);
-    return {
-      forwardTransform: (x, y) => affine.apply(tileAffine, x, y),
-      inverseTransform: (x, y) => affine.apply(invTileAffine, x, y),
-    };
-  }
-
-  crsBoundsToTileRange(
-    projectedMinX: number,
-    projectedMinY: number,
-    projectedMaxX: number,
-    projectedMaxY: number,
-  ): { minCol: number; maxCol: number; minRow: number; maxRow: number } {
-    // Map all four CRS corners through the inverse affine to get pixel coords,
-    // then take the bounding box in pixel space
-    const inv = this._invAffine;
-    const corners = [
-      affine.apply(inv, projectedMinX, projectedMinY),
-      affine.apply(inv, projectedMaxX, projectedMinY),
-      affine.apply(inv, projectedMinX, projectedMaxY),
-      affine.apply(inv, projectedMaxX, projectedMaxY),
-    ];
-
-    const pxCoords = corners.map(([px]) => px);
-    const pyCoords = corners.map(([, py]) => py);
-
-    const pixMinX = Math.min(...pxCoords);
-    const pixMaxX = Math.max(...pxCoords);
-    const pixMinY = Math.min(...pyCoords);
-    const pixMaxY = Math.max(...pyCoords);
-
-    const tw = this._tileWidth;
-    const th = this._tileHeight;
-    const maxCol = this.matrixWidth - 1;
-    const maxRow = this.matrixHeight - 1;
-
-    const minCol = Math.max(0, Math.min(maxCol, Math.floor(pixMinX / tw)));
-    const hiCol = Math.max(0, Math.min(maxCol, Math.floor(pixMaxX / tw)));
-    const minRow = Math.max(0, Math.min(maxRow, Math.floor(pixMinY / th)));
-    const hiRow = Math.max(0, Math.min(maxRow, Math.floor(pixMaxY / th)));
-
-    return { minCol, maxCol: hiCol, minRow, maxRow: hiRow };
-  }
-}
+import {
+  AffineTileset,
+  AffineTilesetLevel,
+} from "@developmentseed/deck.gl-raster";
+import type { GeoZarrMetadata } from "@developmentseed/geozarr";
 
 /**
  * Convert a `GeoZarrMetadata` object into a `TilesetDescriptor` for use with
  * `RasterTileset2D`.
  *
  * @param meta  Parsed GeoZarr metadata (from `parseGeoZarrMetadata`).
- * @param opts  Projection functions and tiling parameters:
- *   - `projectTo4326`:   Forward projection function: source CRS → EPSG:4326.
- *   - `projectFrom4326`: Inverse projection function: EPSG:4326 → source CRS.
- *   - `projectTo3857`:   Forward projection function: source CRS → EPSG:3857.
- *   - `projectFrom3857`: Inverse projection function: EPSG:3857 → source CRS.
- *   - `chunkSizes`:      Chunk (tile) width/height per level, in the same
- *                        finest-first order as `meta.levels`.
- *   - `mpu`:             Meters per CRS unit (computed from the resolved CRS).
+ * @param opts  Projection functions and tiling parameters.
+ * @param opts.projectTo4326   Forward projection: source CRS → EPSG:4326.
+ * @param opts.projectFrom4326 Inverse projection: EPSG:4326 → source CRS.
+ * @param opts.projectTo3857   Forward projection: source CRS → EPSG:3857.
+ * @param opts.projectFrom3857 Inverse projection: EPSG:3857 → source CRS.
+ * @param opts.chunkSizes      Chunk (tile) width/height per level, in the same
+ *                             finest-first order as `meta.levels`.
+ * @param opts.mpu             Meters per CRS unit.
  */
 export function geoZarrToDescriptor(
   meta: GeoZarrMetadata,
@@ -152,54 +33,33 @@ export function geoZarrToDescriptor(
     mpu: number;
   },
 ): TilesetDescriptor {
-  const {
-    projectTo4326,
-    projectFrom4326,
-    projectTo3857,
-    projectFrom3857,
-    chunkSizes,
-    mpu,
-  } = opts;
-
-  if (chunkSizes.length !== meta.levels.length) {
+  if (opts.chunkSizes.length !== meta.levels.length) {
     throw new Error(
-      `chunkSizes length (${chunkSizes.length}) must match meta.levels length (${meta.levels.length})`,
+      `chunkSizes length (${opts.chunkSizes.length}) must match meta.levels length (${meta.levels.length})`,
     );
   }
 
-  // meta.levels is finest-first; TilesetDescriptor requires coarsest-first
+  // meta.levels is finest-first; TilesetDescriptor requires coarsest-first.
   const reversedLevels = [...meta.levels].reverse();
-  const reversedChunks = [...chunkSizes].reverse();
+  const reversedChunks = [...opts.chunkSizes].reverse();
 
-  const levels: TilesetLevel[] = reversedLevels.map((level, i) => {
+  const levels = reversedLevels.map((level, i) => {
     const chunk = reversedChunks[i]!;
-    return new ZarrTilesetLevel(level, chunk.width, chunk.height, mpu);
+    return new AffineTilesetLevel({
+      affine: level.affine,
+      arrayWidth: level.arrayWidth,
+      arrayHeight: level.arrayHeight,
+      tileWidth: chunk.width,
+      tileHeight: chunk.height,
+      mpu: opts.mpu,
+    });
   });
 
-  // Compute source CRS bounds from the coarsest level affine applied to array corners
-  const coarsestLevel = reversedLevels[0]!;
-  const { arrayWidth, arrayHeight, affine: af } = coarsestLevel;
-  const corners = [
-    affine.apply(af, 0, 0),
-    affine.apply(af, arrayWidth, 0),
-    affine.apply(af, 0, arrayHeight),
-    affine.apply(af, arrayWidth, arrayHeight),
-  ];
-  const xs = corners.map(([x]) => x);
-  const ys = corners.map(([, y]) => y);
-  const projectedBounds: Bounds = [
-    Math.min(...xs),
-    Math.min(...ys),
-    Math.max(...xs),
-    Math.max(...ys),
-  ];
-
-  return {
+  return new AffineTileset({
     levels,
-    projectTo4326,
-    projectFrom4326,
-    projectTo3857,
-    projectFrom3857,
-    projectedBounds,
-  };
+    projectTo4326: opts.projectTo4326,
+    projectFrom4326: opts.projectFrom4326,
+    projectTo3857: opts.projectTo3857,
+    projectFrom3857: opts.projectFrom3857,
+  });
 }

--- a/packages/geotiff/src/index.ts
+++ b/packages/geotiff/src/index.ts
@@ -22,4 +22,3 @@ export { Overview } from "./overview.js";
 export type { DecoderPoolOptions } from "./pool/pool.js";
 export { DecoderPool, defaultDecoderPool } from "./pool/pool.js";
 export type { Tile } from "./tile.js";
-export { generateTileMatrixSet } from "./tile-matrix-set.js";

--- a/packages/geotiff/tests/helpers.ts
+++ b/packages/geotiff/tests/helpers.ts
@@ -4,7 +4,7 @@
 // project's outDir, and tsconfig.build.json excludes tests/ from emission.
 import { resolve } from "node:path";
 import { SourceFile } from "@chunkd/source-file";
-import { GeoTIFF } from "@developmentseed/geotiff";
+import { GeoTIFF } from "../src/geotiff.js";
 
 // ── Fixture helpers ─────────────────────────────────────────────────────
 

--- a/packages/geotiff/tests/integration-rasterio.test.ts
+++ b/packages/geotiff/tests/integration-rasterio.test.ts
@@ -9,10 +9,10 @@
 import assert from "node:assert";
 import { readFile } from "node:fs/promises";
 import { TiffTag } from "@cogeotiff/core";
-import type { GeoTIFF } from "@developmentseed/geotiff";
 import { beforeAll, describe, expect, it } from "vitest";
 import type { RasterArray, RasterTypedArray } from "../src/array.js";
 import { toBandSeparate } from "../src/array.js";
+import type { GeoTIFF } from "../src/geotiff.js";
 import { fixturePath, loadGeoTIFF } from "./helpers.js";
 import type { NPYTile } from "./utils/parse-npy.js";
 import { parseNPY } from "./utils/parse-npy.js";

--- a/packages/geotiff/tests/integration.test.ts
+++ b/packages/geotiff/tests/integration.test.ts
@@ -9,11 +9,11 @@
  * are intentionally omitted here.
  */
 
-import type { GeoTIFF } from "@developmentseed/geotiff";
 import type { GeoTIFFImage, GeoTIFF as GeotiffJs } from "geotiff";
 import { fromFile } from "geotiff";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { toBandSeparate } from "../src/array.js";
+import type { GeoTIFF } from "../src/geotiff.js";
 import { fixturePath, loadGeoTIFF } from "./helpers.js";
 
 const FIXTURES = [

--- a/packages/geotiff/tests/polyfills.ts
+++ b/packages/geotiff/tests/polyfills.ts
@@ -1,5 +1,5 @@
 import { Compression } from "@cogeotiff/core";
-import { DECODER_REGISTRY } from "@developmentseed/geotiff";
+import { DECODER_REGISTRY } from "../src/decode.js";
 
 async function identity(bytes: ArrayBuffer): Promise<ArrayBuffer> {
   return bytes;

--- a/packages/geotiff/tests/tile-matrix-set.test.ts
+++ b/packages/geotiff/tests/tile-matrix-set.test.ts
@@ -1,6 +1,6 @@
-import { GeoTIFF } from "@developmentseed/geotiff";
 import { parseWkt } from "@developmentseed/proj";
 import { describe, expect, it } from "vitest";
+import { GeoTIFF } from "../src/geotiff.js";
 import { generateTileMatrixSet } from "../src/tile-matrix-set.js";
 import { loadGeoTIFF } from "./helpers.js";
 

--- a/packages/geotiff/tests/tile-matrix-set.test.ts
+++ b/packages/geotiff/tests/tile-matrix-set.test.ts
@@ -1,6 +1,7 @@
-import { GeoTIFF, generateTileMatrixSet } from "@developmentseed/geotiff";
+import { GeoTIFF } from "@developmentseed/geotiff";
 import { parseWkt } from "@developmentseed/proj";
 import { describe, expect, it } from "vitest";
+import { generateTileMatrixSet } from "../src/tile-matrix-set.js";
 import { loadGeoTIFF } from "./helpers.js";
 
 const EPSG_4326 = {


### PR DESCRIPTION
Working test image render from https://github.com/developmentseed/deck.gl-raster/issues/375: (@cbdj is this a public image that's ok to host in an example?)

<img width="754" height="825" alt="image" src="https://github.com/user-attachments/assets/c5768660-a3dd-4928-b2f4-c14db08d6e34" />

Working rotated umbra image from https://github.com/developmentseed/deck.gl-raster/issues/327 (`http://umbra-open-data-catalog.s3.amazonaws.com/sar-data/tasks/Port%20of%20Rotterdam%2C%20Netherlands/00864c2c-0b0f-49ef-b283-997735b27878/2025-07-29-11-17-12_UMBRA-08/2025-07-29-11-17-12_UMBRA-08_GEC.tif`):

<img width="1303" height="840" alt="image" src="https://github.com/user-attachments/assets/5e109ed4-dc4e-42e7-bccb-c564459524c1" />


## Summary

- Introduces `AffineTilesetLevel` and `AffineTileset` in `@developmentseed/deck.gl-raster` — a generic `TilesetDescriptor` shape backed by a per-level affine transform plus tile and array sizes. Handles axis-aligned, rotated/skewed, and non-square-pixel grids uniformly.
- Routes `COGLayer` and `MultiCOGLayer` through a new `geoTiffToDescriptor` glue function instead of `generateTileMatrixSet` + `TileMatrixSetAdaptor`. Fixes #327 (rotated COGs no longer throw) and #375 (non-square-pixel COGs render correctly).
- Migrates `geoZarrToDescriptor` onto the same shared primitives — the inline `ZarrTilesetLevel` and bounds derivation are gone.
- `MultiCOGLayer` per-tile reprojection now goes through `TilesetLevel.tileTransform()` instead of morecantile + `fromAffine`, dropping a small layer of indirection.
- Adds `rotation()` to `@developmentseed/affine` (port of Python `rasterio/affine`'s rotation classmethod), and switches `identity` documentation along with a few other small cleanups.
- Drops `generateTileMatrixSet` from the `@developmentseed/geotiff` public exports. The implementation and its tests stay in the source tree in case TMS-from-COG synthesis is needed in the future.

Spec: [`dev-docs/specs/2026-04-27-affine-tileset-design.md`](dev-docs/specs/2026-04-27-affine-tileset-design.md)

Closes https://github.com/developmentseed/deck.gl-raster/issues/456
Fixes #327
Fixes #375

## Test plan

- [x] All 248 tests across 10 packages pass (`pnpm -w test`)
- [x] New unit tests for `AffineTilesetLevel` cover axis-aligned, rotated, non-square pixels, and the empty-range case
- [x] New unit tests for `AffineTileset` cover bounds derivation for axis-aligned and rotated coarsest levels
- [x] New unit tests for `geoTiffToDescriptor` cover level ordering and bounds propagation
- [x] New unit tests for `affine.rotation()` cover origin pivot, non-origin pivot, and pivot-fixed-point invariant
- [ ] Manually verify: render an EPSG:4326 COG with non-square pixels (the dataset from #375) — should appear in the right geographic location with no missing southern strip
- [ ] Manually verify: render a COG with a rotated geotransform (e.g. the Umbra SAR sample from #327) — should not throw and should render correctly oriented

🤖 Generated with [Claude Code](https://claude.com/claude-code)