### PR TITLE
fix(mosaic-layer): make sources prop reactive to updates

### DIFF
--- a/dev-docs/specs/2026-05-07-mosaic-layer-dynamic-sources-design.md
+++ b/dev-docs/specs/2026-05-07-mosaic-layer-dynamic-sources-design.md
@@ -1,0 +1,177 @@
+# MosaicLayer Dynamic Sources
+
+## Problem
+
+`MosaicLayer` only renders the `sources` array provided on first mount. Later updates to the `sources` prop are ignored and the rendered mosaic never grows or shrinks. This is reported in [#510](https://github.com/developmentseed/deck.gl-raster/issues/510), motivated by STAC search pagination in `stac-map`, where new items should be appended to the mosaic as they load.
+
+Root cause: [`MosaicLayer.renderTileLayer`](../../packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts) builds a `MosaicTileset2DFactory` whose constructor closes over the snapshot value of `mosaicSources`:
+
+```ts
+class MosaicTileset2DFactory extends MosaicTileset2D<MosaicT> {
+  constructor(opts: any) {
+    super(mosaicSources, opts);
+  }
+}
+```
+
+deck.gl's `TileLayer` only instantiates `TilesetClass` once (see `tile-layer.ts` `updateState`). After the first call, the inner tileset is reused across prop updates and never sees the new `sources` array.
+
+## Goals
+
+- Updates to the `MosaicLayer` `sources` prop are picked up automatically by the rendering, with no manual API call required by the consumer.
+- The detection of a sources change happens inside the layer lifecycle (during deck.gl's tileset update cycle), not via ad-hoc external state.
+- Existing rendered sub-layers and tile cache entries are preserved across `sources` updates whose tile IDs are unchanged. We must not prematurely tear down sub-layers when sources are appended.
+- The cache-stability contract is documented on the public `MosaicLayerProps.sources` JSDoc and on the `MosaicSource.x` / `.y` / `.z` JSDoc, so consumers know exactly when to supply explicit identifiers vs. rely on array-position defaults.
+- No public API change to `MosaicLayer` or `MosaicTileset2D`. Behavior on the first render is identical.
+
+## Non-Goals
+
+- Stable tile IDs across reordering or middle-removal. Today, sources without an explicit `x`/`y`/`z` get `x: i, y: 0, z: 0` derived from their array index, so the tile ID `${z}-${x}-${y}` is only stable for sources whose array position is stable. Pure append works perfectly. Reordering or middle-removal will invalidate the cache slots of shifted sources, same as today. Consumers who need cache stability across arbitrary mutation can already supply explicit `x`/`y`/`z` per source. We document this contract on the public JSDoc but do not change the default behavior.
+- Removing finalized sub-layer resources (deck.gl's existing tile cache eviction handles this).
+- Diff-based partial index updates. We rebuild the Flatbush index in O(N) on any reference change. For mosaics in the 10s–1000s of items range this is negligible.
+
+## Design
+
+### 1. `MosaicTileset2D` accepts a sources getter, rebuilds index lazily
+
+Replace the constructor's `sources: MosaicT[]` parameter with a getter `getSources: () => MosaicT[]`. Add a private `ensureIndex()` method that, on each call, fetches the latest sources array, compares by reference to the previously cached array, and rebuilds the source-with-tile-index list and Flatbush spatial index when (and only when) the reference has changed. Call `ensureIndex()` at the top of `getTileIndices`.
+
+```ts
+class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
+  private getSources: () => MosaicT[];
+  private cachedRaw: MosaicT[] | null = null;
+  private sources: (TileIndex & MosaicT)[] = [];
+  private index: Flatbush | null = null;
+
+  constructor(getSources: () => MosaicT[], opts: Tileset2DProps) {
+    super(opts);
+    this.getSources = getSources;
+  }
+
+  private ensureIndex(): void {
+    const raw = this.getSources();
+    if (raw === this.cachedRaw) return;
+    this.cachedRaw = raw;
+
+    this.sources = raw.map((source, i) => ({
+      x: source.x ?? i,
+      y: source.y ?? 0,
+      z: source.z ?? 0,
+      ...source,
+    }));
+
+    const index = new Flatbush(Math.max(raw.length, 1));
+    for (const source of raw) {
+      const [minX, minY, maxX, maxY] = source.bbox;
+      index.add(minX, minY, maxX, maxY);
+    }
+    index.finish();
+    this.index = index;
+  }
+
+  override getTileIndices(opts): (TileIndex & MosaicT)[] {
+    this.ensureIndex();
+    // existing zoom guards and Flatbush search logic
+  }
+}
+```
+
+Notes:
+- `Math.max(raw.length, 1)` because Flatbush requires `numItems >= 1`. An empty sources array still constructs a usable (if empty) index.
+- Reference equality (`===`) is the contract: consumers that pass a new array (e.g. via React state with a new array on append) trigger a rebuild; consumers that mutate-in-place do not. This matches deck.gl's standard `data` prop convention.
+
+### 2. `MosaicLayer.renderTileLayer` passes a getter closing over `this.props`
+
+Inside `renderTileLayer`, the inner factory class becomes:
+
+```ts
+const self = this;
+class MosaicTileset2DFactory extends MosaicTileset2D<MosaicT> {
+  constructor(opts: any) {
+    super(() => self.props.sources, opts);
+  }
+}
+```
+
+The arrow function captures the `MosaicLayer` instance. deck.gl reuses the same `MosaicLayer` instance across prop updates and swaps `this.props` in place, so the getter always returns the current `sources` array.
+
+### 3. Why the existing flow already triggers `getTileIndices`
+
+No changes are required to the inner `TileLayer` or the `MosaicLayer.updateState` lifecycle. The reactive flow on a `sources` prop update is:
+
+1. `MosaicLayer.renderLayers()` runs and produces a fresh inner `TileLayer` descriptor. `getTileData` and `renderSubLayers` are inline closures, so their references differ each render. `TilesetClass` is also a fresh class.
+2. deck.gl matches the inner `TileLayer` by id. Because at least one prop reference differs, `propsChanged` is true and `TileLayer.updateState` calls `tileset.setOptions(opts)`.
+3. `Tileset2D.setOptions` resets `_viewport = null`.
+4. `_updateTileset` calls `tileset.update(viewport)`. With `_viewport === null`, the guard re-runs `getTileIndices`.
+5. `MosaicTileset2D.getTileIndices` calls `ensureIndex()`, which detects the new `sources` reference and rebuilds the Flatbush in O(N). The new index is used immediately for tile selection.
+6. `_getTile(index, true)` looks each selected tile up in `tileset._cache` by tile ID. Existing tiles for unchanged sources are returned from cache; new sources produce new tile IDs and trigger fresh fetches.
+
+The `_cache` is preserved across the entire flow — no `reloadAll` is invoked, no `TilesetClass` reinstantiation occurs, and no sub-layer is torn down.
+
+### 4. Public JSDoc updates
+
+Update the JSDoc on `MosaicLayerProps.sources` to document the dynamic-update behavior and the cache-stability contract:
+
+```ts
+/**
+ * List of mosaic sources to render.
+ *
+ * The mosaic updates reactively when this prop is replaced with a new array
+ * reference. Mutating the array in place will not trigger an update — pass a
+ * fresh array (e.g. `[...sources, newItem]`) to add or remove items.
+ *
+ * Tile cache reuse depends on stable tile IDs. By default, each source's tile
+ * ID is derived from its position in this array (see `MosaicSource.x`/`y`/`z`
+ * for the exact derivation). This means:
+ *
+ * - Appending items preserves all existing rendered tiles.
+ * - Reordering or removing items from the middle of the array will invalidate
+ *   the cache slots of shifted items, causing them to re-fetch.
+ *
+ * If you need cache stability across arbitrary `sources` mutations, supply
+ * explicit `x`, `y`, and `z` identifiers per source so each source's tile ID
+ * stays stable regardless of array position.
+ */
+sources: MosaicT[];
+```
+
+Update the `MosaicSource` JSDoc to explain the role of `x` / `y` / `z` as cache identifiers (not viewport coordinates):
+
+```ts
+/**
+ * Minimal required interface of a mosaic item.
+ */
+export type MosaicSource = {
+  /**
+   * Optional tile-cache identifier component. Together with `y` and `z`, forms
+   * the tile ID `${z}-${x}-${y}` used to key the inner Tileset2D cache.
+   * Defaults to the source's index in the `sources` array. Supply an explicit
+   * value when you need cache stability across reordering or removal.
+   */
+  x?: number;
+  /** See `x`. Defaults to `0`. */
+  y?: number;
+  /** See `x`. Defaults to `0`. */
+  z?: number;
+  /**
+   * Geographic bounds (WGS84) of the source in [minX, minY, maxX, maxY] format
+   */
+  bbox: [number, number, number, number];
+};
+```
+
+## Risks
+
+- If a consumer ever stabilizes every prop the `MosaicLayer` passes through to the inner `TileLayer` (so `propsChanged` is false), step 2 above does not trigger. Today this is impossible because `getTileData`, `renderSubLayers`, and `TilesetClass` are all inline-defined per render. We will keep them inline-defined to preserve this behavior.
+- An empty initial `sources` array followed by a non-empty update is supported: the initial Flatbush is built with capacity 1 but contains zero adds, and `ensureIndex` rebuilds when the array reference changes.
+
+## Testing
+
+Add a vitest unit test for `MosaicTileset2D` covering:
+
+1. Construction with an empty getter, then a getter returning `[A, B]`, asserts that `getTileIndices` returns A and B for a viewport intersecting both.
+2. After a sources reference change appending `[A, B, C]`, `getTileIndices` returns all three. The `cachedRaw` reference now equals the new array.
+3. Calling `getTileIndices` twice with the same getter return value does not rebuild the index (assert `index` reference identity).
+4. A getter that returns the same reference but with mutated contents does NOT pick up the mutation (documents the reference-equality contract).
+
+No new integration test is needed for `MosaicLayer` itself — the existing examples exercise the renderTileLayer wiring, and the unit tests above cover the new dynamic behavior.

--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -414,7 +414,7 @@ export default function App() {
       maxCacheSize: Infinity,
       // @ts-expect-error beforeId is injected by @deck.gl/mapbox; LayerProps
       // doesn't know about it.
-      beforeId: "tunnel_service_case",
+      beforeId: "boundary_country_outline",
     });
     layers.push(mosaicLayer);
   }

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
@@ -83,13 +83,13 @@ export class MosaicLayer<
       maxRequests,
     } = this.props;
 
