### PR TITLE
fix: In `RasterTileLayer`, allow `renderTile` to return `null` to avoid rendering a layer

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,3 @@
 {
-  ".": "0.6.0",
-  "packages/affine": "0.6.0",
-  "packages/geotiff": "0.6.0",
-  "packages/morecantile": "0.6.0"
+  ".": "0.6.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * feat: Web Mercator axis-aligned cutline support by @kylebarron in https://github.com/developmentseed/deck.gl-raster/pull/424
 
+## v0.6.1 - 2026-04-29
+
+feat: Allow `renderTile` prop in `RasterTileLayer` to return `null`
+
 ## v0.6.0 - 2026-04-29
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-    "name": "monorepo",
-    "private": true,
-    "version": "0.6.1",
-    "description": "GPU-accelerated COG and Zarr visualization in deck.gl",
-    "scripts": {
-        "build": "pnpm --recursive --filter=!docs build",
-        "build:watch": "tsc --build --watch",
-        "clean": "pnpm --recursive exec sh -c 'rm -rf dist *.tsbuildinfo'",
-        "format": "biome format .",
-        "format:fix": "biome format --write .",
-        "lint": "biome lint .",
-        "lint:fix": "biome lint --write .",
-        "check": "biome check .",
-        "check:fix": "biome check --write .",
-        "publint": "pnpm --recursive --filter=\"./packages/**\" exec publint",
-        "test": "pnpm -r test",
-        "typecheck": "pnpm -r typecheck"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^2.4.13",
-        "publint": "^0.3.18",
-        "tsup": "^8.5.1",
-        "typescript": "^6.0.3"
-    },
-    "pnpm": {
-        "overrides": {
-            "@deck.gl/aggregation-layers": "^9.3.1",
-            "@deck.gl/core": "^9.3.1",
-            "@deck.gl/extensions": "^9.3.1",
-            "@deck.gl/geo-layers": "^9.3.1",
-            "@deck.gl/layers": "^9.3.1",
-            "@deck.gl/mapbox": "^9.3.1",
-            "@deck.gl/mesh-layers": "^9.3.1",
-            "@deck.gl/widgets": "^9.3.1",
-            "@loaders.gl/core": "^4.3.4",
-            "@luma.gl/constants": "^9.3.3",
-            "@luma.gl/core": "^9.3.3",
-            "@luma.gl/engine": "^9.3.3",
-            "@luma.gl/gltf": "^9.3.3",
-            "@luma.gl/shadertools": "^9.3.3",
-            "@luma.gl/webgl": "^9.3.3"
-        }
-    },
-    "packageManager": "pnpm@10.25.0",
-    "volta": {
-        "node": "24.11.1",
-        "pnpm": "10.25.0"
+  "name": "monorepo",
+  "private": true,
+  "version": "0.6.1",
+  "description": "GPU-accelerated COG and Zarr visualization in deck.gl",
+  "scripts": {
+    "build": "pnpm --recursive --filter=!docs build",
+    "build:watch": "tsc --build --watch",
+    "clean": "pnpm --recursive exec sh -c 'rm -rf dist *.tsbuildinfo'",
+    "format": "biome format .",
+    "format:fix": "biome format --write .",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write .",
+    "check": "biome check .",
+    "check:fix": "biome check --write .",
+    "publint": "pnpm --recursive --filter=\"./packages/**\" exec publint",
+    "test": "pnpm -r test",
+    "typecheck": "pnpm -r typecheck"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.13",
+    "publint": "^0.3.18",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "@deck.gl/aggregation-layers": "^9.3.1",
+      "@deck.gl/core": "^9.3.1",
+      "@deck.gl/extensions": "^9.3.1",
+      "@deck.gl/geo-layers": "^9.3.1",
+      "@deck.gl/layers": "^9.3.1",
+      "@deck.gl/mapbox": "^9.3.1",
+      "@deck.gl/mesh-layers": "^9.3.1",
+      "@deck.gl/widgets": "^9.3.1",
+      "@loaders.gl/core": "^4.3.4",
+      "@luma.gl/constants": "^9.3.3",
+      "@luma.gl/core": "^9.3.3",
+      "@luma.gl/engine": "^9.3.3",
+      "@luma.gl/gltf": "^9.3.3",
+      "@luma.gl/shadertools": "^9.3.3",
+      "@luma.gl/webgl": "^9.3.3"
     }
+  },
+  "packageManager": "pnpm@10.25.0",
+  "volta": {
+    "node": "24.11.1",
+    "pnpm": "10.25.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-  "name": "monorepo",
-  "private": true,
-  "version": "0.6.0",
-  "description": "GPU-accelerated COG and Zarr visualization in deck.gl",
-  "scripts": {
-    "build": "pnpm --recursive --filter=!docs build",
-    "build:watch": "tsc --build --watch",
-    "clean": "pnpm --recursive exec sh -c 'rm -rf dist *.tsbuildinfo'",
-    "format": "biome format .",
-    "format:fix": "biome format --write .",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint --write .",
-    "check": "biome check .",
-    "check:fix": "biome check --write .",
-    "publint": "pnpm --recursive --filter=\"./packages/**\" exec publint",
-    "test": "pnpm -r test",
-    "typecheck": "pnpm -r typecheck"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.4.13",
-    "publint": "^0.3.18",
-    "tsup": "^8.5.1",
-    "typescript": "^6.0.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "@deck.gl/aggregation-layers": "^9.3.1",
-      "@deck.gl/core": "^9.3.1",
-      "@deck.gl/extensions": "^9.3.1",
-      "@deck.gl/geo-layers": "^9.3.1",
-      "@deck.gl/layers": "^9.3.1",
-      "@deck.gl/mapbox": "^9.3.1",
-      "@deck.gl/mesh-layers": "^9.3.1",
-      "@deck.gl/widgets": "^9.3.1",
-      "@loaders.gl/core": "^4.3.4",
-      "@luma.gl/constants": "^9.3.3",
-      "@luma.gl/core": "^9.3.3",
-      "@luma.gl/engine": "^9.3.3",
-      "@luma.gl/gltf": "^9.3.3",
-      "@luma.gl/shadertools": "^9.3.3",
-      "@luma.gl/webgl": "^9.3.3"
+    "name": "monorepo",
+    "private": true,
+    "version": "0.6.1",
+    "description": "GPU-accelerated COG and Zarr visualization in deck.gl",
+    "scripts": {
+        "build": "pnpm --recursive --filter=!docs build",
+        "build:watch": "tsc --build --watch",
+        "clean": "pnpm --recursive exec sh -c 'rm -rf dist *.tsbuildinfo'",
+        "format": "biome format .",
+        "format:fix": "biome format --write .",
+        "lint": "biome lint .",
+        "lint:fix": "biome lint --write .",
+        "check": "biome check .",
+        "check:fix": "biome check --write .",
+        "publint": "pnpm --recursive --filter=\"./packages/**\" exec publint",
+        "test": "pnpm -r test",
+        "typecheck": "pnpm -r typecheck"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "^2.4.13",
+        "publint": "^0.3.18",
+        "tsup": "^8.5.1",
+        "typescript": "^6.0.3"
+    },
+    "pnpm": {
+        "overrides": {
+            "@deck.gl/aggregation-layers": "^9.3.1",
+            "@deck.gl/core": "^9.3.1",
+            "@deck.gl/extensions": "^9.3.1",
+            "@deck.gl/geo-layers": "^9.3.1",
+            "@deck.gl/layers": "^9.3.1",
+            "@deck.gl/mapbox": "^9.3.1",
+            "@deck.gl/mesh-layers": "^9.3.1",
+            "@deck.gl/widgets": "^9.3.1",
+            "@loaders.gl/core": "^4.3.4",
+            "@luma.gl/constants": "^9.3.3",
+            "@luma.gl/core": "^9.3.3",
+            "@luma.gl/engine": "^9.3.3",
+            "@luma.gl/gltf": "^9.3.3",
+            "@luma.gl/shadertools": "^9.3.3",
+            "@luma.gl/webgl": "^9.3.3"
+        }
+    },
+    "packageManager": "pnpm@10.25.0",
+    "volta": {
+        "node": "24.11.1",
+        "pnpm": "10.25.0"
     }
-  },
-  "packageManager": "pnpm@10.25.0",
-  "volta": {
-    "node": "24.11.1",
-    "pnpm": "10.25.0"
-  }
 }

--- a/packages/affine/package.json
+++ b/packages/affine/package.json
@@ -1,52 +1,52 @@
 {
-    "name": "@developmentseed/affine",
-    "version": "0.6.1",
-    "description": "Port of Python `affine` package for working with affine transformations in JavaScript.",
-    "type": "module",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
-    "sideEffects": false,
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc --build tsconfig.build.json",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "typecheck": "tsc --noEmit",
-        "prepublishOnly": "npm run build"
-    },
-    "keywords": [
-        "geotiff",
-        "zarr",
-        "cog",
-        "cloud-optimized-geotiff",
-        "raster",
-        "visualization",
-        "webgl",
-        "gpu"
-    ],
-    "author": "Development Seed",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-    },
-    "devDependencies": {
-        "@types/node": "^25.6.0",
-        "jsdom": "^29.0.2",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
-    },
-    "dependencies": {},
-    "peerDependencies": {},
-    "volta": {
-        "extends": "../../package.json"
+  "name": "@developmentseed/affine",
+  "version": "0.6.1",
+  "description": "Port of Python `affine` package for working with affine transformations in JavaScript.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "geotiff",
+    "zarr",
+    "cog",
+    "cloud-optimized-geotiff",
+    "raster",
+    "visualization",
+    "webgl",
+    "gpu"
+  ],
+  "author": "Development Seed",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "jsdom": "^29.0.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "dependencies": {},
+  "peerDependencies": {},
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/affine/package.json
+++ b/packages/affine/package.json
@@ -1,52 +1,52 @@
 {
-  "name": "@developmentseed/affine",
-  "version": "0.6.0",
-  "description": "Port of Python `affine` package for working with affine transformations in JavaScript.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "name": "@developmentseed/affine",
+    "version": "0.6.1",
+    "description": "Port of Python `affine` package for working with affine transformations in JavaScript.",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc --build tsconfig.build.json",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build"
+    },
+    "keywords": [
+        "geotiff",
+        "zarr",
+        "cog",
+        "cloud-optimized-geotiff",
+        "raster",
+        "visualization",
+        "webgl",
+        "gpu"
+    ],
+    "author": "Development Seed",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+    },
+    "devDependencies": {
+        "@types/node": "^25.6.0",
+        "jsdom": "^29.0.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+    },
+    "dependencies": {},
+    "peerDependencies": {},
+    "volta": {
+        "extends": "../../package.json"
     }
-  },
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
-  },
-  "keywords": [
-    "geotiff",
-    "zarr",
-    "cog",
-    "cloud-optimized-geotiff",
-    "raster",
-    "visualization",
-    "webgl",
-    "gpu"
-  ],
-  "author": "Development Seed",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-  },
-  "devDependencies": {
-    "@types/node": "^25.6.0",
-    "jsdom": "^29.0.2",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
-  },
-  "dependencies": {},
-  "peerDependencies": {},
-  "volta": {
-    "extends": "../../package.json"
-  }
 }

