### PR TITLE
feat: Use `devicePixelRatio` for level of detail computation in tile traversal

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -1,0 +1,44 @@
+# dev-docs
+
+Internal developer documentation for `deck.gl-raster`. Primary
+audience: contributors and future maintainers, including future-you.
+
+## Layout
+
+**Top-level files** in this directory are *living* docs — they explain
+how the codebase works as it currently is, and are expected to be kept
+up to date alongside the code they describe. If you change a system a
+top-level doc covers, update the doc in the same change. Examples:
+[`zoom-terminology.md`](zoom-terminology.md),
+[`lod-and-pixel-matching.md`](lod-and-pixel-matching.md),
+[`gpu-modules.md`](gpu-modules.md),
+[`texture-alignment.md`](texture-alignment.md),
+[`boundless-tiles.md`](boundless-tiles.md).
+
+[`specs/`](specs/) contains *historical* design documents committed at
+the time a non-trivial change was being designed. They preserve the
+problem framing, goals, non-goals, and design decisions that shaped
+the implementation. Specs are **not** kept in sync with the code as it
+evolves — they're read as artifacts of the moment they were written.
+If a system changes substantially after its spec was written, capture
+the new state in a top-level living doc rather than rewriting the
+spec.
+
+[`ideas/`](ideas/) holds design proposals that have been considered
+but deferred. Read-only context until promoted into a spec.
+
+[`plans/`](plans/) is gitignored. Ephemeral, implementation-level
+task lists that translate a spec into executable steps.
+
+## When to write what
+
+- Changing how the code behaves and want others to understand it
+  later → top-level living doc.
+- Designing a non-trivial change before writing code → spec.
+- Capturing an idea you don't have time to act on → idea.
+- Breaking a spec down into bite-sized tasks for execution → plan.
+
+## See also
+
+- [`specs/README.md`](specs/README.md)
+- [`ideas/README.md`](ideas/README.md)

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -1,7 +1,6 @@
 # dev-docs
 
-Internal developer documentation for `deck.gl-raster`. Primary
-audience: contributors and future maintainers, including future-you.
+Internal developer documentation for `deck.gl-raster`.
 
 ## Layout
 

--- a/dev-docs/lod-and-pixel-matching.md
+++ b/dev-docs/lod-and-pixel-matching.md
@@ -136,11 +136,32 @@ device pixels (units cancel to `device-pixel / source-pixel`). When it
 is at most 1, a source pixel spans no more than a device pixel — the
 source is at least as fine as the display can resolve.
 