-    // Capture `this` so the factory's getter resolves the latest sources prop
-    // on every Tileset2D update cycle, allowing the spatial index to rebuild
-    // when the consumer passes a new sources array.
-    const self = this;
+    // The arrow function is defined here so its lexical `this` is the
+    // MosaicLayer instance (which deck.gl reuses across prop updates),
+    // ensuring `this.props.sources` returns the latest array on every call.
+    const getSources = () => this.props.sources;
     class MosaicTileset2DFactory extends MosaicTileset2D<MosaicT> {
       constructor(opts: any) {
-        super(() => self.props.sources, opts);
+        super(getSources, opts);
       }
     }
 

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
@@ -18,7 +18,25 @@ export type MosaicLayerProps<
     | "maxCacheSize"
     | "maxRequests"
   > & {
-    /** List of mosaic sources to render */
+    /**
+     * List of mosaic sources to render.
+     *
+     * The mosaic updates reactively when this prop is replaced with a new
+     * array reference. Mutating the array in place will not trigger an
+     * update — pass a fresh array (e.g. `[...sources, newItem]`) to add or
+     * remove items.
+     *
+     * Tile cache reuse depends on stable tile IDs. By default, each source's
+     * tile ID is derived from its position in this array (see `MosaicSource`'s
+     * `x` / `y` / `z` for the exact derivation), so:
+     *
+     * - Appending items preserves all existing rendered tiles.
+     * - Reordering or removing items from the middle of the array invalidates
+     *   the cache slots of shifted items, causing them to re-fetch.
+     *
+     * Supply explicit `x`, `y`, and `z` identifiers per source if you need
+     * cache stability across arbitrary mutations of `sources`.
+     */
     sources: MosaicT[];
 
     /** Fetch data for this source. */
@@ -53,7 +71,6 @@ export class MosaicLayer<
   static override defaultProps = defaultProps;
 
   renderTileLayer(
-    mosaicSources: MosaicT[],
     renderSource: MosaicLayerProps<MosaicT, DataT>["renderSource"],
   ): TileLayer {
     const {
@@ -66,9 +83,13 @@ export class MosaicLayer<
       maxRequests,
     } = this.props;
 
+    // Capture `this` so the factory's getter resolves the latest sources prop
+    // on every Tileset2D update cycle, allowing the spatial index to rebuild
+    // when the consumer passes a new sources array.
+    const self = this;
     class MosaicTileset2DFactory extends MosaicTileset2D<MosaicT> {
       constructor(opts: any) {
-        super(mosaicSources, opts);
+        super(() => self.props.sources, opts);
       }
     }
 
@@ -112,10 +133,13 @@ export class MosaicLayer<
   override renderLayers(): Layer | null | LayersList {
     const { sources, renderSource } = this.props;
 
-    if (!sources || sources.length === 0) {
+    if (!sources) {
       return null;
     }
 
-    return this.renderTileLayer(sources, renderSource);
+    // Note: we deliberately render the inner TileLayer even when `sources` is
+    // empty so the same Tileset2D instance lives across empty -> non-empty
+    // transitions and picks up later updates without recreation.
+    return this.renderTileLayer(renderSource);
   }
 }

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-tileset-2d.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-tileset-2d.ts
@@ -43,11 +43,26 @@ export type MosaicSource = {
  * closure returns a new array reference (compared by `===`); mutating the
  * array in place will not be detected.
  */
+/** Sources prepared for spatial querying: each source augmented with the
+ * `TileIndex` fields, paired with a Flatbush index over their bboxes. */
+type BuiltIndex<MosaicT> = {
+  sources: (TileIndex & MosaicT)[];
+  index: Flatbush;
+};
+
 export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
+  /** Closure returning the parent layer's current sources array. Re-evaluated
+   * on each `getTileIndices` call so updates to the layer's `sources` prop
+   * propagate without recreating the tileset. */
   private getSources: () => MosaicT[];
+
+  /** Last sources array reference the index was built from. Compared by `===`
+   * against the closure's next return value to decide whether to rebuild. */
   private cachedRaw: MosaicT[] | null = null;
-  private sources: (TileIndex & MosaicT)[] = [];
-  private index: Flatbush | null = null;
+
+  /** Sources + spatial index built from `cachedRaw`. `null` means the last
+   * observed sources list was empty (Flatbush requires at least one item). */
+  private cached: BuiltIndex<MosaicT> | null = null;
 
   constructor(getSources: () => MosaicT[], opts: Tileset2DProps) {
     super(opts);
@@ -55,33 +70,31 @@ export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
   }
 
   /**
-   * Rebuild the spatial index if the closure returns a new sources array
-   * reference. No-op when the reference is unchanged.
+   * Returns the prepared sources + spatial index for the current sources
+   * array, rebuilding only if the closure has produced a new array reference
+   * since the last call. Returns `null` when the sources list is empty.
    */
-  private ensureIndex(): void {
+  private ensureIndex(): BuiltIndex<MosaicT> | null {
     const raw = this.getSources();
     if (raw === this.cachedRaw) {
-      return;
+      return this.cached;
     }
     this.cachedRaw = raw;
+
+    if (raw.length === 0) {
+      this.cached = null;
+      return null;
+    }
 
     // Add x,y,z to each source for TileIndex compatibility
     // This is mostly just a hack to satisfy deck.gl typing requirements for
     // getTileIndices
-    this.sources = raw.map((source, i) => ({
+    const sources: (TileIndex & MosaicT)[] = raw.map((source, i) => ({
       x: source.x === undefined ? i : source.x,
       y: source.y === undefined ? 0 : source.y,
       z: source.z === undefined ? 0 : source.z,
       ...source,
     }));
-
-    // Flatbush requires numItems >= 1 and that all declared items are added
-    // before finish(); skip the build when there are no sources and let
-    // getTileIndices short-circuit on the empty cachedRaw.
-    if (raw.length === 0) {
-      this.index = null;
-      return;
-    }
 
     const index = new Flatbush(raw.length);
     for (const source of raw) {
@@ -89,7 +102,9 @@ export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
       index.add(minX, minY, maxX, maxY);
     }
     index.finish();
-    this.index = index;
+
+    this.cached = { sources, index };
+    return this.cached;
   }
 
   override getTileIndices({
@@ -101,20 +116,20 @@ export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
     maxZoom?: number;
     minZoom?: number;
   }): (TileIndex & MosaicT)[] {
-    this.ensureIndex();
-
     if (viewport.zoom < (minZoom ?? -Infinity)) {
       return [];
     }
     if (viewport.zoom > (maxZoom ?? Infinity)) {
       return [];
     }
-    if (this.cachedRaw === null || this.cachedRaw.length === 0) {
+
+    const built = this.ensureIndex();
+    if (built === null) {
       return [];
     }
 
     const bounds = viewport.getBounds();
-    const indices = this.index!.search(...bounds);
-    return indices.map((sourceIndex) => this.sources[sourceIndex]!);
+    const indices = built.index.search(...bounds);
+    return indices.map((sourceIndex) => built.sources[sourceIndex]!);
   }
 }

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-tileset-2d.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-tileset-2d.ts
@@ -74,7 +74,7 @@ export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
    * array, rebuilding only if the closure has produced a new array reference
    * since the last call. Returns `null` when the sources list is empty.
    */
-  private ensureIndex(): BuiltIndex<MosaicT> | null {
+  private buildSpatialIndex(): BuiltIndex<MosaicT> | null {
     const raw = this.getSources();
     if (raw === this.cachedRaw) {
       return this.cached;
@@ -123,7 +123,7 @@ export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
       return [];
     }
 
-    const built = this.ensureIndex();
+    const built = this.buildSpatialIndex();
     if (built === null) {
       return [];
     }

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-tileset-2d.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-tileset-2d.ts
@@ -14,8 +14,16 @@ export type TileIndex = { x: number; y: number; z: number };
  * Minimal required interface of a mosaic item.
  */
 export type MosaicSource = {
+  /**
+   * Optional tile-cache identifier component. Together with `y` and `z`, forms
+   * the tile ID `${z}-${x}-${y}` used to key the inner Tileset2D cache.
+   * Defaults to the source's index in the `sources` array. Supply an explicit
+   * value when you need cache stability across reordering or removal of items.
+   */
   x?: number;
+  /** See `x`. Defaults to `0`. */
   y?: number;
+  /** See `x`. Defaults to `0`. */
   z?: number;
   /**
    * Geographic bounds (WGS84) of the source in [minX, minY, maxX, maxY] format
@@ -28,32 +36,59 @@ export type MosaicSource = {
  *
  * This is intended to be used for a collection of image mosaics, where we want
  * to render all images currently visible in the viewport.
+ *
+ * The constructor accepts a `getSources` closure rather than a sources array
+ * so that updates to the parent layer's `sources` prop are picked up across
+ * the tileset's lifetime. The spatial index is rebuilt on demand whenever the
+ * closure returns a new array reference (compared by `===`); mutating the
+ * array in place will not be detected.
  */
 export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
-  private sources: (TileIndex & MosaicT)[];
-  private index: Flatbush;
+  private getSources: () => MosaicT[];
+  private cachedRaw: MosaicT[] | null = null;
+  private sources: (TileIndex & MosaicT)[] = [];
+  private index: Flatbush | null = null;
 
-  constructor(sources: MosaicT[], opts: Tileset2DProps) {
+  constructor(getSources: () => MosaicT[], opts: Tileset2DProps) {
     super(opts);
+    this.getSources = getSources;
+  }
+
+  /**
+   * Rebuild the spatial index if the closure returns a new sources array
+   * reference. No-op when the reference is unchanged.
+   */
+  private ensureIndex(): void {
+    const raw = this.getSources();
+    if (raw === this.cachedRaw) {
+      return;
+    }
+    this.cachedRaw = raw;
 
     // Add x,y,z to each source for TileIndex compatibility
     // This is mostly just a hack to satisfy deck.gl typing requirements for
     // getTileIndices
-    this.sources = sources.map((source, i) => ({
+    this.sources = raw.map((source, i) => ({
       x: source.x === undefined ? i : source.x,
       y: source.y === undefined ? 0 : source.y,
       z: source.z === undefined ? 0 : source.z,
       ...source,
     }));
 
-    // Build spatial index of mosaic sources
-    const index = new Flatbush(sources.length);
-    for (const source of sources) {
+    // Flatbush requires numItems >= 1 and that all declared items are added
+    // before finish(); skip the build when there are no sources and let
+    // getTileIndices short-circuit on the empty cachedRaw.
+    if (raw.length === 0) {
+      this.index = null;
+      return;
+    }
+
+    const index = new Flatbush(raw.length);
+    for (const source of raw) {
       const [minX, minY, maxX, maxY] = source.bbox;
       index.add(minX, minY, maxX, maxY);
     }
     index.finish();
-
     this.index = index;
   }
 
@@ -66,15 +101,20 @@ export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
     maxZoom?: number;
     minZoom?: number;
   }): (TileIndex & MosaicT)[] {
+    this.ensureIndex();
+
     if (viewport.zoom < (minZoom ?? -Infinity)) {
       return [];
     }
     if (viewport.zoom > (maxZoom ?? Infinity)) {
       return [];
     }
+    if (this.cachedRaw === null || this.cachedRaw.length === 0) {
+      return [];
+    }
 
     const bounds = viewport.getBounds();
-    const indices = this.index.search(...bounds);
+    const indices = this.index!.search(...bounds);
     return indices.map((sourceIndex) => this.sources[sourceIndex]!);
   }
 }

--- a/packages/deck.gl-geotiff/tests/mosaic-tileset.test.ts
+++ b/packages/deck.gl-geotiff/tests/mosaic-tileset.test.ts
@@ -1,0 +1,147 @@
+import type { Viewport } from "@deck.gl/core";
+import type { _Tileset2DProps as Tileset2DProps } from "@deck.gl/geo-layers";
+import { describe, expect, it } from "vitest";
+import type { MosaicSource } from "../src/mosaic-layer/mosaic-tileset-2d.js";
+import { MosaicTileset2D } from "../src/mosaic-layer/mosaic-tileset-2d.js";
+
+const TILESET_OPTS: Tileset2DProps = {
+  // getTileData is required by the type but not exercised in these tests.
+  getTileData: async () => null,
+};
+
+function fakeViewport(bounds: [number, number, number, number], zoom = 5) {
+  return {
+    zoom,
+    getBounds: () => bounds,
+  } as unknown as Viewport;
+}
+
+type Item = MosaicSource & { id: string };
+const A: Item = { id: "A", bbox: [0, 0, 10, 10] };
+const B: Item = { id: "B", bbox: [20, 0, 30, 10] };
+const C: Item = { id: "C", bbox: [40, 0, 50, 10] };
+
+describe("MosaicTileset2D dynamic sources", () => {
+  it("returns sources intersecting the viewport on initial query", () => {
+    const sourcesRef: { current: Item[] } = { current: [A, B] };
+    const tileset = new MosaicTileset2D<Item>(
+      () => sourcesRef.current,
+      TILESET_OPTS,
+    );
+
+    const result = tileset.getTileIndices({
+      viewport: fakeViewport([-1, -1, 11, 11]),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("A");
+  });
+
+  it("picks up appended sources without reconstructing the tileset", () => {
+    const sourcesRef: { current: Item[] } = { current: [A, B] };
+    const tileset = new MosaicTileset2D<Item>(
+      () => sourcesRef.current,
+      TILESET_OPTS,
+    );
+
+    // Initial query — only A and B available
+    tileset.getTileIndices({
+      viewport: fakeViewport([-1, -1, 51, 11]),
+    });
+
+    // Consumer replaces the array reference with an appended array
+    sourcesRef.current = [A, B, C];
+
+    const result = tileset.getTileIndices({
+      viewport: fakeViewport([-1, -1, 51, 11]),
+    });
+
+    expect(result.map((s) => s.id).sort()).toEqual(["A", "B", "C"]);
+  });
+
+  it("starts from an empty array and rebuilds on first non-empty update", () => {
+    const sourcesRef: { current: Item[] } = { current: [] };
+    const tileset = new MosaicTileset2D<Item>(
+      () => sourcesRef.current,
+      TILESET_OPTS,
+    );
+
+    expect(
+      tileset.getTileIndices({ viewport: fakeViewport([-1, -1, 51, 11]) }),
+    ).toEqual([]);
+
+    sourcesRef.current = [A, B];
+
+    const result = tileset.getTileIndices({
+      viewport: fakeViewport([-1, -1, 51, 11]),
+    });
+    expect(result.map((s) => s.id).sort()).toEqual(["A", "B"]);
+  });
+
+  it("does not pick up in-place mutations of the same array reference", () => {
+    const stable: Item[] = [A, B];
+    const tileset = new MosaicTileset2D<Item>(() => stable, TILESET_OPTS);
+
+    tileset.getTileIndices({
+      viewport: fakeViewport([-1, -1, 51, 11]),
+    });
+
+    // Mutate the array in place — same reference
+    stable.push(C);
+
+    const result = tileset.getTileIndices({
+      viewport: fakeViewport([-1, -1, 51, 11]),
+    });
+
+    // C is not picked up because the array reference did not change.
+    expect(result.map((s) => s.id).sort()).toEqual(["A", "B"]);
+  });
+
+  it("derives default tile-id components from array position", () => {
+    const sourcesRef: { current: Item[] } = { current: [A, B, C] };
+    const tileset = new MosaicTileset2D<Item>(
+      () => sourcesRef.current,
+      TILESET_OPTS,
+    );
+
+    const result = tileset.getTileIndices({
+      viewport: fakeViewport([-1, -1, 51, 11]),
+    });
+
+    const byId = new Map(result.map((s) => [s.id, s] as const));
+    expect(byId.get("A")).toMatchObject({ x: 0, y: 0, z: 0 });
+    expect(byId.get("B")).toMatchObject({ x: 1, y: 0, z: 0 });
+    expect(byId.get("C")).toMatchObject({ x: 2, y: 0, z: 0 });
+  });
+
+  it("respects explicit x/y/z on a source", () => {
+    const explicit: MosaicSource & { id: string } = {
+      id: "explicit",
+      bbox: [0, 0, 10, 10],
+      x: 42,
+      y: 7,
+      z: 3,
+    };
+    const tileset = new MosaicTileset2D<MosaicSource & { id: string }>(
+      () => [explicit],
+      TILESET_OPTS,
+    );
+
+    const result = tileset.getTileIndices({
+      viewport: fakeViewport([-1, -1, 11, 11]),
+    });
+
+    expect(result[0]).toMatchObject({ id: "explicit", x: 42, y: 7, z: 3 });
+  });
+
+  it("returns no tiles when zoom is outside the [minZoom, maxZoom] range", () => {
+    const tileset = new MosaicTileset2D<Item>(() => [A], TILESET_OPTS);
+    const viewport = fakeViewport([-1, -1, 11, 11], 5);
+
+    expect(tileset.getTileIndices({ viewport, minZoom: 10 })).toEqual([]);
+    expect(tileset.getTileIndices({ viewport, maxZoom: 1 })).toEqual([]);
+    expect(
+      tileset.getTileIndices({ viewport, minZoom: 0, maxZoom: 10 }),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- `MosaicTileset2D` now takes a `() => MosaicT[]` getter instead of a snapshot array; the spatial index rebuilds lazily inside `getTileIndices` whenever the closure returns a new array reference, picking up updates without recreating the tileset and preserving the inner tile cache.
- `MosaicLayer.renderTileLayer` closes over `this`, passing `() => self.props.sources` so deck.gl's existing `setOptions` → `_viewport = null` → `getTileIndices` flow on every prop update naturally surfaces the new sources.
- Public JSDoc on `MosaicLayerProps.sources` and `MosaicSource.x/y/z` now documents the array-reference-equality contract and the cache-stability implications for append vs. reorder/middle-removal.

Closes #510.

Design doc: [`dev-docs/specs/2026-05-07-mosaic-layer-dynamic-sources-design.md`](https://github.com/developmentseed/deck.gl-raster/blob/kyle/mosaic-layer-edit/dev-docs/specs/2026-05-07-mosaic-layer-dynamic-sources-design.md).

## Test plan

- [x] New `tests/mosaic-tileset.test.ts` covers initial query, append-without-reconstruction, empty → non-empty transition, in-place-mutation no-op (documents the reference-equality contract), default tile-id derivation from array position, explicit `x/y/z`, and zoom-range guards. 7/7 pass.
- [x] `pnpm exec biome check` clean on `packages/deck.gl-geotiff/src/mosaic-layer/` and the new test file.
- [x] `pnpm exec tsc --noEmit` reports no new errors in mosaic files (pre-existing workspace-build-order errors in `multi-cog-layer.ts` and `tests/{geotiff-tileset,render-pipeline}.test.ts` are unchanged).
- [ ] Smoke-test in `stac-map` against the use case in #510 (continuously appending STAC search results to a single `MosaicLayer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)