### PR TITLE
fix!: Default to linear sampling for non-paletted COGs

### DIFF
--- a/examples/cog-basic/src/App.tsx
+++ b/examples/cog-basic/src/App.tsx
@@ -42,6 +42,10 @@ const COG_OPTIONS: { title: string; url: string; attribution?: ReactNode }[] = [
       </>
     ),
   },
+  {
+    title: "Swisstopo National Map 1:1 million",
+    url: "https://data.geo.admin.ch/ch.swisstopo.pixelkarte-farbe-pk1000.noscale/swiss-map-raster1000_1000/swiss-map-raster1000_1000_krel_50_2056.tif",
+  },
   // {
   //   title: "Fields of the World — Denmark S2",
   //   url: "https://data.source.coop/kerner-lab/fields-of-the-world/denmark/s2_images/window_a/g22_00002_10.tif",

--- a/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
+++ b/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts
@@ -133,7 +133,8 @@ function createUnormPipeline(
     renderPipeline.push(toRGBModule);
   }
 
-  // For palette images, use nearest-neighbor sampling
+  // For palette images, use nearest-neighbor sampling, because indices into a
+  // colormap can't be interpolated
   const samplerOptions: SamplerProps =
     photometric === Photometric.Palette
       ? {
@@ -182,11 +183,7 @@ function createUnormPipeline(
       format: textureFormat,
       width,
       height,
-      // Use nearest filtering for the mask to avoid interpolated edges/halos
-      sampler: {
-        minFilter: "nearest",
-        magFilter: "nearest",
-      },
+      sampler: samplerOptions,
     });
 
     let maskTexture: Texture | undefined;
@@ -197,7 +194,11 @@ function createUnormPipeline(
         format: "r8unorm",
         width,
         height,
-        sampler: samplerOptions,
+        // Use nearest filtering for the mask to avoid interpolated edges/halos
+        sampler: {
+          minFilter: "nearest",
+          magFilter: "nearest",
+        },
       });
       byteLength += mask.byteLength;
     }


### PR DESCRIPTION
Closes https://github.com/developmentseed/deck.gl-raster/issues/505

I think the existing code was a mistake. I think 
https://github.com/developmentseed/deck.gl-raster/blob/8adf3e9063d5d14fd1a3bac89a65ea7cdb599b83/packages/deck.gl-geotiff/src/geotiff/render-pipeline.ts#L185-L189
was always intended to be applied to the _mask_ texture, but was being applied to the data texture instead