--- a/packages/deck.gl-geotiff/package.json
+++ b/packages/deck.gl-geotiff/package.json
@@ -1,70 +1,70 @@
 {
-    "name": "@developmentseed/deck.gl-geotiff",
-    "version": "0.6.1",
-    "description": "GeoTIFF and Cloud-Optimized GeoTIFF visualization in deck.gl",
-    "type": "module",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
-    "sideEffects": false,
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc --build tsconfig.build.json",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "typecheck": "tsc --noEmit",
-        "prepublishOnly": "npm run build"
-    },
-    "keywords": [
-        "deck.gl",
-        "geotiff",
-        "zarr",
-        "cog",
-        "cloud-optimized-geotiff",
-        "raster",
-        "visualization",
-        "webgl",
-        "gpu"
-    ],
-    "author": "Development Seed",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-    },
-    "devDependencies": {
-        "@chunkd/source-file": "^11.2.0",
-        "@types/node": "^25.6.0",
-        "jsdom": "^29.0.2",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
-    },
-    "dependencies": {
-        "@cogeotiff/core": "^9.5.0",
-        "@developmentseed/affine": "workspace:^",
-        "@developmentseed/deck.gl-raster": "workspace:^",
-        "@developmentseed/geotiff": "workspace:^",
-        "@developmentseed/morecantile": "workspace:^",
-        "@developmentseed/proj": "workspace:^",
-        "@developmentseed/raster-reproject": "workspace:^",
-        "flatbush": "^4.5.0",
-        "proj4": "^2.20.4"
-    },
-    "peerDependencies": {
-        "@deck.gl/core": "^9.3.0",
-        "@deck.gl/geo-layers": "^9.3.0",
-        "@deck.gl/layers": "^9.3.0",
-        "@deck.gl/mesh-layers": "^9.3.0",
-        "@luma.gl/core": "^9.3.2"
-    },
-    "volta": {
-        "extends": "../../package.json"
+  "name": "@developmentseed/deck.gl-geotiff",
+  "version": "0.6.1",
+  "description": "GeoTIFF and Cloud-Optimized GeoTIFF visualization in deck.gl",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "deck.gl",
+    "geotiff",
+    "zarr",
+    "cog",
+    "cloud-optimized-geotiff",
+    "raster",
+    "visualization",
+    "webgl",
+    "gpu"
+  ],
+  "author": "Development Seed",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+  },
+  "devDependencies": {
+    "@chunkd/source-file": "^11.2.0",
+    "@types/node": "^25.6.0",
+    "jsdom": "^29.0.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "@cogeotiff/core": "^9.5.0",
+    "@developmentseed/affine": "workspace:^",
+    "@developmentseed/deck.gl-raster": "workspace:^",
+    "@developmentseed/geotiff": "workspace:^",
+    "@developmentseed/morecantile": "workspace:^",
+    "@developmentseed/proj": "workspace:^",
+    "@developmentseed/raster-reproject": "workspace:^",
+    "flatbush": "^4.5.0",
+    "proj4": "^2.20.4"
+  },
+  "peerDependencies": {
+    "@deck.gl/core": "^9.3.0",
+    "@deck.gl/geo-layers": "^9.3.0",
+    "@deck.gl/layers": "^9.3.0",
+    "@deck.gl/mesh-layers": "^9.3.0",
+    "@luma.gl/core": "^9.3.2"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/deck.gl-geotiff/package.json
+++ b/packages/deck.gl-geotiff/package.json
@@ -1,70 +1,70 @@
 {
-  "name": "@developmentseed/deck.gl-geotiff",
-  "version": "0.6.0",
-  "description": "GeoTIFF and Cloud-Optimized GeoTIFF visualization in deck.gl",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "name": "@developmentseed/deck.gl-geotiff",
+    "version": "0.6.1",
+    "description": "GeoTIFF and Cloud-Optimized GeoTIFF visualization in deck.gl",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc --build tsconfig.build.json",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build"
+    },
+    "keywords": [
+        "deck.gl",
+        "geotiff",
+        "zarr",
+        "cog",
+        "cloud-optimized-geotiff",
+        "raster",
+        "visualization",
+        "webgl",
+        "gpu"
+    ],
+    "author": "Development Seed",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+    },
+    "devDependencies": {
+        "@chunkd/source-file": "^11.2.0",
+        "@types/node": "^25.6.0",
+        "jsdom": "^29.0.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+    },
+    "dependencies": {
+        "@cogeotiff/core": "^9.5.0",
+        "@developmentseed/affine": "workspace:^",
+        "@developmentseed/deck.gl-raster": "workspace:^",
+        "@developmentseed/geotiff": "workspace:^",
+        "@developmentseed/morecantile": "workspace:^",
+        "@developmentseed/proj": "workspace:^",
+        "@developmentseed/raster-reproject": "workspace:^",
+        "flatbush": "^4.5.0",
+        "proj4": "^2.20.4"
+    },
+    "peerDependencies": {
+        "@deck.gl/core": "^9.3.0",
+        "@deck.gl/geo-layers": "^9.3.0",
+        "@deck.gl/layers": "^9.3.0",
+        "@deck.gl/mesh-layers": "^9.3.0",
+        "@luma.gl/core": "^9.3.2"
+    },
+    "volta": {
+        "extends": "../../package.json"
     }
-  },
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
-  },
-  "keywords": [
-    "deck.gl",
-    "geotiff",
-    "zarr",
-    "cog",
-    "cloud-optimized-geotiff",
-    "raster",
-    "visualization",
-    "webgl",
-    "gpu"
-  ],
-  "author": "Development Seed",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-  },
-  "devDependencies": {
-    "@chunkd/source-file": "^11.2.0",
-    "@types/node": "^25.6.0",
-    "jsdom": "^29.0.2",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
-  },
-  "dependencies": {
-    "@cogeotiff/core": "^9.5.0",
-    "@developmentseed/affine": "workspace:^",
-    "@developmentseed/deck.gl-raster": "workspace:^",
-    "@developmentseed/geotiff": "workspace:^",
-    "@developmentseed/morecantile": "workspace:^",
-    "@developmentseed/proj": "workspace:^",
-    "@developmentseed/raster-reproject": "workspace:^",
-    "flatbush": "^4.5.0",
-    "proj4": "^2.20.4"
-  },
-  "peerDependencies": {
-    "@deck.gl/core": "^9.3.0",
-    "@deck.gl/geo-layers": "^9.3.0",
-    "@deck.gl/layers": "^9.3.0",
-    "@deck.gl/mesh-layers": "^9.3.0",
-    "@luma.gl/core": "^9.3.2"
-  },
-  "volta": {
-    "extends": "../../package.json"
-  }
 }

