### PR TITLE
refactor: make `MultiCOGLayer` extend `RasterTileLayer`

### DIFF
--- a/dev-docs/specs/2026-05-01-multi-cog-layer-extends-raster-tile-layer-design.md
+++ b/dev-docs/specs/2026-05-01-multi-cog-layer-extends-raster-tile-layer-design.md
@@ -1,0 +1,177 @@
+# MultiCOGLayer Extends RasterTileLayer
+
+## Problem
+
+`MultiCOGLayer` (in `deck.gl-geotiff`) is the only first-party tile layer that still extends `CompositeLayer` directly. It re-implements wiring that `RasterTileLayer` (in `deck.gl-raster`) already provides:
+
+- Globe vs. Web Mercator coordinate-system branching (`coordinateSystem`, `coordinateOrigin`, `modelMatrix`)
+- Per-tile `RasterLayer` construction with `reprojectionFns`
+- Combining the user's `signal` prop with the inner `TileLayer`'s per-tile `AbortSignal`
+- Forwarding `TileLayer` passthrough props (`maxRequests`, `maxCacheSize`, etc.)
+- Constructing the inner `RasterTileset2D` factory subclass
+
+That's roughly 150 lines of duplicated boilerplate. It also blocks the future API broadening tracked in [#417](https://github.com/developmentseed/deck.gl-raster/issues/417), because the planned `getTileData` / `renderTile` extension points are most naturally expressed in terms of `RasterTileLayer`'s base hooks.
+
+This spec covers a single mechanical refactor: make `MultiCOGLayer` extend `RasterTileLayer`. No public API changes. The follow-up work that adds the new user-facing extension points is a separate spec.
+
+## Goals
+
+- `MultiCOGLayer extends RasterTileLayer<MultiTileResult, MultiCOGLayerProps>`.
+- Drop the duplicated globe/mercator/debug/signal/`TileLayer` wiring; inherit it from the base.
+- Preserve the rich multi-band debug overlay (per-band tile outlines and tiered text labels) that the base's default debug overlay does not provide.
+- Keep `MultiCOGLayerProps` and runtime behavior unchanged. All existing examples (`naip-mosaic`, `sentinel-2`, `aef-mosaic`) render identically.
+
+## Non-Goals
+
+- Adding the `getTileData` / `renderTile` user-facing extension points (PR 2 — separate spec).
+- Changing the multi-resolution fetch + stitch logic. The current `_fetchPrimaryBand` / `_fetchSecondaryBand` and UV-transform computation are preserved verbatim.
+- Refactoring the multi-band debug overlay's content or styling.
+- Touching `COGLayer` or `ZarrLayer` (already migrated).
+
+## Design
+
+### 1. Base-class hook for extra per-tile sub-layers
+
+`RasterTileLayer._renderSubLayers` is currently `private` and produces, in order:
+
+1. Tile-outline debug paths (when `debug` is true) via `renderDebugTileOutline`.
+2. The per-tile `RasterLayer` (when `props.data` is truthy and `renderTile` returned a non-null result).
+
+`MultiCOGLayer`'s rich debug overlay needs access to the per-tile `MultiTileData` (band debug info, secondary tile corners) and the multi-tileset descriptor. To accommodate this without giving subclasses control over the whole `_renderSubLayers` body, add one protected hook:
+
+```ts
+/**
+ * Hook for subclasses to append additional sub-layers to each rendered tile.
+ *
+ * Called once per tile inside _renderSubLayers, after the main RasterLayer is
+ * constructed. The default implementation returns an empty array.
+ *
+ * Subclasses can use this to render tile-scoped overlays that depend on the
+ * fetched DataT (e.g. multi-band debug outlines).
+ */
+protected _renderExtraSubLayers(
+  tile: Tile2DHeader<DataT>,
+  data: DataT,
+): Layer[] {
+  return [];
+}
+```
+
+`_renderSubLayers` calls `this._renderExtraSubLayers(tile, props.data)` immediately after building the `RasterLayer` and concatenates the result. Existing direct-use behavior is unchanged: the default returns `[]`.
+
+The base's existing tile-outline debug path (`renderDebugTileOutline`) stays put — it does not depend on `DataT` and applies to every `RasterTileLayer`. Subclasses with richer debug needs simply add to it via the new hook.
+
+### 2. MultiCOGLayer migration
+
+#### Class signature
+
+```ts
+export class MultiCOGLayer extends RasterTileLayer<
+  MultiTileResult,
+  MultiCOGLayerProps
+> {
+  static override layerName = "MultiCOGLayer";
+  static override defaultProps = {
+    ...RasterTileLayer.defaultProps,
+    epsgResolver: { type: "accessor" as const, value: defaultEpsgResolver },
+    debugLevel: { type: "number" as const, value: 1 },
+  } as typeof RasterTileLayer.defaultProps;
+  // ...
+}
+```
+
+`MultiCOGLayer`'s existing user-facing props are layered into the second type parameter so the base's `tilesetDescriptor` / `getTileData` / `renderTile` props are excluded — `MultiCOGLayer` doesn't expose those yet.
+
+#### State shape (simplified)
+
+```ts
+declare state: {
+  sources: Map<string, SourceState> | null;
+  multiDescriptor: MultiTilesetDescriptor | null;
+};
+```
+
+The four projection functions (`forwardTo4326`, `inverseFrom4326`, `forwardTo3857`, `inverseFrom3857`) are dropped from layer state. They already live on the primary `TilesetDescriptor` produced by `geoTiffToDescriptor` and can be read from `state.multiDescriptor.primary` wherever needed (currently only inside the debug overlay's outline projection).
+
+#### Overrides
+
+```ts
+protected override _tilesetDescriptor(): TilesetDescriptor | undefined {
+  return this.state.multiDescriptor?.primary;
+}
+
+protected override _getTileDataCallback() {
+  if (!this.state.multiDescriptor || !this.state.sources) {
+    return undefined;
+  }
+  return (tile: TileLoadProps, options: GetTileDataOptions) =>
+    this._getTileData(tile, options);
+}
+
+protected override _renderTileCallback() {
+  if (!this.state.multiDescriptor) {
+    return undefined;
+  }
+  return (data: MultiTileResult): RenderTileResult =>
+    this._buildRenderResult(data);
+}
+
+protected override _renderExtraSubLayers(
+  tile: Tile2DHeader<MultiTileResult>,
+  data: MultiTileResult,
+): Layer[] {
+  if (!this.props.debug || !data.debugInfo) {
+    return [];
+  }
+  return this._renderDebugLayers(tile, data);
+}
+```
+
+`_buildRenderResult(data)` runs the existing logic from `_renderSubLayers`: builds the `composite` band mapping (default → first source on R), validates required bands are present, calls `buildCompositeBandsProps`, prepends the `CompositeBands` module to the user's `renderPipeline`, and returns `{ image: undefined, renderPipeline }`. When required bands are missing it returns `null` — matching the contract from #489 and ensuring the inner `RasterLayer` is not constructed (preserving today's behavior of skipping the tile entirely).
+
+`_getTileData` keeps the current `tile.signal` + `this.props.signal` composition removed — `RasterTileLayer._wrapGetTileData` already produces a combined signal in `options.signal`, so the user-side `_getTileData` can read `options.signal` directly.
+
+#### Code deleted
+
+- `_renderSubLayers` (the multi-cog one): replaced by the inherited base implementation plus `_renderExtraSubLayers` + `_buildRenderResult`.
+- `renderTileLayer`: inherited.
+- `renderLayers`: inherited.
+- The `forwardTo4326` / `inverseFrom4326` / `forwardTo3857` / `inverseFrom3857` slots in state and the wiring that populates and reads them.
+- `_parseAllSources`'s creation of those four converters (the descriptor builder already produces them).
+- `WEB_MERCATOR_METER_CIRCUMFERENCE`, `WEB_MERCATOR_TO_WORLD_SCALE`, `TILE_SIZE` constants in this file (already in `raster-tile-layer/constants.ts`, and only used by the deleted globe/mercator branch).
+
+#### Code preserved verbatim
+
+- `_parseAllSources` minus the dropped converter setup.
+- `_getTileData` (the multi-source fetch entry point).
+- `_fetchPrimaryBand`, `_fetchSecondaryBand`.
+- `_renderDebugLayers` (the rich per-band overlay), now wired through `_renderExtraSubLayers` instead of being inlined.
+- `cornersToWgs84Path`, `selectImage`, `createBandTexture`.
+
+### 3. File touches
+
+```
+packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+  + protected _renderExtraSubLayers(tile, data) hook
+  + call site in _renderSubLayers
+
+packages/deck.gl-geotiff/src/multi-cog-layer.ts
+  major refactor (described above); ~150 lines deleted, no API changes
+```
+
+No other files change.
+
+### 4. Testing
+
+- All existing tests pass without modification (no public API changes).
+- Manual smoke test in each existing example: `naip-mosaic`, `sentinel-2`, `aef-mosaic`. Verify identical rendering, identical debug overlay, identical fitBounds behavior on `onGeoTIFFLoad`, identical behavior when toggling sources at runtime.
+- Verify globe projection still works for `MultiCOGLayer` (the base handles it; this is a non-regression check).
+- Verify `signal` prop still aborts in-flight fetches when toggling sources or unmounting.
+
+If unit tests for `MultiCOGLayer` exist and lock down the duplicated wiring (e.g. assertions on `RasterLayer` props), they may need to be relaxed or rewritten against the inherited base behavior.
+
+## Risks / Open Questions
+
+- **Signal composition contract.** `MultiCOGLayer._getTileData` currently composes `tile.signal` + `this.props.signal` itself. The base now does this in `_wrapGetTileData` and forwards the composed signal in `options.signal`. The migration must ensure `_fetchPrimaryBand` / `_fetchSecondaryBand` consume `options.signal`, not `this.props.signal`, to avoid double-composition or regression.
+- **`null` vs empty render pipeline for missing-bands case.** The current code returns `null` from `renderSubLayers` when `composite` references an unknown band; the new `renderTile` contract permits returning `null` (issue #489 in recent commits). Use that path so the underlying `RasterLayer` is not constructed at all, matching the previous behavior.
+- **Debug overlay sublayer ordering.** Today's `MultiCOGLayer._renderSubLayers` returns `[rasterLayer, ...debugSublayers]`. The base returns `[rasterLayer, ...tileOutlineSublayers]` and the new hook appends after. Verify the visual result is unchanged (it should be — paths and text both render on top regardless of array order in deck.gl since they're layered by sub-layer ID, but worth confirming visually).