-The ratio is read from
-`this.context.device.canvasContext.cssToDeviceRatio()` inside the
-layer (which honors deck's `useDevicePixels` setting, including
-explicit numeric overrides) and threaded through `getTileIndices` into
-the traversal params.
+The ratio is computed inline in the layer as
+`drawingBufferWidth / cssWidth` (read off
+`this.context.device.getDefaultCanvasContext()` per traversal) and
+threaded through `getTileIndices` into the traversal params.
+
+This is the **drawing-buffer ratio**, not the system DPR
+(`window.devicePixelRatio` /
+`canvasContext.getDevicePixelRatio()`). The two are equal under
+`useDevicePixels: true` (deck.gl's default), and diverge when the
+user sets:
+
+- `useDevicePixels: false` → drawing buffer matches CSS, ratio = 1.
+- `useDevicePixels: <number>` → explicit override.
+- `setDrawingBufferSize()` called directly, or `maxDrawingBufferSize`
+  capping a 4K canvas → drawing buffer smaller than the screen's
+  physical pixels.
+
+We use the drawing-buffer ratio because it reflects what deck.gl is
+actually rendering to — which is the right thing for LOD to match.
+The luma.gl maintainers deprecated `cssToDeviceRatio()` (which
+historically returned this value) in part because the name conflated
+"drawing buffer" with "device pixel"; computing
+`drawingBufferWidth / cssWidth` explicitly avoids that ambiguity.
+The variable names elsewhere in our code (`pixelRatio`,
+`devicePixelsPerSourcePixel`) follow deck.gl's convention of using
+"device pixel" colloquially to mean "rendered framebuffer pixel."
 
 Behavior change: on a 2× display, ~4× more tiles fetched per view (one
 finer overview level, four times the tile count over the same area).

--- a/dev-docs/lod-and-pixel-matching.md
+++ b/dev-docs/lod-and-pixel-matching.md
@@ -1,0 +1,255 @@
+# LOD selection and pixel matching
+
+This doc explains how `deck.gl-raster` decides which tile pyramid level
+to fetch for any given view, and what the relationship is between a
+source raster's pixel size and a screen pixel. The logic is short but
+the assumptions baked into it are not obvious. This doc names them.
+
+For the difference between *viewport zoom* and *tile z-index*, see
+[zoom-terminology.md](zoom-terminology.md). The criterion described
+here uses both.
+
+## The two quantities
+
+The LOD criterion compares two ground-meters quantities, one from the
+data, one from the viewport.
+
+**`tileMetersPerPixel`** — how many ground meters one source pixel
+covers. Defined per `TilesetLevel`:
+
+- For OGC `TileMatrixSet` levels, computed from the matrix's
+  `scaleDenominator` and the OGC standard pixel size (0.28 mm) at
+  [tile-matrix-set.ts:34](../packages/deck.gl-raster/src/raster-tileset/tile-matrix-set.ts#L34).
+- For `AffineTilesetLevel` (geotiff overviews, geozarr multiscales),
+  computed from the affine transform's pixel scale times a
+  meters-per-CRS-unit factor at [affine-tileset-level.ts:59](../packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts#L59).
+
+It is a single value per level. It does not vary across the level's
+extent.
+
+**`metersPerScreenPixel`** — how many ground meters one *CSS* pixel of
+the framebuffer covers. Computed per tile from the viewport zoom and
+the tile's bounding-volume center latitude at
+[raster-tile-traversal.ts:764-770](../packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts#L764-L770):
+
+```
+metersPerScreenPixel = earthCircumference · cos(lat) / 2^(zoom + 8)
+```
+
+The `+8` reflects the OSM convention that viewport zoom 0 fits the
+world into a 256-pixel-wide tile (2^8). The `cos(lat)` is the standard
+Web Mercator latitude distortion: a CSS pixel near the pole covers
+fewer ground meters than one at the equator at the same viewport zoom.
+
+## The criterion
+
+The LOD test in
+[raster-tile-traversal.ts:286-302](../packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts#L286-L302):
+
+```ts
+if (tileMetersPerPixel <= metersPerScreenPixel || ...) {
+  this.selected = true;
+}
+```
+
+Read: *"source pixel ≤ screen pixel in ground meters"* — the source
+resolution is at least as fine as the screen resolution. The traversal
+walks the pyramid coarse-to-fine, so the first level satisfying this is
+the *coarsest* level that doesn't blur. That's the right choice: any
+finer would send more data than the screen can resolve.
+
+Compare to upstream's OSM traversal in
+`@deck.gl/geo-layers`'s `tileset-2d/tile-2d-traversal.ts`:
+
+```ts
+const distance = boundingVolume.distanceTo(viewport.cameraPosition)
+                 * viewport.scale / viewport.height;
+z += Math.floor(Math.log2(distance));
+```
+
+Same idea — adjust the selected level by how much the screen scales
+the tile — but expressed in OSM-zoom integer steps, valid only because
+OSM tile z and viewport zoom are equal by construction. The
+`metersPerPixel` form generalizes to arbitrary tiling grids and source
+CRSes.
+
+## Per-tile LOD already varies
+
+A common assumption is that a render selects a single z-level for all
+visible tiles. That is **not** what happens. The criterion is evaluated
+in the per-tile `update()` recursion, with `metersPerScreenPixel`
+computed at *that* tile's bounding-volume center. A tile at lat = 70°
+gets a smaller `metersPerScreenPixel` than one at lat = 0° at the same
+viewport zoom, so it can be satisfied at a coarser level. Visible sets
+typically span multiple levels, especially in views that cover a wide
+latitude band.
+
+Worth flagging because the question "should LOD vary by latitude?"
+naturally arises alongside
+[issue #89](https://github.com/developmentseed/deck.gl-raster/issues/89).
+On the *screen* side, it already does. Issue #89 is specifically
+about the *source* side — see "What the criterion does not account
+for" below.
+
+## What the criterion accounts for
+
+**Web Mercator data on a Web Mercator screen.** The `cos(lat)` factor
+appears in `metersPerScreenPixel` and is also implicit in any Mercator
+source's projection (tile-aligned grids in Mercator have uniform pixel
+size in *Mercator units* but cosine-shrunk in ground meters). Both
+sides shrink the same way at the same latitude, so the comparison is
+correct even though `tileMetersPerPixel` uses the equator-equivalent
+value from the OGC scale denominator. The distortion cancels.
+
+**Globe view.** Bounding volumes are constructed from sample points
+projected through the source-to-3857 path, capturing the sphere's
+geometry. Frustum culling rejects out-of-view tiles before the LOD
+test runs.
+
+**Mixed-CRS source data.** Reference points sampled from the tile in
+its native CRS, projected to EPSG:3857, then rescaled to common space.
+The bounding volume reflects the actual on-globe footprint.
+
+## What the criterion does not account for
+
+Four named gaps. Two are accepted limitations; one is addressed by
+the criterion change described below; one is a sketch of how a future
+redesign would collapse them.
+
+### (A) CSS vs device pixels — addressed by [#64](https://github.com/developmentseed/deck.gl-raster/issues/64)
+
+`metersPerScreenPixel` is in *CSS* pixels. With deck.gl's default
+`useDevicePixels: true`, the framebuffer has `devicePixelRatio` more
+pixels per CSS pixel, each covering `1/dpr` of those meters. The
+unfixed criterion under-resolves on HiDPI displays by `dpr`.
+
+The fix renames the comparison to a dimensionless ratio:
+
+```
+devicePixelsPerSourcePixel = tileMetersPerPixel * pixelRatio
+                             / metersPerCSSPixel
+select if devicePixelsPerSourcePixel <= 1
+```
+
+The value is the on-screen size of one source pixel measured in
+device pixels (units cancel to `device-pixel / source-pixel`). When it
+is at most 1, a source pixel spans no more than a device pixel — the
+source is at least as fine as the display can resolve.
+
+The ratio is read from
+`this.context.device.canvasContext.cssToDeviceRatio()` inside the
+layer (which honors deck's `useDevicePixels` setting, including
+explicit numeric overrides) and threaded through `getTileIndices` into
+the traversal params.
+
+Behavior change: on a 2× display, ~4× more tiles fetched per view (one
+finer overview level, four times the tile count over the same area).
+That is the correct behavior under the device-pixel framing — the
+display can resolve that detail.
+
+### (B) Camera distance and tilt — accepted limitation
+
+`getMetersPerPixel(lat, zoom)` is a top-down formula. Tilted views
+exhibit perspective foreshortening: distant tiles cover fewer screen
+pixels than near tiles at the same latitude, but our formula treats
+them identically. The result is over-fetching distant tiles in heavily
+tilted views.
+
+Upstream OSM avoids this with `boundingVolume.distanceTo(cameraPosition)`,
+which directly measures projected screen size in pixels. Folding this
+into our criterion would require either restructuring the formula
+around projected screen footprint (see (D)) or adding a
+distance-to-camera correction term. We accept the limitation; impact
+is mostly invisible for top-down imagery viewers.
+
+### (C) Source-side latitude variation — accepted limitation, [#89](https://github.com/developmentseed/deck.gl-raster/issues/89)
+
+`tileMetersPerPixel` is a single per-level value. For Web Mercator data
+this is correct (see the "what it accounts for" section). For
+*degree-based* CRSes — `WorldCRS84Quad` and similar — a degree of
+longitude shrinks with latitude, so a single source pixel covers fewer
+ground meters near the poles than at the equator. The constant
+overstates resolution at high latitudes.
+
+Source-pixel dimensions are also direction-dependent in degree CRSes:
+east-west spans `cellSize · 111000 · cos(lat)` meters; north-south
+spans `cellSize · 111000` meters. A truly correct criterion would
+either pick the larger (conservative) dimension or compute a
+geometric mean. We do neither; the criterion uses a single isotropic
+value.
+
+The fix would be a per-tile `metersPerPixel(tileCenter)` API on
+`TilesetLevel`, not a per-level constant. We accept the limitation
+because the affected use case — global degree-based source pyramids —
+is not currently a priority.
+
+### (D) A unifying alternative — possible future direction
+
+The two acknowledged gaps (B and C) both stem from comparing
+*ground-meters approximations* on each side. Both could be eliminated
+by computing the criterion directly in screen pixels. Sketch:
+
+```ts
+// Project the tile's common-space corners through the viewport's
+// viewProjectionMatrix and measure the on-screen footprint in CSS
+// pixels.
+const onScreen = projectTileToScreenAABB(tile, viewport);
+const devicePixelsPerSourcePixel = pixelRatio * Math.max(
+  onScreen.width  / tile.tileWidth,
+  onScreen.height / tile.tileHeight,
+);
+selected = devicePixelsPerSourcePixel <= 1;
+```
+
+`viewport.viewProjectionMatrix` already has perspective, latitude
+distortion, and source-to-screen projection baked in (it's the matrix
+the GPU uses). The on-screen footprint emerges from it directly.
+Subsumes:
+
+- (B) — perspective is in the matrix; distant tiles project to fewer
+  pixels.
+- (C) — corners are projected from each tile's actual common-space
+  position; whatever distortion the source uses is reflected in the
+  footprint without any per-CRS code path.
+- Globe view — same matrix, no special case needed.
+
+Costs: a few extra mat4×vec4 multiplications per tile during traversal
+(we already project corners for the bounding volume; reuse those
+points). One real risk: tiles crossing the camera plane in heavily
+tilted views can produce degenerate projections (`w ≤ 0`); needs
+explicit handling.
+
+We are not doing this now because the current criterion is correct in
+the common cases (Mercator data on a Mercator screen, top-down or
+moderately tilted) and (D) is a larger change than the audit pressure
+warrants. The right time to revisit is when (a) tilt becomes important
+to a user, or (b) degree-based or other non-Mercator source pyramids
+become a supported scenario.
+
+## Glossary
+
+- **`tileMetersPerPixel`** — ground meters per source pixel for a
+  given `TilesetLevel`. Per-level constant.
+- **`metersPerScreenPixel`** / **`metersPerCSSPixel`** — ground meters
+  per CSS pixel at the current viewport zoom and a given latitude.
+- **`pixelRatio`** / **`cssToDeviceRatio`** — device pixels per CSS
+  pixel; deck.gl's effective rendering ratio. Read from
+  `device.canvasContext.cssToDeviceRatio()`.
+- **`devicePixelsPerSourcePixel`** — the LOD criterion variable.
+  On-screen size of one source pixel, measured in device pixels.
+  Less than or equal to 1 means the source can fully resolve the
+  rendered framebuffer.
+- **`viewport.zoom`** — continuous zoom value on the active viewport.
+  See [zoom-terminology.md](zoom-terminology.md).
+- **`tile.z`** — tile pyramid level index (0 = coarsest in our
+  descriptors). See [zoom-terminology.md](zoom-terminology.md).
+
+## See also
+
+- [zoom-terminology.md](zoom-terminology.md) — viewport zoom vs. tile
+  z-index
+- [raster-tile-traversal.ts](../packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts) — the LOD logic implementation
+- Upstream `@deck.gl/geo-layers` `tile-2d-traversal.ts` for comparison
+- Issues
+  [#64](https://github.com/developmentseed/deck.gl-raster/issues/64),
+  [#89](https://github.com/developmentseed/deck.gl-raster/issues/89)

--- a/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+++ b/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
@@ -272,9 +272,28 @@ export class RasterTileLayer<
     getTileData: NonNullable<RasterTileLayerProps<DataT>["getTileData"]>,
     renderTile: NonNullable<RasterTileLayerProps<DataT>["renderTile"]>,
   ): TileLayer {
+    // Capture the device once so the inner `TilesetFactory` can read
+    // its current effective device-pixel ratio per `getTileIndices`
+    // call. The ratio is sampled lazily so window-drag-between-displays
+    // (or runtime changes to `useDevicePixels`) take effect on the next
+    // traversal. See dev-docs/lod-and-pixel-matching.md § (A).
+    //
+    // We compute drawingBuffer/CSS rather than using
+    // `cssToDeviceRatio()` (deprecated) or the `devicePixelRatio`
+    // property (always reflects the system value, ignoring
+    // `Deck.useDevicePixels`). The drawing-buffer ratio is the
+    // *effective* DPR Deck is rendering at.
+    const device = this.context.device;
     class TilesetFactory extends RasterTileset2D {
       constructor(opts: Tileset2DProps) {
-        super(opts, descriptor);
+        super(opts, descriptor, {
+          getPixelRatio: () => {
+            const ctx = device.getDefaultCanvasContext();
+            const [drawingBufferWidth] = ctx.getDrawingBufferSize();
+            const [cssWidth] = ctx.getCSSSize();
+            return cssWidth ? drawingBufferWidth / cssWidth : 1;
+          },
+        });
       }
     }
 

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
@@ -243,6 +243,13 @@ export class RasterTileNode {
     maxZ?: number;
     /** Optional geographic bounds filter */
     bounds?: Bounds;
+    /**
+     * Device pixels per CSS pixel. The LOD test selects a tile when its
+     * source pixels are at most one *device* pixel wide; on HiDPI displays
+     * (`pixelRatio > 1`) this picks a finer overview than the CSS-pixel
+     * comparison would. See `dev-docs/lod-and-pixel-matching.md` § (A).
+     */
+    pixelRatio: number;
   }): boolean {
     // Reset state
     this.childVisible = false;
@@ -256,6 +263,7 @@ export class RasterTileNode {
       maxZ = this.descriptor.levels.length - 1,
       project,
       bounds,
+      pixelRatio,
     } = params;
 
     // Get bounding volume for this tile
@@ -284,19 +292,24 @@ export class RasterTileNode {
     // Only select this tile if no child is visible (prevents overlapping tiles)
     // "When pitch is low, force selection at maxZ."
     if (!this.childVisible && this.z >= minZ) {
-      const metersPerScreenPixel = getMetersPerPixelAtBoundingVolume(
+      const metersPerCSSPixel = getMetersPerPixelAtBoundingVolume(
         boundingVolume,
         viewport.zoom,
       );
 
       const tileMetersPerPixel = this.level.metersPerPixel;
 
+      // On-screen size of one source pixel, measured in device pixels.
+      // ≤ 1 means the source can fully resolve the rendered framebuffer.
+      // See dev-docs/lod-and-pixel-matching.md.
+      const devicePixelsPerSourcePixel =
+        (tileMetersPerPixel * pixelRatio) / metersPerCSSPixel;
+
       if (
-        tileMetersPerPixel <= metersPerScreenPixel ||
+        devicePixelsPerSourcePixel <= 1 ||
         this.z >= maxZ ||
         (children === null && this.z >= minZ)
       ) {
-        // "Select this tile when its scale is at least as detailed as the screen."
         this.selected = true;
         return true;
       }
@@ -664,9 +677,16 @@ export function getTileIndices(
     maxZ: number;
     zRange: ZRange | null;
     wgs84Bounds: Bounds;
+    /**
+     * Device pixels per CSS pixel for the LOD criterion. Defaults to 1
+     * (CSS-pixel-accurate selection). Pass deck.gl's
+     * `device.canvasContext.cssToDeviceRatio()` for device-pixel accuracy
+     * on HiDPI displays. See `dev-docs/lod-and-pixel-matching.md` § (A).
+     */
+    pixelRatio?: number;
   },
 ): TileIndex[] {
-  const { viewport, maxZ, zRange, wgs84Bounds } = opts;
+  const { viewport, maxZ, zRange, wgs84Bounds, pixelRatio = 1 } = opts;
 
   // Only define `project` function for Globe viewports, same as upstream
   const project: ((xyz: number[]) => number[]) | null =
@@ -737,6 +757,7 @@ export function getTileIndices(
     minZ,
     maxZ,
     bounds,
+    pixelRatio,
   };
 
   for (const root of roots) {

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
@@ -57,28 +57,31 @@ export type TileMetadata = {
 };
 
 /**
+ * Configuration for a {@link RasterTileset2D}.
+ */
+export interface RasterTileset2DOptions {
+  /**
+   * Returns the current drawing-buffer-pixel/CSS-pixel ratio.
+   *
+   * Read at every `getTileIndices` call so that runtime changes (e.g. dragging
+   * the window between displays of different DPR, or toggling
+   * `Deck.useDevicePixels`) take effect on the next tile evaluation.
+   *
+   * Defaults to a constant `1` if omitted, which makes LOD selection
+   * CSS-pixel-accurate but blurry on HiDPI displays. The `RasterTileLayer`
+   * wires this to `drawingBufferWidth / cssWidth` read from the layer's
+   * canvas context per call. See `dev-docs/lod-and-pixel-matching.md` § (A).
+   */
+  getPixelRatio?: () => number;
+}
+
+/**
  * A generic tileset implementation organized according to the OGC
  * [TileMatrixSet](https://docs.ogc.org/is/17-083r4/17-083r4.html)
  * specification.
  *
  * Handles tile lifecycle, caching, and viewport-based loading.
  */
-/**
- * Optional configuration for a {@link RasterTileset2D}.
- */
-export interface RasterTileset2DOptions {
-  /**
-   * Returns the current device-pixels-per-CSS-pixel ratio. Read at every
-   * `getTileIndices` call so that runtime changes (e.g. dragging the
-   * window between displays of different DPR) take effect on the next
-   * tile evaluation. Defaults to a constant `1` if omitted, which makes
-   * LOD selection CSS-pixel-accurate but blurry on HiDPI displays. The
-   * `RasterTileLayer` wires this to `device.canvasContext.cssToDeviceRatio()`.
-   * See `dev-docs/lod-and-pixel-matching.md` § (A).
-   */
-  getPixelRatio?: () => number;
-}
-
 export class RasterTileset2D extends Tileset2D {
   private descriptor: TilesetDescriptor;
   private wgs84Bounds: Bounds;

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
@@ -63,13 +63,35 @@ export type TileMetadata = {
  *
  * Handles tile lifecycle, caching, and viewport-based loading.
  */
+/**
+ * Optional configuration for a {@link RasterTileset2D}.
+ */
+export interface RasterTileset2DOptions {
+  /**
+   * Returns the current device-pixels-per-CSS-pixel ratio. Read at every
+   * `getTileIndices` call so that runtime changes (e.g. dragging the
+   * window between displays of different DPR) take effect on the next
+   * tile evaluation. Defaults to a constant `1` if omitted, which makes
+   * LOD selection CSS-pixel-accurate but blurry on HiDPI displays. The
+   * `RasterTileLayer` wires this to `device.canvasContext.cssToDeviceRatio()`.
+   * See `dev-docs/lod-and-pixel-matching.md` § (A).
+   */
+  getPixelRatio?: () => number;
+}
+
 export class RasterTileset2D extends Tileset2D {
   private descriptor: TilesetDescriptor;
   private wgs84Bounds: Bounds;
+  private getPixelRatio: () => number;
 
-  constructor(opts: Tileset2DProps, descriptor: TilesetDescriptor) {
+  constructor(
+    opts: Tileset2DProps,
+    descriptor: TilesetDescriptor,
+    { getPixelRatio }: RasterTileset2DOptions = {},
+  ) {
     super(opts);
     this.descriptor = descriptor;
+    this.getPixelRatio = getPixelRatio ?? (() => 1);
 
     const rawBounds = transformBounds(
       this.descriptor.projectTo4326,
@@ -131,6 +153,7 @@ export class RasterTileset2D extends Tileset2D {
       maxZ,
       zRange: opts.zRange ?? null,
       wgs84Bounds: this.wgs84Bounds,
+      pixelRatio: this.getPixelRatio(),
     });
 
     return tileIndices;

--- a/packages/deck.gl-raster/tests/raster-tileset/lod-pixel-ratio.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/lod-pixel-ratio.test.ts
@@ -1,0 +1,96 @@
+import { WebMercatorViewport } from "@deck.gl/core";
+import type { _Tileset2DProps as Tileset2DProps } from "@deck.gl/geo-layers";
+import { describe, expect, it } from "vitest";
+import { RasterTileset2D } from "../../src/raster-tileset/raster-tileset-2d.js";
+import type {
+  TilesetDescriptor,
+  TilesetLevel,
+} from "../../src/raster-tileset/tileset-interface.js";
+import type { Corners } from "../../src/raster-tileset/types.js";
+
+// Identity projection — source CRS is treated as EPSG:4326 == EPSG:3857
+// for the limited geometric range the test covers.
+const identity = (x: number, y: number): [number, number] => [x, y];
+
+/**
+ * Single-tile level covering [-1, -1, 1, 1] in source CRS, with caller-
+ * specified `metersPerPixel`.
+ */
+function makeLevel(metersPerPixel: number): TilesetLevel {
+  const corners: Corners = {
+    topLeft: [-1, 1],
+    topRight: [1, 1],
+    bottomLeft: [-1, -1],
+    bottomRight: [1, -1],
+  };
+  return {
+    matrixWidth: 1,
+    matrixHeight: 1,
+    tileWidth: 256,
+    tileHeight: 256,
+    metersPerPixel,
+    projectedTileCorners: () => corners,
+    tileTransform: () => {
+      throw new Error("not used in this test");
+    },
+    crsBoundsToTileRange: () => ({
+      minCol: 0,
+      maxCol: 0,
+      minRow: 0,
+      maxRow: 0,
+    }),
+  };
+}
+
+function makeDescriptor(metersPerPixelByLevel: number[]): TilesetDescriptor {
+  return {
+    levels: metersPerPixelByLevel.map(makeLevel),
+    projectTo3857: identity,
+    projectTo4326: identity,
+    projectFrom3857: identity,
+    projectFrom4326: identity,
+    projectedBounds: [-1, -1, 1, 1],
+  };
+}
+
+function makeViewport(): WebMercatorViewport {
+  // zoom=18, lat=0 → metersPerScreenPixel ≈ 0.597 m
+  return new WebMercatorViewport({
+    longitude: 0,
+    latitude: 0,
+    zoom: 18,
+    width: 100,
+    height: 100,
+  });
+}
+
+describe("LOD selection: pixelRatio threading", () => {
+  // Levels chosen so metersPerScreenPixel ≈ 0.597 lands between z=1 and z=2:
+  //   z=0 mpp = 1.0   (always too coarse for this view)
+  //   z=1 mpp = 0.4   (sufficient at dpr=1; insufficient at dpr=2 since 0.4*2 > 0.597)
+  //   z=2 mpp = 0.1   (always sufficient)
+  const descriptor = makeDescriptor([1.0, 0.4, 0.1]);
+
+  function getSelectedZ(pixelRatio: number): number[] {
+    const tileset = new RasterTileset2D(
+      {
+        getTileData: () => new Promise(() => {}),
+      } as Tileset2DProps,
+      descriptor,
+      { getPixelRatio: () => pixelRatio },
+    );
+    const indices = tileset.getTileIndices({
+      viewport: makeViewport(),
+      zRange: null,
+    });
+    return indices.map((idx) => idx.z);
+  }
+
+  it("selects intermediate level z=1 at pixelRatio=1", () => {
+    expect(getSelectedZ(1)).toEqual([1]);
+  });
+
+  it("selects finer level z=2 at pixelRatio=2 (HiDPI display)", () => {
+    expect(getSelectedZ(2)).toEqual([2]);
+  });
+});


### PR DESCRIPTION
Closes #64

## Summary

- Tile LOD now matches source pixels to *device* pixels rather than CSS pixels, honoring `Deck.useDevicePixels`. 
    - This is cleaner than making a new prop just for the raster layers. If you want a custom LOD change, you can change it in `useDevicePixels` that you pass to `Deck`
- Refactors the LOD comparison from `tileMetersPerPixel <= metersPerScreenPixel` to a dimensionless `devicePixelsPerSourcePixel <= 1`. The pixel ratio is threaded through `getTileIndices` → `RasterTileNode.update()` and read lazily from the layer's drawing buffer (`drawingBufferWidth / cssWidth`) so window-drag-between-displays takes effect on the next traversal.
- Adds `dev-docs/lod-and-pixel-matching.md` documenting the LOD criterion, why per-tile LOD already varies by latitude, and three named gaps that remain (camera distance/tilt, source-side latitude variation #89, and a sketch of a unified `viewport.project`-based criterion).
- Adds `dev-docs/README.md` clarifying the four-folder layout (top-level living docs, `specs/`, `ideas/`, `plans/`).

**Behavior change:** on a 2× display, ~4× more tiles fetched per view (one finer overview level over the same area). Correct under the device-pixel framing — the display can resolve that detail.