--- a/packages/deck.gl-raster/package.json
+++ b/packages/deck.gl-raster/package.json
@@ -1,75 +1,75 @@
 {
-    "name": "@developmentseed/deck.gl-raster",
-    "version": "0.6.1",
-    "description": "Georeferenced image data visualization in deck.gl",
-    "type": "module",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        },
-        "./gpu-modules": {
-            "types": "./dist/gpu-modules/index.d.ts",
-            "default": "./dist/gpu-modules/index.js"
-        },
-        "./gpu-modules/colormaps.png": "./dist/gpu-modules/colormaps.png"
+  "name": "@developmentseed/deck.gl-raster",
+  "version": "0.6.1",
+  "description": "Georeferenced image data visualization in deck.gl",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
-    "sideEffects": false,
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc --build tsconfig.build.json && cp src/gpu-modules/colormaps.png dist/gpu-modules/colormaps.png",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "typecheck": "tsc --noEmit",
-        "prepublishOnly": "npm run build"
+    "./gpu-modules": {
+      "types": "./dist/gpu-modules/index.d.ts",
+      "default": "./dist/gpu-modules/index.js"
     },
-    "keywords": [
-        "deck.gl",
-        "geotiff",
-        "zarr",
-        "cog",
-        "cloud-optimized-geotiff",
-        "raster",
-        "visualization",
-        "webgl",
-        "gpu"
-    ],
-    "author": "Development Seed",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-    },
-    "devDependencies": {
-        "@luma.gl/core": "^9.3.2",
-        "@luma.gl/shadertools": "^9.3.2",
-        "@types/node": "^25.6.0",
-        "jsdom": "^29.0.2",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
-    },
-    "peerDependencies": {
-        "@developmentseed/morecantile": "workspace:^",
-        "@deck.gl/core": "^9.3.0",
-        "@deck.gl/geo-layers": "^9.3.0",
-        "@deck.gl/layers": "^9.3.0",
-        "@deck.gl/mesh-layers": "^9.3.0",
-        "@luma.gl/core": "^9.3.2",
-        "@luma.gl/shadertools": "^9.3.2"
-    },
-    "dependencies": {
-        "@developmentseed/affine": "workspace:^",
-        "@developmentseed/proj": "workspace:^",
-        "@developmentseed/raster-reproject": "workspace:^",
-        "@math.gl/core": "^4.1.0",
-        "@math.gl/culling": "^4.1.0",
-        "@math.gl/web-mercator": "^4.1.0"
-    },
-    "volta": {
-        "extends": "../../package.json"
-    }
+    "./gpu-modules/colormaps.png": "./dist/gpu-modules/colormaps.png"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json && cp src/gpu-modules/colormaps.png dist/gpu-modules/colormaps.png",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "deck.gl",
+    "geotiff",
+    "zarr",
+    "cog",
+    "cloud-optimized-geotiff",
+    "raster",
+    "visualization",
+    "webgl",
+    "gpu"
+  ],
+  "author": "Development Seed",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+  },
+  "devDependencies": {
+    "@luma.gl/core": "^9.3.2",
+    "@luma.gl/shadertools": "^9.3.2",
+    "@types/node": "^25.6.0",
+    "jsdom": "^29.0.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "peerDependencies": {
+    "@developmentseed/morecantile": "workspace:^",
+    "@deck.gl/core": "^9.3.0",
+    "@deck.gl/geo-layers": "^9.3.0",
+    "@deck.gl/layers": "^9.3.0",
+    "@deck.gl/mesh-layers": "^9.3.0",
+    "@luma.gl/core": "^9.3.2",
+    "@luma.gl/shadertools": "^9.3.2"
+  },
+  "dependencies": {
+    "@developmentseed/affine": "workspace:^",
+    "@developmentseed/proj": "workspace:^",
+    "@developmentseed/raster-reproject": "workspace:^",
+    "@math.gl/core": "^4.1.0",
+    "@math.gl/culling": "^4.1.0",
+    "@math.gl/web-mercator": "^4.1.0"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/deck.gl-raster/package.json
+++ b/packages/deck.gl-raster/package.json
@@ -1,75 +1,75 @@
 {
-  "name": "@developmentseed/deck.gl-raster",
-  "version": "0.6.0",
-  "description": "Georeferenced image data visualization in deck.gl",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "name": "@developmentseed/deck.gl-raster",
+    "version": "0.6.1",
+    "description": "Georeferenced image data visualization in deck.gl",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./gpu-modules": {
+            "types": "./dist/gpu-modules/index.d.ts",
+            "default": "./dist/gpu-modules/index.js"
+        },
+        "./gpu-modules/colormaps.png": "./dist/gpu-modules/colormaps.png"
     },