--- a/packages/deck.gl-geotiff/src/geotiff-reprojection.ts
+++ b/packages/deck.gl-geotiff/src/geotiff-reprojection.ts
@@ -1,5 +1,6 @@
 import type { Affine } from "@developmentseed/affine";
 import * as affine from "@developmentseed/affine";
+import type { ProjectionFunction } from "@developmentseed/deck.gl-raster";
 import type { GeoTIFF } from "@developmentseed/geotiff";
 import type { ProjectionDefinition } from "@developmentseed/proj";
 import type { ReprojectionFns } from "@developmentseed/raster-reproject";
@@ -32,8 +33,8 @@ export async function extractGeotiffReprojectors(
 }
 
 export function fromAffine(geotransform: Affine): {
-  forwardTransform: (x: number, y: number) => [number, number];
-  inverseTransform: (x: number, y: number) => [number, number];
+  forwardTransform: ProjectionFunction;
+  inverseTransform: ProjectionFunction;
 } {
   const inverseGeotransform = affine.invert(geotransform);
   return {

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -13,6 +13,7 @@ import type {
   Corners,
   GetTileDataOptions,
   MultiTilesetDescriptor,
+  ProjectionFunction,
   RasterModule,
   RenderTileResult,
   TilesetDescriptor,
@@ -109,9 +110,9 @@ interface MultiTileResult {
   /** Per-band texture data, keyed by source name. */
   bands: Map<string, BandTileData>;
   /** Forward transform from pixel coordinates to CRS coordinates. */
-  forwardTransform: (x: number, y: number) => [number, number];
+  forwardTransform: ProjectionFunction;
   /** Inverse transform from CRS coordinates to pixel coordinates. */
-  inverseTransform: (x: number, y: number) => [number, number];
+  inverseTransform: ProjectionFunction;
   /** Width of the primary tile in pixels. */
   width: number;
   /** Height of the primary tile in pixels. */
@@ -768,7 +769,7 @@ export class MultiCOGLayer extends RasterTileLayer<
     tileId: string,
     tile: Tile2DHeader<MultiTileResult>,
     data: MultiTileResult,
-    forwardTo4326: (x: number, y: number) => [number, number],
+    forwardTo4326: ProjectionFunction,
   ): Layer[] {
     const layers: Layer[] = [];
     const debugLevel = this.props.debugLevel ?? 1;
@@ -966,7 +967,7 @@ function createBandTexture(device: Device, array: RasterArray): Texture {
  */
 function cornersToWgs84Path(
   corners: Corners,
-  projectTo4326: (x: number, y: number) => [number, number],
+  projectTo4326: ProjectionFunction,
 ): { path: [number, number][]; center: [number, number] } {
   const topLeft = projectTo4326(corners.topLeft[0], corners.topLeft[1]);
   const topRight = projectTo4326(corners.topRight[0], corners.topRight[1]);

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -1,31 +1,27 @@
 import type {
   CompositeLayerProps,
   Layer,
-  LayerProps,
-  LayersList,
   UpdateParameters,
 } from "@deck.gl/core";
-import { CompositeLayer } from "@deck.gl/core";
 import type {
   _Tile2DHeader as Tile2DHeader,
   TileLayerProps,
   _TileLoadProps as TileLoadProps,
-  _Tileset2DProps as Tileset2DProps,
 } from "@deck.gl/geo-layers";
-import { TileLayer } from "@deck.gl/geo-layers";
 import { PathLayer, TextLayer } from "@deck.gl/layers";
 import type {
   Corners,
+  GetTileDataOptions,
   MultiTilesetDescriptor,
   RasterModule,
+  RenderTileResult,
   TilesetDescriptor,
   TilesetLevel,
   UvTransform,
 } from "@developmentseed/deck.gl-raster";
 import {
   createMultiTilesetDescriptor,
-  RasterLayer,
-  RasterTileset2D,
+  RasterTileLayer,
   resolveSecondaryTiles,
   selectSecondaryLevel,
   tilesetLevelsEqual,
@@ -48,24 +44,10 @@ import {
   metersPerUnit,
   parseWkt,
 } from "@developmentseed/proj";
-import type { ReprojectionFns } from "@developmentseed/raster-reproject";
 import type { Device, Texture, TextureFormat } from "@luma.gl/core";
 import proj4 from "proj4";
 import { fetchGeoTIFF, getGeographicBounds } from "./geotiff/geotiff.js";
 import { geoTiffToDescriptor } from "./geotiff-tileset.js";
-
-/** Size of deck.gl's common coordinate space in world units. */
-const TILE_SIZE = 512;
-
-/** The size of the globe in web mercator meters. */
-const WEB_MERCATOR_METER_CIRCUMFERENCE = 40075016.686;
-
-/**
- * Scale factor for converting EPSG:3857 meters into deck.gl world units
- * (512x512).
- */
-const WEB_MERCATOR_TO_WORLD_SCALE =
-  TILE_SIZE / WEB_MERCATOR_METER_CIRCUMFERENCE;
 
 /**
  * Color palette for debug overlays.
@@ -277,10 +259,8 @@ export type MultiCOGLayerProps = CompositeLayerProps &
   };
 
 const defaultProps = {
+  ...RasterTileLayer.defaultProps,
   epsgResolver: { type: "accessor" as const, value: defaultEpsgResolver },
-  maxError: { type: "number" as const, value: 0.125 },
-  debug: { type: "boolean" as const, value: false },
-  debugOpacity: { type: "number" as const, value: 0.5 },
   debugLevel: { type: "number" as const, value: 1 },
 };
 
@@ -297,27 +277,26 @@ const defaultProps = {
  * @see {@link createMultiTilesetDescriptor} for the grouping logic.
  * @see {@link geoTiffToDescriptor} for the per-source tileset descriptor.
  */
-export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
+export class MultiCOGLayer extends RasterTileLayer<
+  MultiTileResult,
+  MultiCOGLayerProps
+> {
   static override layerName = "MultiCOGLayer";
-  static override defaultProps = defaultProps;
+  // Same casting trick as COGLayer: defaultProps shape diverges from the
+  // base's parameterized type, so cast through to satisfy the static-side
+  // check while keeping subclass-specific defaults.
+  static override defaultProps =
+    defaultProps as unknown as typeof RasterTileLayer.defaultProps;
 
   declare state: {
     sources: Map<string, SourceState> | null;
     multiDescriptor: MultiTilesetDescriptor | null;
-    forwardTo4326: ReprojectionFns["forwardReproject"] | null;
-    inverseFrom4326: ReprojectionFns["inverseReproject"] | null;
-    forwardTo3857: ReprojectionFns["forwardReproject"] | null;
-    inverseFrom3857: ReprojectionFns["inverseReproject"] | null;
   };
 
   override initializeState(): void {
     this.setState({
       sources: null,
       multiDescriptor: null,
-      forwardTo4326: null,
-      inverseFrom4326: null,
-      forwardTo3857: null,
-      inverseFrom3857: null,
     });
   }
 
@@ -419,10 +398,6 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
     this.setState({
       sources: sourceMap,
       multiDescriptor,
-      forwardTo4326,
-      inverseFrom4326,
-      forwardTo3857,
-      inverseFrom3857,
     });
 
     if (this.props.onGeoTIFFLoad) {
@@ -451,18 +426,14 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
    * @param tile - Tile load props from the TileLayer, containing index and signal.
    * @returns Per-band textures, UV transforms, and reprojection functions.
    */
-  async _getTileData(tile: TileLoadProps): Promise<MultiTileResult> {
-    const { signal } = tile;
+  async _getTileData(
+    tile: TileLoadProps,
+    options: GetTileDataOptions,
+  ): Promise<MultiTileResult> {
     const { x, y, z } = tile.index;
     const { multiDescriptor, sources } = this.state;
     const pool = this.props.pool ?? defaultDecoderPool();
-    const device = this.context.device;
-
-    // Combine abort signals if both are defined
-    const combinedSignal =
-      signal && this.props.signal
-        ? AbortSignal.any([signal, this.props.signal])
-        : signal || this.props.signal;
+    const { device, signal: combinedSignal } = options;
 
     // Compute per-tile reprojection transforms from the primary descriptor
     const primaryKey = multiDescriptor!.primaryKey;
@@ -540,10 +511,6 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       0,
     );
 
-    console.log(
-      `Tile (${x}, ${y}, ${z}): fetched bands [${[...bands.keys()].join(", ")}], total byte length: ${byteLength}`,
-    );
-
     return {
       bands,
       forwardTransform,
@@ -553,6 +520,85 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
       byteLength,
       debugInfo,
     };
+  }
+
+  protected override _tilesetDescriptor(): TilesetDescriptor | undefined {
+    return this.state.multiDescriptor?.primary;
+  }
+
+  protected override _getTileDataCallback() {
+    if (!this.state.multiDescriptor || !this.state.sources) {
+      return undefined;
+    }
+    return (
+      tile: TileLoadProps,
+      options: GetTileDataOptions,
+    ): Promise<MultiTileResult> => this._getTileData(tile, options);
+  }
+
+  protected override _renderTileCallback() {
+    if (!this.state.multiDescriptor) {
+      return undefined;
+    }
+    return (data: MultiTileResult): RenderTileResult | null =>
+      this._buildRenderResult(data);
+  }
+
+  protected override _renderExtraSubLayers(
+    tile: Tile2DHeader<MultiTileResult>,
+    data: MultiTileResult,
+  ): Layer[] {
+    if (!this.props.debug || !data.debugInfo) {
+      return [];
+    }
+    const projectTo4326 = this.state.multiDescriptor?.primary.projectTo4326;
+    if (!projectTo4326) {
+      return [];
+    }
+    return this._renderDebugLayers(
+      `${this.id}-${tile.id}`,
+      tile,
+      data,
+      projectTo4326,
+    );
+  }
+
+  /**
+   * Build the per-tile render pipeline. Mirrors the band-binding logic that
+   * previously lived inline in `_renderSubLayers`.
+   *
+   * Returns `null` when the configured `composite` references a band that
+   * isn't present in the cached tile data (happens transiently while sources
+   * are switching).
+   */
+  private _buildRenderResult(data: MultiTileResult): RenderTileResult | null {
+    const { bands } = data;
+
+    const composite = this.props.composite ?? {
+      r: [...bands.keys()][0]!,
+    };
+
+    const requiredBands = [
+      composite.r,
+      composite.g,
+      composite.b,
+      composite.a,
+    ].filter((n): n is string => n != null);
+    if (requiredBands.some((name) => !bands.has(name))) {
+      return null;
+    }
+
+    const compositeBandsProps = buildCompositeBandsProps(composite, bands);
+
+    const renderPipeline: RasterModule[] = [
+      {
+        module: CompositeBands as RasterModule["module"],
+        props: compositeBandsProps as RasterModule["props"],
+      },
+      ...(this.props.renderPipeline ?? []),
+    ];
+
+    return { renderPipeline };
   }
 
   /**
@@ -709,126 +755,6 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
   }
 
   /**
-   * Create sub-layers for a single loaded tile.
-   *
-   * Builds a {@link RasterLayer} with reprojection functions and a render
-   * pipeline that starts with a {@link CompositeBands} module binding all
-   * band textures, followed by any user-provided pipeline modules.
-   */
-  _renderSubLayers(
-    props: TileLayerProps<MultiTileResult> & {
-      id: string;
-      data?: MultiTileResult;
-      _offset: number;
-      tile: Tile2DHeader<MultiTileResult>;
-    },
-    forwardTo4326: ReprojectionFns["forwardReproject"],
-    inverseFrom4326: ReprojectionFns["inverseReproject"],
-    forwardTo3857: ReprojectionFns["forwardReproject"],
-    inverseFrom3857: ReprojectionFns["inverseReproject"],
-  ): Layer | LayersList | null {
-    const { maxError, debug, debugOpacity } = this.props;
-
-    if (!props.data) {
-      return null;
-    }
-
-    const { bands, forwardTransform, inverseTransform, width, height } =
-      props.data;
-
-    // Build the composite bands mapping — default to first source for R if
-    // no composite mapping is provided
-    const composite = this.props.composite ?? {
-      r: [...bands.keys()][0]!,
-    };
-
-    // Skip rendering if cached tile data doesn't have the required bands
-    // (happens when switching presets — old tiles will be re-fetched)
-    const requiredBands = [
-      composite.r,
-      composite.g,
-      composite.b,
-      composite.a,
-    ].filter((n): n is string => n != null);
-    if (requiredBands.some((name) => !bands.has(name))) {
-      return null;
-    }
-
-    // Map named bands to fixed slot indices and build module props
-    const compositeBandsProps = buildCompositeBandsProps(composite, bands);
-
-    const renderPipeline: RasterModule[] = [
-      {
-        module: CompositeBands as RasterModule["module"],
-        props: compositeBandsProps as RasterModule["props"],
-      },
-      ...(this.props.renderPipeline ?? []),
-    ];
-
-    // Determine projection mode (globe vs web mercator)
-    const isGlobe = this.context.viewport.resolution !== undefined;
-    let reprojectionFns: ReprojectionFns;
-    let deckProjectionProps: Partial<LayerProps>;
-
-    if (isGlobe) {
-      reprojectionFns = {
-        forwardTransform,
-        inverseTransform,
-        forwardReproject: forwardTo4326,
-        inverseReproject: inverseFrom4326,
-      };
-      deckProjectionProps = {};
-    } else {
-      reprojectionFns = {
-        forwardTransform,
-        inverseTransform,
-        forwardReproject: forwardTo3857,
-        inverseReproject: inverseFrom3857,
-      };
-      deckProjectionProps = {
-        coordinateSystem: "cartesian",
-        coordinateOrigin: [TILE_SIZE / 2, TILE_SIZE / 2, 0],
-        // biome-ignore format: array
-        modelMatrix: [
-            WEB_MERCATOR_TO_WORLD_SCALE, 0, 0, 0,
-            0, WEB_MERCATOR_TO_WORLD_SCALE, 0, 0,
-            0, 0, 1, 0,
-            0, 0, 0, 1
-          ],
-      };
-    }
-
-    const rasterLayer = new RasterLayer(
-      this.getSubLayerProps({
-        id: `${props.id}-raster`,
-        width,
-        height,
-        renderPipeline,
-        maxError,
-        reprojectionFns,
-        debug,
-        debugOpacity,
-        ...deckProjectionProps,
-      }),
-    );
-
-    const sublayers: Layer[] = [rasterLayer];
-
-    if (debug && props.data) {
-      sublayers.push(
-        ...this._renderDebugLayers(
-          props.id,
-          props.tile,
-          props.data,
-          forwardTo4326,
-        ),
-      );
-    }
-
-    return sublayers;
-  }
-
-  /**
    * Render debug overlay layers for a single tile: colored outlines for
    * primary and secondary tile boundaries, and tiered text labels.
    *
@@ -842,7 +768,7 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
     tileId: string,
     tile: Tile2DHeader<MultiTileResult>,
     data: MultiTileResult,
-    forwardTo4326: ReprojectionFns["forwardReproject"],
+    forwardTo4326: (x: number, y: number) => [number, number],
   ): Layer[] {
     const layers: Layer[] = [];
     const debugLevel = this.props.debugLevel ?? 1;
@@ -981,96 +907,6 @@ export class MultiCOGLayer extends CompositeLayer<MultiCOGLayerProps> {
 
     return layers;
   }
-
-  /**
-   * Build the tile layer that drives tile traversal and rendering.
-   *
-   * Creates a {@link RasterTileset2D} factory from the primary tileset,
-   * then returns a {@link TileLayer} wired up with tile fetching and
-   * sub-layer rendering.
-   */
-  renderTileLayer(
-    multiDescriptor: MultiTilesetDescriptor,
-    forwardTo4326: ReprojectionFns["forwardReproject"],
-    inverseFrom4326: ReprojectionFns["inverseReproject"],
-    forwardTo3857: ReprojectionFns["forwardReproject"],
-    inverseFrom3857: ReprojectionFns["inverseReproject"],
-  ): TileLayer {
-    const { primary } = multiDescriptor;
-
-    // Create a factory class that wraps RasterTileset2D with the primary descriptor
-    class PrimaryTilesetFactory extends RasterTileset2D {
-      constructor(opts: Tileset2DProps) {
-        super(opts, primary);
-      }
-    }
-
-    const {
-      maxRequests,
-      maxCacheSize,
-      maxCacheByteSize,
-      debounceTime,
-      refinementStrategy,
-    } = this.props;
-
-    // Stringify sources to detect when the set of COG URLs changes.
-    // This triggers TileLayer to invalidate its cache and re-fetch.
-    const sourceKeys = Object.keys(this.props.sources).sort().join(",");
-    const sourceUrls = Object.values(this.props.sources)
-      .map((s) => String(s.url))
-      .sort()
-      .join(",");
-
-    return new TileLayer<MultiTileResult>({
-      id: `multi-cog-tile-layer-${this.id}-${sourceUrls}`,
-      TilesetClass: PrimaryTilesetFactory,
-      getTileData: async (tile) => this._getTileData(tile),
-      renderSubLayers: (props) =>
-        this._renderSubLayers(
-          props,
-          forwardTo4326,
-          inverseFrom4326,
-          forwardTo3857,
-          inverseFrom3857,
-        ),
-      updateTriggers: {
-        getTileData: [sourceKeys, sourceUrls],
-      },
-      debounceTime,
-      maxCacheByteSize,
-      maxCacheSize,
-      maxRequests,
-      refinementStrategy,
-    });
-  }
-
-  override renderLayers(): Layer | LayersList | null {
-    const {
-      multiDescriptor,
-      forwardTo4326,
-      inverseFrom4326,
-      forwardTo3857,
-      inverseFrom3857,
-    } = this.state;
-
-    if (
-      !multiDescriptor ||
-      !forwardTo4326 ||
-      !inverseFrom4326 ||
-      !forwardTo3857 ||
-      !inverseFrom3857
-    ) {
-      return null;
-    }
-
-    return this.renderTileLayer(
-      multiDescriptor,
-      forwardTo4326,
-      inverseFrom4326,
-      forwardTo3857,
-      inverseFrom3857,
-    );
-  }
 }
 
 /**
@@ -1130,7 +966,7 @@ function createBandTexture(device: Device, array: RasterArray): Texture {
  */
 function cornersToWgs84Path(
   corners: Corners,
-  projectTo4326: ReprojectionFns["forwardReproject"],
+  projectTo4326: (x: number, y: number) => [number, number],
 ): { path: [number, number][]; center: [number, number] } {
   const topLeft = projectTo4326(corners.topLeft[0], corners.topLeft[1]);
   const topRight = projectTo4326(corners.topRight[0], corners.topRight[1]);

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -544,16 +544,16 @@ export class MultiCOGLayer extends RasterTileLayer<
       this._buildRenderResult(data);
   }
 
-  protected override _renderExtraSubLayers(
+  protected override _renderDebug(
     tile: Tile2DHeader<MultiTileResult>,
-    data: MultiTileResult,
+    data: MultiTileResult | null,
   ): Layer[] {
-    if (!this.props.debug || !data.debugInfo) {
-      return [];
+    if (!data?.debugInfo) {
+      return super._renderDebug(tile, data);
     }
     const projectTo4326 = this.state.multiDescriptor?.primary.projectTo4326;
     if (!projectTo4326) {
-      return [];
+      return super._renderDebug(tile, data);
     }
     return this._renderDebugLayers(
       `${this.id}-${tile.id}`,

--- a/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+++ b/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
@@ -222,6 +222,24 @@ export class RasterTileLayer<
     return (this.props as unknown as RasterTileLayerProps<DataT>).renderTile;
   }
 
+  /**
+   * Hook for subclasses to append additional sub-layers to each rendered tile.
+   *
+   * Called once per tile from `_renderSubLayers`, after the main {@link RasterLayer}
+   * is constructed and only when the tile has fetched data. The default returns
+   * an empty array.
+   *
+   * Subclasses may use this to render tile-scoped overlays that depend on the
+   * fetched `DataT` — for example, a multi-band debug overlay that draws
+   * outlines and labels for each source's contributing tiles.
+   */
+  protected _renderExtraSubLayers(
+    _tile: Tile2DHeader<DataT>,
+    _data: NonNullable<DataT>,
+  ): Layer[] {
+    return [];
+  }
+
   override renderLayers(): Layer | null {
     const descriptor = this._tilesetDescriptor();
     const getTileData = this._getTileDataCallback();
@@ -392,6 +410,7 @@ export class RasterTileLayer<
         ...deckProjectionProps,
       }),
     );
-    return [rasterLayer, ...layers];
+    const extra = this._renderExtraSubLayers(tile, props.data);
+    return [rasterLayer, ...extra, ...layers];
   }
 }

--- a/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+++ b/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
@@ -223,21 +223,36 @@ export class RasterTileLayer<
   }
 
   /**
-   * Hook for subclasses to append additional sub-layers to each rendered tile.
+   * Hook for rendering per-tile debug overlay sub-layers.
    *
-   * Called once per tile from `_renderSubLayers`, after the main {@link RasterLayer}
-   * is constructed and only when the tile has fetched data. The default returns
-   * an empty array.
+   * Called once per tile from `_renderSubLayers` only when `props.debug` is
+   * `true`. The hook fires both before data has arrived (`data` is `null`) and
+   * after (`data` is the fetched `DataT`), so the default outline can render
+   * during loading.
    *
-   * Subclasses may use this to render tile-scoped overlays that depend on the
-   * fetched `DataT` — for example, a multi-band debug overlay that draws
-   * outlines and labels for each source's contributing tiles.
+   * Default behavior renders the primary tile boundary via
+   * {@link renderDebugTileOutline} using the active descriptor. Subclasses can
+   * override to replace, extend (via `super._renderDebug(...)`), or suppress
+   * the default — for example, a multi-source layer can replace the default
+   * with per-band tile outlines and tiered metadata labels once `data` is
+   * available.
    */
-  protected _renderExtraSubLayers(
-    _tile: Tile2DHeader<DataT>,
-    _data: NonNullable<DataT>,
+  protected _renderDebug(
+    tile: Tile2DHeader<DataT>,
+    _data: DataT | null,
   ): Layer[] {
-    return [];
+    const descriptor = this._tilesetDescriptor();
+    if (!descriptor) {
+      return [];
+    }
+    // Tiles built by RasterTileset2D are augmented with TileMetadata
+    // (projectedBbox/Corners, tileWidth/Height) at construction time. The cast
+    // makes that runtime augmentation visible to the typed helper.
+    return renderDebugTileOutline(
+      `${this.id}-${tile.id}-bounds`,
+      tile as Tile2DHeader<DataT> & TileMetadata,
+      descriptor.projectTo4326,
+    );
   }
 
   override renderLayers(): Layer | null {
@@ -338,30 +353,23 @@ export class RasterTileLayer<
     const { maxError, debug, debugOpacity } = this.props;
     const tile = props.tile as Tile2DHeader<DataT> & TileMetadata;
 
-    const layers: Layer[] = [];
-    if (debug) {
-      layers.push(
-        ...renderDebugTileOutline(
-          `${this.id}-${tile.id}-bounds`,
-          tile,
-          descriptor.projectTo4326,
-        ),
-      );
-    }
+    const debugLayers = debug
+      ? this._renderDebug(tile, props.data ?? null)
+      : [];
 
     if (!props.data) {
-      return layers;
+      return debugLayers;
     }
 
     const { x, y, z } = tile.index;
     const level = descriptor.levels[z];
     if (!level) {
-      return layers;
+      return debugLayers;
     }
     const { forwardTransform, inverseTransform } = level.tileTransform(x, y);
     const tileResult = renderTile(props.data);
     if (!tileResult) {
-      return layers;
+      return debugLayers;
     }
     const { image, renderPipeline } = tileResult;
     const { width, height } = props.data;
@@ -410,7 +418,6 @@ export class RasterTileLayer<
         ...deckProjectionProps,
       }),
     );
-    const extra = this._renderExtraSubLayers(tile, props.data);
-    return [rasterLayer, ...extra, ...layers];
+    return [rasterLayer, ...debugLayers];
   }
 }

--- a/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
@@ -1,7 +1,7 @@
 import type { Affine } from "@developmentseed/affine";
 import * as affine from "@developmentseed/affine";
 import type { TilesetLevel } from "./tileset-interface.js";
-import type { Bounds, Corners } from "./types.js";
+import type { Bounds, Corners, ProjectionFunction } from "./types.js";
 
 /**
  * Constructor options for {@link AffineTilesetLevel}.
@@ -91,8 +91,8 @@ export class AffineTilesetLevel implements TilesetLevel {
     col: number,
     row: number,
   ): {
-    forwardTransform: (x: number, y: number) => [number, number];
-    inverseTransform: (x: number, y: number) => [number, number];
+    forwardTransform: ProjectionFunction;
+    inverseTransform: ProjectionFunction;
   } {
     const tileOffset = affine.translation(
       col * this.tileWidth,

--- a/packages/deck.gl-raster/src/raster-tileset/tile-matrix-set.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/tile-matrix-set.ts
@@ -132,8 +132,8 @@ class TileMatrixAdaptor implements TilesetLevel {
     col: number,
     row: number,
   ): {
-    forwardTransform: (x: number, y: number) => [number, number];
-    inverseTransform: (x: number, y: number) => [number, number];
+    forwardTransform: ProjectionFunction;
+    inverseTransform: ProjectionFunction;
   } {
     const fwd = tileTransform(this.inner, { col, row });
     const inv = affine.invert(fwd);

--- a/packages/deck.gl-raster/src/raster-tileset/tileset-interface.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/tileset-interface.ts
@@ -72,8 +72,8 @@ export interface TilesetLevel {
     col: number,
     row: number,
   ) => {
-    forwardTransform: (x: number, y: number) => [number, number];
-    inverseTransform: (x: number, y: number) => [number, number];
+    forwardTransform: ProjectionFunction;
+    inverseTransform: ProjectionFunction;
   };
 }
 

--- a/packages/deck.gl-raster/tests/raster-tile-layer/raster-tile-layer.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tile-layer/raster-tile-layer.test.ts
@@ -17,4 +17,18 @@ describe("RasterTileLayer", () => {
   it("can be constructed with no props without throwing", () => {
     expect(() => new RasterTileLayer({ id: "test" })).not.toThrow();
   });
+
+  it("exposes a _renderExtraSubLayers hook returning [] by default", () => {
+    class ProbeLayer extends RasterTileLayer {
+      callExtra(tile: unknown, data: unknown) {
+        return (
+          this as unknown as {
+            _renderExtraSubLayers: (t: unknown, d: unknown) => unknown[];
+          }
+        )._renderExtraSubLayers(tile, data);
+      }
+    }
+    const layer = new ProbeLayer({ id: "probe" });
+    expect(layer.callExtra({}, { width: 1, height: 1 })).toEqual([]);
+  });
 });

--- a/packages/deck.gl-raster/tests/raster-tile-layer/raster-tile-layer.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tile-layer/raster-tile-layer.test.ts
@@ -18,17 +18,17 @@ describe("RasterTileLayer", () => {
     expect(() => new RasterTileLayer({ id: "test" })).not.toThrow();
   });
 
-  it("exposes a _renderExtraSubLayers hook returning [] by default", () => {
+  it("exposes a _renderDebug hook returning [] when no descriptor is configured", () => {
     class ProbeLayer extends RasterTileLayer {
-      callExtra(tile: unknown, data: unknown) {
+      callDebug(tile: unknown, data: unknown) {
         return (
           this as unknown as {
-            _renderExtraSubLayers: (t: unknown, d: unknown) => unknown[];
+            _renderDebug: (t: unknown, d: unknown) => unknown[];
           }
-        )._renderExtraSubLayers(tile, data);
+        )._renderDebug(tile, data);
       }
     }
     const layer = new ProbeLayer({ id: "probe" });
-    expect(layer.callExtra({}, { width: 1, height: 1 })).toEqual([]);
+    expect(layer.callDebug({ id: "x" }, null)).toEqual([]);
   });
 });

--- a/packages/proj/src/web-mercator.ts
+++ b/packages/proj/src/web-mercator.ts
@@ -1,3 +1,5 @@
+import type { ProjectionFunction } from "./transform-bounds.js";
+
 const WGS84_ELLIPSOID_A = 6378137;
 
 // Maximum latitude representable in Web Mercator (EPSG:3857), in degrees.
@@ -35,9 +37,9 @@ function wgs84To3857(lon: number, lat: number): [number, number] {
  * hold shared projection utilities like this. *
  */
 export function makeClampedForwardTo3857(
-  forwardTo3857: (x: number, y: number) => [number, number],
-  forwardTo4326: (x: number, y: number) => [number, number],
-): (x: number, y: number) => [number, number] {
+  forwardTo3857: ProjectionFunction,
+  forwardTo4326: ProjectionFunction,
+): ProjectionFunction {
   return (x: number, y: number): [number, number] => {
     const [px, py] = forwardTo3857(x, y);
     if (Number.isFinite(px) && Number.isFinite(py)) {


### PR DESCRIPTION
## Summary

- Migrate `MultiCOGLayer` to extend `RasterTileLayer` instead of `CompositeLayer`. Drops ~165 lines of duplicated wiring (globe/mercator branching, signal combining, `RasterLayer` construction, `RasterTileset2D` factory subclass) — all already provided by `RasterTileLayer`.
- Multi-source fetch + stitch + UV transform logic stays in `MultiCOGLayer._getTileData` (now consuming the base's combined `options.signal` instead of recomposing).
- Rich per-band debug overlay (per-source tile outlines + tiered text labels) moves to a new protected `_renderExtraSubLayers(tile, data)` hook on `RasterTileLayer` that subclasses can override; default returns `[]`.
- **No public API change.** `MultiCOGLayerProps` and runtime behavior unchanged.

Spec: [`dev-docs/specs/2026-05-01-multi-cog-layer-extends-raster-tile-layer-design.md`](dev-docs/specs/2026-05-01-multi-cog-layer-extends-raster-tile-layer-design.md)

See #417. First of three planned PRs (this one is the mechanical refactor; follow-ups will add the new `getTileData`/`renderTile` extension points and an NLCD animation example).