-    "./gpu-modules": {
-      "types": "./dist/gpu-modules/index.d.ts",
-      "default": "./dist/gpu-modules/index.js"
+    "sideEffects": false,
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc --build tsconfig.build.json && cp src/gpu-modules/colormaps.png dist/gpu-modules/colormaps.png",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build"
     },
-    "./gpu-modules/colormaps.png": "./dist/gpu-modules/colormaps.png"
-  },
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json && cp src/gpu-modules/colormaps.png dist/gpu-modules/colormaps.png",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
-  },
-  "keywords": [
-    "deck.gl",
-    "geotiff",
-    "zarr",
-    "cog",
-    "cloud-optimized-geotiff",
-    "raster",
-    "visualization",
-    "webgl",
-    "gpu"
-  ],
-  "author": "Development Seed",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-  },
-  "devDependencies": {
-    "@luma.gl/core": "^9.3.2",
-    "@luma.gl/shadertools": "^9.3.2",
-    "@types/node": "^25.6.0",
-    "jsdom": "^29.0.2",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
-  },
-  "peerDependencies": {
-    "@developmentseed/morecantile": "workspace:^",
-    "@deck.gl/core": "^9.3.0",
-    "@deck.gl/geo-layers": "^9.3.0",
-    "@deck.gl/layers": "^9.3.0",
-    "@deck.gl/mesh-layers": "^9.3.0",
-    "@luma.gl/core": "^9.3.2",
-    "@luma.gl/shadertools": "^9.3.2"
-  },
-  "dependencies": {
-    "@developmentseed/affine": "workspace:^",
-    "@developmentseed/proj": "workspace:^",
-    "@developmentseed/raster-reproject": "workspace:^",
-    "@math.gl/core": "^4.1.0",
-    "@math.gl/culling": "^4.1.0",
-    "@math.gl/web-mercator": "^4.1.0"
-  },
-  "volta": {
-    "extends": "../../package.json"
-  }
+    "keywords": [
+        "deck.gl",
+        "geotiff",
+        "zarr",
+        "cog",
+        "cloud-optimized-geotiff",
+        "raster",
+        "visualization",
+        "webgl",
+        "gpu"
+    ],
+    "author": "Development Seed",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+    },
+    "devDependencies": {
+        "@luma.gl/core": "^9.3.2",
+        "@luma.gl/shadertools": "^9.3.2",
+        "@types/node": "^25.6.0",
+        "jsdom": "^29.0.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+    },
+    "peerDependencies": {
+        "@developmentseed/morecantile": "workspace:^",
+        "@deck.gl/core": "^9.3.0",
+        "@deck.gl/geo-layers": "^9.3.0",
+        "@deck.gl/layers": "^9.3.0",
+        "@deck.gl/mesh-layers": "^9.3.0",
+        "@luma.gl/core": "^9.3.2",
+        "@luma.gl/shadertools": "^9.3.2"
+    },
+    "dependencies": {
+        "@developmentseed/affine": "workspace:^",
+        "@developmentseed/proj": "workspace:^",
+        "@developmentseed/raster-reproject": "workspace:^",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0"
+    },
+    "volta": {
+        "extends": "../../package.json"
+    }
 }

--- a/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+++ b/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
@@ -105,7 +105,7 @@ export type RasterTileLayerProps<
      *
      * Subclasses may supply this via state by overriding `_renderTileCallback()`.
      */
-    renderTile?: (data: DataT) => RenderTileResult;
+    renderTile?: (data: DataT) => RenderTileResult | null;
 
     /**
      * Maximum reprojection error in pixels for mesh refinement.
@@ -341,7 +341,11 @@ export class RasterTileLayer<
       return layers;
     }
     const { forwardTransform, inverseTransform } = level.tileTransform(x, y);
-    const { image, renderPipeline } = renderTile(props.data);
+    const tileResult = renderTile(props.data);
+    if (!tileResult) {
+      return layers;
+    }
+    const { image, renderPipeline } = tileResult;
     const { width, height } = props.data;
 
     const isGlobe = this.context.viewport.resolution !== undefined;

--- a/packages/deck.gl-zarr/package.json
+++ b/packages/deck.gl-zarr/package.json
@@ -1,67 +1,67 @@
 {
-    "name": "@developmentseed/deck.gl-zarr",
-    "version": "0.6.1",
-    "description": "Zarr visualization in deck.gl.",
-    "type": "module",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
-    "sideEffects": false,
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc --build tsconfig.build.json",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "typecheck": "tsc --noEmit",
-        "prepublishOnly": "npm run build"
-    },
-    "keywords": [
-        "deck.gl",
-        "geotiff",
-        "zarr",
-        "cog",
-        "cloud-optimized-geotiff",
-        "raster",
-        "visualization",
-        "webgl",
-        "gpu"
-    ],
-    "author": "Development Seed",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-    },
-    "devDependencies": {
-        "@types/node": "^25.6.0",
-        "jsdom": "^29.0.2",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
-    },
-    "dependencies": {
-        "@developmentseed/affine": "workspace:^",
-        "@developmentseed/deck.gl-raster": "workspace:^",
-        "@developmentseed/geozarr": "workspace:^",
-        "@developmentseed/proj": "workspace:^",
-        "@developmentseed/raster-reproject": "workspace:^",
-        "proj4": "^2.20.4",
-        "wkt-parser": "^1.5.3",
-        "zarrita": "^0.7.1"
-    },
-    "peerDependencies": {
-        "@deck.gl/core": "^9.3.0",
-        "@deck.gl/geo-layers": "^9.3.0",
-        "@deck.gl/layers": "^9.3.0",
-        "@luma.gl/core": "^9.3.2"
-    },
-    "volta": {
-        "extends": "../../package.json"
+  "name": "@developmentseed/deck.gl-zarr",
+  "version": "0.6.1",
+  "description": "Zarr visualization in deck.gl.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "deck.gl",
+    "geotiff",
+    "zarr",
+    "cog",
+    "cloud-optimized-geotiff",
+    "raster",
+    "visualization",
+    "webgl",
+    "gpu"
+  ],
+  "author": "Development Seed",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "jsdom": "^29.0.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "@developmentseed/affine": "workspace:^",
+    "@developmentseed/deck.gl-raster": "workspace:^",
+    "@developmentseed/geozarr": "workspace:^",
+    "@developmentseed/proj": "workspace:^",
+    "@developmentseed/raster-reproject": "workspace:^",
+    "proj4": "^2.20.4",
+    "wkt-parser": "^1.5.3",
+    "zarrita": "^0.7.1"
+  },
+  "peerDependencies": {
+    "@deck.gl/core": "^9.3.0",
+    "@deck.gl/geo-layers": "^9.3.0",
+    "@deck.gl/layers": "^9.3.0",
+    "@luma.gl/core": "^9.3.2"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/deck.gl-zarr/package.json
+++ b/packages/deck.gl-zarr/package.json
@@ -1,67 +1,67 @@
 {
-  "name": "@developmentseed/deck.gl-zarr",
-  "version": "0.6.0",
-  "description": "Zarr visualization in deck.gl.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "name": "@developmentseed/deck.gl-zarr",
+    "version": "0.6.1",
+    "description": "Zarr visualization in deck.gl.",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc --build tsconfig.build.json",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build"
+    },
+    "keywords": [
+        "deck.gl",
+        "geotiff",
+        "zarr",
+        "cog",
+        "cloud-optimized-geotiff",
+        "raster",
+        "visualization",
+        "webgl",
+        "gpu"
+    ],
+    "author": "Development Seed",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+    },
+    "devDependencies": {
+        "@types/node": "^25.6.0",
+        "jsdom": "^29.0.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+    },
+    "dependencies": {
+        "@developmentseed/affine": "workspace:^",
+        "@developmentseed/deck.gl-raster": "workspace:^",
+        "@developmentseed/geozarr": "workspace:^",
+        "@developmentseed/proj": "workspace:^",
+        "@developmentseed/raster-reproject": "workspace:^",
+        "proj4": "^2.20.4",
+        "wkt-parser": "^1.5.3",
+        "zarrita": "^0.7.1"
+    },
+    "peerDependencies": {
+        "@deck.gl/core": "^9.3.0",
+        "@deck.gl/geo-layers": "^9.3.0",
+        "@deck.gl/layers": "^9.3.0",
+        "@luma.gl/core": "^9.3.2"
+    },
+    "volta": {
+        "extends": "../../package.json"
     }
-  },
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
-  },
-  "keywords": [
-    "deck.gl",
-    "geotiff",
-    "zarr",
-    "cog",
-    "cloud-optimized-geotiff",
-    "raster",
-    "visualization",
-    "webgl",
-    "gpu"
-  ],
-  "author": "Development Seed",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-  },
-  "devDependencies": {
-    "@types/node": "^25.6.0",
-    "jsdom": "^29.0.2",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
-  },
-  "dependencies": {
-    "@developmentseed/affine": "workspace:^",
-    "@developmentseed/deck.gl-raster": "workspace:^",
-    "@developmentseed/geozarr": "workspace:^",
-    "@developmentseed/proj": "workspace:^",
-    "@developmentseed/raster-reproject": "workspace:^",
-    "proj4": "^2.20.4",
-    "wkt-parser": "^1.5.3",
-    "zarrita": "^0.7.1"
-  },
-  "peerDependencies": {
-    "@deck.gl/core": "^9.3.0",
-    "@deck.gl/geo-layers": "^9.3.0",
-    "@deck.gl/layers": "^9.3.0",
-    "@luma.gl/core": "^9.3.2"
-  },
-  "volta": {
-    "extends": "../../package.json"
-  }
 }

--- a/packages/epsg/package.json
+++ b/packages/epsg/package.json
@@ -1,51 +1,51 @@
 {
-  "name": "@developmentseed/epsg",
-  "version": "0.6.0",
-  "description": "The full EPSG projection database, compressed to 309kb for the web.",
-  "type": "module",
-  "exports": {
-    "./all": {
-      "types": "./dist/all.d.ts",
-      "default": "./dist/all.js"
+    "name": "@developmentseed/epsg",
+    "version": "0.6.1",
+    "description": "The full EPSG projection database, compressed to 309kb for the web.",
+    "type": "module",
+    "exports": {
+        "./all": {
+            "types": "./dist/all.d.ts",
+            "default": "./dist/all.js"
+        },
+        "./all.csv.gz": "./dist/all.csv.gz"
     },
-    "./all.csv.gz": "./dist/all.csv.gz"
-  },
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json && cp src/all.csv.gz dist/all.csv.gz",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
-  },
-  "keywords": [
-    "proj4",
-    "geotiff",
-    "zarr",
-    "cog",
-    "cloud-optimized-geotiff",
-    "raster",
-    "visualization",
-    "webgl",
-    "gpu"
-  ],
-  "author": "Development Seed",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-  },
-  "devDependencies": {
-    "@types/node": "^25.6.0",
-    "jsdom": "^29.0.2",
-    "proj4": "^2.20.4",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
-  },
-  "volta": {
-    "extends": "../../package.json"
-  }
+    "sideEffects": false,
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc --build tsconfig.build.json && cp src/all.csv.gz dist/all.csv.gz",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build"
+    },
+    "keywords": [
+        "proj4",
+        "geotiff",
+        "zarr",
+        "cog",
+        "cloud-optimized-geotiff",
+        "raster",
+        "visualization",
+        "webgl",
+        "gpu"
+    ],
+    "author": "Development Seed",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+    },
+    "devDependencies": {
+        "@types/node": "^25.6.0",
+        "jsdom": "^29.0.2",
+        "proj4": "^2.20.4",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+    },
+    "volta": {
+        "extends": "../../package.json"
+    }
 }

--- a/packages/epsg/package.json
+++ b/packages/epsg/package.json
@@ -1,51 +1,51 @@
 {
-    "name": "@developmentseed/epsg",
-    "version": "0.6.1",
-    "description": "The full EPSG projection database, compressed to 309kb for the web.",
-    "type": "module",
-    "exports": {
-        "./all": {
-            "types": "./dist/all.d.ts",
-            "default": "./dist/all.js"
-        },
-        "./all.csv.gz": "./dist/all.csv.gz"
+  "name": "@developmentseed/epsg",
+  "version": "0.6.1",
+  "description": "The full EPSG projection database, compressed to 309kb for the web.",
+  "type": "module",
+  "exports": {
+    "./all": {
+      "types": "./dist/all.d.ts",
+      "default": "./dist/all.js"
     },
-    "sideEffects": false,
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc --build tsconfig.build.json && cp src/all.csv.gz dist/all.csv.gz",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "typecheck": "tsc --noEmit",
-        "prepublishOnly": "npm run build"
-    },
-    "keywords": [
-        "proj4",
-        "geotiff",
-        "zarr",
-        "cog",
-        "cloud-optimized-geotiff",
-        "raster",
-        "visualization",
-        "webgl",
-        "gpu"
-    ],
-    "author": "Development Seed",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-    },
-    "devDependencies": {
-        "@types/node": "^25.6.0",
-        "jsdom": "^29.0.2",
-        "proj4": "^2.20.4",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
-    },
-    "volta": {
-        "extends": "../../package.json"
-    }
+    "./all.csv.gz": "./dist/all.csv.gz"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json && cp src/all.csv.gz dist/all.csv.gz",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "proj4",
+    "geotiff",
+    "zarr",
+    "cog",
+    "cloud-optimized-geotiff",
+    "raster",
+    "visualization",
+    "webgl",
+    "gpu"
+  ],
+  "author": "Development Seed",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "jsdom": "^29.0.2",
+    "proj4": "^2.20.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/geotiff/package.json
+++ b/packages/geotiff/package.json
@@ -1,66 +1,66 @@
 {
-  "name": "@developmentseed/geotiff",
-  "version": "0.6.0",
-  "description": "High-level GeoTIFF reading library.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "name": "@developmentseed/geotiff",
+    "version": "0.6.1",
+    "description": "High-level GeoTIFF reading library.",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./pool/worker": {
+            "types": "./dist/pool/worker.d.ts",
+            "default": "./dist/pool/worker.js"
+        }
     },
-    "./pool/worker": {
-      "types": "./dist/pool/worker.d.ts",
-      "default": "./dist/pool/worker.js"
+    "sideEffects": false,
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc --build tsconfig.build.json",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build"
+    },
+    "keywords": [
+        "geotiff",
+        "cog",
+        "cloud-optimized-geotiff",
+        "raster"
+    ],
+    "author": "Development Seed",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+    },
+    "devDependencies": {
+        "@chunkd/source-file": "^11.2.0",
+        "@developmentseed/geotiff": "workspace:^",
+        "@types/node": "^25.6.0",
+        "geotiff": "^3.0.5",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+    },
+    "volta": {
+        "extends": "../../package.json"
+    },
+    "dependencies": {
+        "@chunkd/middleware": "^11.2.0",
+        "@chunkd/source": "^11.2.0",
+        "@chunkd/source-http": "^11.2.0",
+        "@chunkd/source-memory": "^11.0.3",
+        "@cogeotiff/core": "^9.5.0",
+        "@developmentseed/affine": "workspace:^",
+        "@developmentseed/proj": "workspace:^",
+        "@developmentseed/lzw-tiff-decoder": "^0.2.2",
+        "@developmentseed/morecantile": "workspace:^",
+        "fzstd": "^0.1.1",
+        "lerc": "^4.1.1",
+        "uuid": "^14.0.0"
     }
-  },
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
-  },
-  "keywords": [
-    "geotiff",
-    "cog",
-    "cloud-optimized-geotiff",
-    "raster"
-  ],
-  "author": "Development Seed",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-  },
-  "devDependencies": {
-    "@chunkd/source-file": "^11.2.0",
-    "@developmentseed/geotiff": "workspace:^",
-    "@types/node": "^25.6.0",
-    "geotiff": "^3.0.5",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
-  },
-  "volta": {
-    "extends": "../../package.json"
-  },
-  "dependencies": {
-    "@chunkd/middleware": "^11.2.0",
-    "@chunkd/source": "^11.2.0",
-    "@chunkd/source-http": "^11.2.0",
-    "@chunkd/source-memory": "^11.0.3",
-    "@cogeotiff/core": "^9.5.0",
-    "@developmentseed/affine": "workspace:^",
-    "@developmentseed/proj": "workspace:^",
-    "@developmentseed/lzw-tiff-decoder": "^0.2.2",
-    "@developmentseed/morecantile": "workspace:^",
-    "fzstd": "^0.1.1",
-    "lerc": "^4.1.1",
-    "uuid": "^14.0.0"
-  }
 }

--- a/packages/geotiff/package.json
+++ b/packages/geotiff/package.json
@@ -1,66 +1,66 @@
 {
-    "name": "@developmentseed/geotiff",
-    "version": "0.6.1",
-    "description": "High-level GeoTIFF reading library.",
-    "type": "module",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        },
-        "./pool/worker": {
-            "types": "./dist/pool/worker.d.ts",
-            "default": "./dist/pool/worker.js"
-        }
+  "name": "@developmentseed/geotiff",
+  "version": "0.6.1",
+  "description": "High-level GeoTIFF reading library.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
-    "sideEffects": false,
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc --build tsconfig.build.json",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "typecheck": "tsc --noEmit",
-        "prepublishOnly": "npm run build"
-    },
-    "keywords": [
-        "geotiff",
-        "cog",
-        "cloud-optimized-geotiff",
-        "raster"
-    ],
-    "author": "Development Seed",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-    },
-    "devDependencies": {
-        "@chunkd/source-file": "^11.2.0",
-        "@developmentseed/geotiff": "workspace:^",
-        "@types/node": "^25.6.0",
-        "geotiff": "^3.0.5",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
-    },
-    "volta": {
-        "extends": "../../package.json"
-    },
-    "dependencies": {
-        "@chunkd/middleware": "^11.2.0",
-        "@chunkd/source": "^11.2.0",
-        "@chunkd/source-http": "^11.2.0",
-        "@chunkd/source-memory": "^11.0.3",
-        "@cogeotiff/core": "^9.5.0",
-        "@developmentseed/affine": "workspace:^",
-        "@developmentseed/proj": "workspace:^",
-        "@developmentseed/lzw-tiff-decoder": "^0.2.2",
-        "@developmentseed/morecantile": "workspace:^",
-        "fzstd": "^0.1.1",
-        "lerc": "^4.1.1",
-        "uuid": "^14.0.0"
+    "./pool/worker": {
+      "types": "./dist/pool/worker.d.ts",
+      "default": "./dist/pool/worker.js"
     }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "geotiff",
+    "cog",
+    "cloud-optimized-geotiff",
+    "raster"
+  ],
+  "author": "Development Seed",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+  },
+  "devDependencies": {
+    "@chunkd/source-file": "^11.2.0",
+    "@developmentseed/geotiff": "workspace:^",
+    "@types/node": "^25.6.0",
+    "geotiff": "^3.0.5",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "dependencies": {
+    "@chunkd/middleware": "^11.2.0",
+    "@chunkd/source": "^11.2.0",
+    "@chunkd/source-http": "^11.2.0",
+    "@chunkd/source-memory": "^11.0.3",
+    "@cogeotiff/core": "^9.5.0",
+    "@developmentseed/affine": "workspace:^",
+    "@developmentseed/proj": "workspace:^",
+    "@developmentseed/lzw-tiff-decoder": "^0.2.2",
+    "@developmentseed/morecantile": "workspace:^",
+    "fzstd": "^0.1.1",
+    "lerc": "^4.1.1",
+    "uuid": "^14.0.0"
+  }
 }

--- a/packages/geozarr/package.json
+++ b/packages/geozarr/package.json
@@ -1,52 +1,52 @@
 {
-  "name": "@developmentseed/geozarr",
-  "version": "0.6.0",
-  "description": "GeoZarr metadata parsing.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "name": "@developmentseed/geozarr",
+    "version": "0.6.1",
+    "description": "GeoZarr metadata parsing.",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc --build tsconfig.build.json",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build"
+    },
+    "keywords": [
+        "zarr",
+        "geozarr",
+        "zarr-conventions",
+        "raster",
+        "geospatial"
+    ],
+    "author": "Development Seed",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+    },
+    "dependencies": {
+        "@developmentseed/affine": "workspace:^",
+        "zarrita": "^0.7.1",
+        "zod": "^4.3.6"
+    },
+    "devDependencies": {
+        "@types/node": "^25.6.0",
+        "jsdom": "^29.0.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+    },
+    "volta": {
+        "extends": "../../package.json"
     }
-  },
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
-  },
-  "keywords": [
-    "zarr",
-    "geozarr",
-    "zarr-conventions",
-    "raster",
-    "geospatial"
-  ],
-  "author": "Development Seed",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-  },
-  "dependencies": {
-    "@developmentseed/affine": "workspace:^",
-    "zarrita": "^0.7.1",
-    "zod": "^4.3.6"
-  },
-  "devDependencies": {
-    "@types/node": "^25.6.0",
-    "jsdom": "^29.0.2",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
-  },
-  "volta": {
-    "extends": "../../package.json"
-  }
 }

--- a/packages/geozarr/package.json
+++ b/packages/geozarr/package.json
@@ -1,52 +1,52 @@
 {
-    "name": "@developmentseed/geozarr",
-    "version": "0.6.1",
-    "description": "GeoZarr metadata parsing.",
-    "type": "module",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
-    "sideEffects": false,
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc --build tsconfig.build.json",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "typecheck": "tsc --noEmit",
-        "prepublishOnly": "npm run build"
-    },
-    "keywords": [
-        "zarr",
-        "geozarr",
-        "zarr-conventions",
-        "raster",
-        "geospatial"
-    ],
-    "author": "Development Seed",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-    },
-    "dependencies": {
-        "@developmentseed/affine": "workspace:^",
-        "zarrita": "^0.7.1",
-        "zod": "^4.3.6"
-    },
-    "devDependencies": {
-        "@types/node": "^25.6.0",
-        "jsdom": "^29.0.2",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
-    },
-    "volta": {
-        "extends": "../../package.json"
+  "name": "@developmentseed/geozarr",
+  "version": "0.6.1",
+  "description": "GeoZarr metadata parsing.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "zarr",
+    "geozarr",
+    "zarr-conventions",
+    "raster",
+    "geospatial"
+  ],
+  "author": "Development Seed",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+  },
+  "dependencies": {
+    "@developmentseed/affine": "workspace:^",
+    "zarrita": "^0.7.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "jsdom": "^29.0.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/morecantile/package.json
+++ b/packages/morecantile/package.json
@@ -1,55 +1,55 @@
 {
-  "name": "@developmentseed/morecantile",
-  "version": "0.6.0",
-  "description": "TypeScript port of Python morecantile — TileMatrixSet utilities.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "name": "@developmentseed/morecantile",
+    "version": "0.6.1",
+    "description": "TypeScript port of Python morecantile — TileMatrixSet utilities.",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc --build tsconfig.build.json",
+        "generate-types": "tsx scripts/generate-types.ts",
+        "prepublishOnly": "npm run build",
+        "test:watch": "vitest",
+        "test": "vitest run",
+        "typecheck": "tsc --noEmit"
+    },
+    "keywords": [
+        "tms",
+        "tile-matrix-set",
+        "morecantile",
+        "xyz",
+        "tiles",
+        "geospatial"
+    ],
+    "author": "Development Seed",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+    },
+    "devDependencies": {
+        "@types/node": "^25.6.0",
+        "jsdom": "^29.0.2",
+        "json-schema-to-typescript": "^15.0.4",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+    },
+    "dependencies": {
+        "@developmentseed/affine": "workspace:^"
+    },
+    "peerDependencies": {},
+    "volta": {
+        "extends": "../../package.json"
     }
-  },
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json",
-    "generate-types": "tsx scripts/generate-types.ts",
-    "prepublishOnly": "npm run build",
-    "test:watch": "vitest",
-    "test": "vitest run",
-    "typecheck": "tsc --noEmit"
-  },
-  "keywords": [
-    "tms",
-    "tile-matrix-set",
-    "morecantile",
-    "xyz",
-    "tiles",
-    "geospatial"
-  ],
-  "author": "Development Seed",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-  },
-  "devDependencies": {
-    "@types/node": "^25.6.0",
-    "jsdom": "^29.0.2",
-    "json-schema-to-typescript": "^15.0.4",
-    "tsx": "^4.21.0",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
-  },
-  "dependencies": {
-    "@developmentseed/affine": "workspace:^"
-  },
-  "peerDependencies": {},
-  "volta": {
-    "extends": "../../package.json"
-  }
 }

--- a/packages/morecantile/package.json
+++ b/packages/morecantile/package.json
@@ -1,55 +1,55 @@
 {
-    "name": "@developmentseed/morecantile",
-    "version": "0.6.1",
-    "description": "TypeScript port of Python morecantile — TileMatrixSet utilities.",
-    "type": "module",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
-    "sideEffects": false,
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc --build tsconfig.build.json",
-        "generate-types": "tsx scripts/generate-types.ts",
-        "prepublishOnly": "npm run build",
-        "test:watch": "vitest",
-        "test": "vitest run",
-        "typecheck": "tsc --noEmit"
-    },
-    "keywords": [
-        "tms",
-        "tile-matrix-set",
-        "morecantile",
-        "xyz",
-        "tiles",
-        "geospatial"
-    ],
-    "author": "Development Seed",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-    },
-    "devDependencies": {
-        "@types/node": "^25.6.0",
-        "jsdom": "^29.0.2",
-        "json-schema-to-typescript": "^15.0.4",
-        "tsx": "^4.21.0",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
-    },
-    "dependencies": {
-        "@developmentseed/affine": "workspace:^"
-    },
-    "peerDependencies": {},
-    "volta": {
-        "extends": "../../package.json"
+  "name": "@developmentseed/morecantile",
+  "version": "0.6.1",
+  "description": "TypeScript port of Python morecantile — TileMatrixSet utilities.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "generate-types": "tsx scripts/generate-types.ts",
+    "prepublishOnly": "npm run build",
+    "test:watch": "vitest",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "tms",
+    "tile-matrix-set",
+    "morecantile",
+    "xyz",
+    "tiles",
+    "geospatial"
+  ],
+  "author": "Development Seed",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "jsdom": "^29.0.2",
+    "json-schema-to-typescript": "^15.0.4",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "@developmentseed/affine": "workspace:^"
+  },
+  "peerDependencies": {},
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/proj/package.json
+++ b/packages/proj/package.json
@@ -1,53 +1,53 @@
 {
-    "name": "@developmentseed/proj",
-    "version": "0.6.1",
-    "description": "Utilities for geographic reprojections.",
-    "type": "module",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
-    "sideEffects": false,
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc --build tsconfig.build.json",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "typecheck": "tsc --noEmit",
-        "prepublishOnly": "npm run build"
-    },
-    "keywords": [
-        "geotiff",
-        "zarr",
-        "cog",
-        "cloud-optimized-geotiff",
-        "raster",
-        "visualization",
-        "webgl",
-        "gpu"
-    ],
-    "author": "Development Seed",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-    },
-    "devDependencies": {
-        "@types/node": "^25.6.0",
-        "proj4": "^2.20.4",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
-    },
-    "dependencies": {
-        "wkt-parser": "1.5.5"
-    },
-    "volta": {
-        "extends": "../../package.json"
+  "name": "@developmentseed/proj",
+  "version": "0.6.1",
+  "description": "Utilities for geographic reprojections.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "geotiff",
+    "zarr",
+    "cog",
+    "cloud-optimized-geotiff",
+    "raster",
+    "visualization",
+    "webgl",
+    "gpu"
+  ],
+  "author": "Development Seed",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "proj4": "^2.20.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "wkt-parser": "1.5.5"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
 }

--- a/packages/proj/package.json
+++ b/packages/proj/package.json
@@ -1,53 +1,53 @@
 {
-  "name": "@developmentseed/proj",
-  "version": "0.6.0",
-  "description": "Utilities for geographic reprojections.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "name": "@developmentseed/proj",
+    "version": "0.6.1",
+    "description": "Utilities for geographic reprojections.",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc --build tsconfig.build.json",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build"
+    },
+    "keywords": [
+        "geotiff",
+        "zarr",
+        "cog",
+        "cloud-optimized-geotiff",
+        "raster",
+        "visualization",
+        "webgl",
+        "gpu"
+    ],
+    "author": "Development Seed",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+    },
+    "devDependencies": {
+        "@types/node": "^25.6.0",
+        "proj4": "^2.20.4",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+    },
+    "dependencies": {
+        "wkt-parser": "1.5.5"
+    },
+    "volta": {
+        "extends": "../../package.json"
     }
-  },
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
-  },
-  "keywords": [
-    "geotiff",
-    "zarr",
-    "cog",
-    "cloud-optimized-geotiff",
-    "raster",
-    "visualization",
-    "webgl",
-    "gpu"
-  ],
-  "author": "Development Seed",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-  },
-  "devDependencies": {
-    "@types/node": "^25.6.0",
-    "proj4": "^2.20.4",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
-  },
-  "dependencies": {
-    "wkt-parser": "1.5.5"
-  },
-  "volta": {
-    "extends": "../../package.json"
-  }
 }

--- a/packages/raster-reproject/package.json
+++ b/packages/raster-reproject/package.json
@@ -1,53 +1,53 @@
 {
-  "name": "@developmentseed/raster-reproject",
-  "version": "0.6.0",
-  "description": "Mesh generation for client-side raster reprojection.",
-  "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "name": "@developmentseed/raster-reproject",
+    "version": "0.6.1",
+    "description": "Mesh generation for client-side raster reprojection.",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsc --build tsconfig.build.json",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "typecheck": "tsc --noEmit",
+        "prepublishOnly": "npm run build"
+    },
+    "keywords": [
+        "deck.gl",
+        "geotiff",
+        "zarr",
+        "cog",
+        "cloud-optimized-geotiff",
+        "raster",
+        "visualization",
+        "webgl",
+        "gpu"
+    ],
+    "author": "Development Seed",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+    },
+    "devDependencies": {
+        "@developmentseed/affine": "workspace:^",
+        "@types/node": "^25.6.0",
+        "jsdom": "^29.0.2",
+        "proj4": "^2.20.4",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+    },
+    "volta": {
+        "extends": "../../package.json"
     }
-  },
-  "sideEffects": false,
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build tsconfig.build.json",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
-  },
-  "keywords": [
-    "deck.gl",
-    "geotiff",
-    "zarr",
-    "cog",
-    "cloud-optimized-geotiff",
-    "raster",
-    "visualization",
-    "webgl",
-    "gpu"
-  ],
-  "author": "Development Seed",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-  },
-  "devDependencies": {
-    "@developmentseed/affine": "workspace:^",
-    "@types/node": "^25.6.0",
-    "jsdom": "^29.0.2",
-    "proj4": "^2.20.4",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
-  },
-  "volta": {
-    "extends": "../../package.json"
-  }
 }

--- a/packages/raster-reproject/package.json
+++ b/packages/raster-reproject/package.json
@@ -1,53 +1,53 @@
 {
-    "name": "@developmentseed/raster-reproject",
-    "version": "0.6.1",
-    "description": "Mesh generation for client-side raster reprojection.",
-    "type": "module",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
-    "sideEffects": false,
-    "files": [
-        "dist"
-    ],
-    "scripts": {
-        "build": "tsc --build tsconfig.build.json",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "typecheck": "tsc --noEmit",
-        "prepublishOnly": "npm run build"
-    },
-    "keywords": [
-        "deck.gl",
-        "geotiff",
-        "zarr",
-        "cog",
-        "cloud-optimized-geotiff",
-        "raster",
-        "visualization",
-        "webgl",
-        "gpu"
-    ],
-    "author": "Development Seed",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
-    },
-    "devDependencies": {
-        "@developmentseed/affine": "workspace:^",
-        "@types/node": "^25.6.0",
-        "jsdom": "^29.0.2",
-        "proj4": "^2.20.4",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
-    },
-    "volta": {
-        "extends": "../../package.json"
+  "name": "@developmentseed/raster-reproject",
+  "version": "0.6.1",
+  "description": "Mesh generation for client-side raster reprojection.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "deck.gl",
+    "geotiff",
+    "zarr",
+    "cog",
+    "cloud-optimized-geotiff",
+    "raster",
+    "visualization",
+    "webgl",
+    "gpu"
+  ],
+  "author": "Development Seed",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/developmentseed/deck.gl-raster.git"
+  },
+  "devDependencies": {
+    "@developmentseed/affine": "workspace:^",
+    "@types/node": "^25.6.0",
+    "jsdom": "^29.0.2",
+    "proj4": "^2.20.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
 }


### PR DESCRIPTION
### Change list

- Allow returning `null` from `rasterTile`. Useful for lonboard in 	https://github.com/developmentseed/lonboard/pull/1183/changes#diff-749baf2a232827f928a56f2acbb4b7b7c6c72968818900cc34f05a66b5d49d18R167-R169
- Bump to 0.6.1