### PR TITLE
feat(geotiff): thread AbortSignal through GeoTIFF open/fromUrl

### DIFF
--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -445,6 +445,9 @@ export default function App() {
           signal,
         });
       },
+      // Smaller cache for MosaicLayer cache, since it caches full COGLayer
+      // instances
+      maxCacheSize: 5,
       // @ts-expect-error beforeId is injected by @deck.gl/mapbox; LayerProps
       // doesn't know about it.
       beforeId: "boundary_country_outline",

--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -68,6 +68,36 @@ type TextureDataT = {
   texture: Texture;
 };
 
+/**
+ * Module-level cache of opened GeoTIFFs keyed by URL.
+ *
+ * Header reads are small and the resulting GeoTIFF instance can be reused
+ * across the example's lifetime. Holding this outside the MosaicLayer's
+ * TileLayer cache lets us drop `maxCacheSize: Infinity` (which was previously
+ * needed to keep header data, but had the side-effect of pinning every parent
+ * tile — and its inner COGLayer's in-flight requests — in memory forever).
+ *
+ * The signal from the parent tile is intentionally ignored here: we want the
+ * header read to complete and stay cached even if the tile that triggered it
+ * is no longer on screen, since other tiles or a later pan-back will reuse it.
+ * Cancellation that matters (per-tile data reads) still flows through the
+ * COGLayer's signal prop.
+ */
+const geotiffCache = new Map<string, Promise<GeoTIFF>>();
+
+function getCachedGeoTIFF(url: string): Promise<GeoTIFF> {
+  let promise = geotiffCache.get(url);
+  if (!promise) {
+    promise = GeoTIFF.fromUrl(url).catch((err) => {
+      // Don't poison the cache on transient failures.
+      geotiffCache.delete(url);
+      throw err;
+    });
+    geotiffCache.set(url, promise);
+  }
+  return promise;
+}
+
 /** Custom tile loader that creates a GPU texture from the GeoTIFF image data. */
 async function getTileData(
   image: GeoTIFF | Overview,
@@ -376,14 +406,12 @@ export default function App() {
     const mosaicLayer = new MosaicLayer<PartialSTACItem, GeoTIFF>({
       id: "naip-mosaic-layer",
       sources: stacItems,
-      // For each source, fetch the GeoTIFF instance
-      // Doing this in getSource allows us to cache the results using TileLayer
-      // mechanisms.
-      getSource: async (source, { signal }) => {
-        const url = source.assets.image.href;
-        const tiff = await GeoTIFF.fromUrl(url, { signal });
-        return tiff;
-      },
+      // For each source, fetch the GeoTIFF instance from a module-level cache
+      // (see `geotiffCache` above). The cache is intentionally separate from
+      // the MosaicLayer's TileLayer cache so we can keep cheap header metadata
+      // around indefinitely without pinning every parent tile (and its inner
+      // COGLayer's in-flight tile requests) in memory.
+      getSource: async (source) => getCachedGeoTIFF(source.assets.image.href),
       renderSource: (source, { data, signal }) => {
         const url = source.assets.image.href;
         return new COGLayer<TextureDataT>({
@@ -406,10 +434,6 @@ export default function App() {
           signal,
         });
       },
-      // We have a max of 1000 STAC items fetched from the Microsoft STAC API;
-      // this isn't so large that we can't just cache all the GeoTIFF header
-      // metadata instances
-      maxCacheSize: Infinity,
       // @ts-expect-error beforeId is injected by @deck.gl/mapbox; LayerProps
       // doesn't know about it.
       beforeId: "boundary_country_outline",

--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -77,19 +77,17 @@ type TextureDataT = {
  * needed to keep header data, but had the side-effect of pinning every parent
  * tile — and its inner COGLayer's in-flight requests — in memory forever).
  *
- * The signal from the parent tile is intentionally ignored here: we want the
- * header read to complete and stay cached even if the tile that triggered it
- * is no longer on screen, since other tiles or a later pan-back will reuse it.
- * Cancellation that matters (per-tile data reads) still flows through the
- * COGLayer's signal prop.
+ * The caller's signal is forwarded into `GeoTIFF.fromUrl` so an in-flight
+ * header read can be aborted when the parent tile leaves view. On any
+ * rejection (including `AbortError`) the entry is evicted, so a later visit
+ * to the same source restarts the fetch rather than reusing a failed promise.
  */
 const geotiffCache = new Map<string, Promise<GeoTIFF>>();
 
-function getCachedGeoTIFF(url: string): Promise<GeoTIFF> {
+function getCachedGeoTIFF(url: string, signal?: AbortSignal): Promise<GeoTIFF> {
   let promise = geotiffCache.get(url);
   if (!promise) {
-    promise = GeoTIFF.fromUrl(url).catch((err) => {
-      // Don't poison the cache on transient failures.
+    promise = GeoTIFF.fromUrl(url, { signal }).catch((err) => {
       geotiffCache.delete(url);
       throw err;
     });
@@ -411,7 +409,8 @@ export default function App() {
       // the MosaicLayer's TileLayer cache so we can keep cheap header metadata
       // around indefinitely without pinning every parent tile (and its inner
       // COGLayer's in-flight tile requests) in memory.
-      getSource: async (source) => getCachedGeoTIFF(source.assets.image.href),
+      getSource: async (source, { signal }) =>
+        getCachedGeoTIFF(source.assets.image.href, signal),
       renderSource: (source, { data, signal }) => {
         const url = source.assets.image.href;
         return new COGLayer<TextureDataT>({

--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -77,10 +77,22 @@ type TextureDataT = {
  * needed to keep header data, but had the side-effect of pinning every parent
  * tile — and its inner COGLayer's in-flight requests — in memory forever).
  *
+ * We cache the `Promise<GeoTIFF>` rather than the resolved `GeoTIFF` so that
+ * concurrent callers for the same URL share one in-flight fetch instead of
+ * each kicking off a duplicate request before any of them sets the cache.
+ *
  * The caller's signal is forwarded into `GeoTIFF.fromUrl` so an in-flight
  * header read can be aborted when the parent tile leaves view. On any
  * rejection (including `AbortError`) the entry is evicted, so a later visit
  * to the same source restarts the fetch rather than reusing a failed promise.
+ *
+ * Caveat: this assumes at most one interested caller per URL at a time. If a
+ * second caller joined an in-flight fetch and the first caller aborted, the
+ * second would see an `AbortError` even though it never wanted to abort. In
+ * this example each STAC item maps to a unique parent tile so the assumption
+ * holds; promoting this pattern into library code would want refcounted
+ * cancellation (one underlying `AbortController`, abort only when all callers
+ * have signalled).
  */
 const geotiffCache = new Map<string, Promise<GeoTIFF>>();
 

--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -379,11 +379,9 @@ export default function App() {
       // For each source, fetch the GeoTIFF instance
       // Doing this in getSource allows us to cache the results using TileLayer
       // mechanisms.
-      getSource: async (source, { signal: _ }) => {
+      getSource: async (source, { signal }) => {
         const url = source.assets.image.href;
-        // TODO: restore passing down signal
-        // https://github.com/developmentseed/deck.gl-raster/issues/292
-        const tiff = await GeoTIFF.fromUrl(url);
+        const tiff = await GeoTIFF.fromUrl(url, { signal });
         return tiff;
       },
       renderSource: (source, { data, signal }) => {

--- a/packages/geotiff/src/geotiff.ts
+++ b/packages/geotiff/src/geotiff.ts
@@ -98,17 +98,20 @@ export class GeoTIFF {
    * @param options.dataSource A source for fetching tile data. This is separate from the source used to construct the TIFF to allow for separate caching implementations.
    * @param options.headerSource The source used to construct the TIFF. This is typically a layered source with caching and chunking, to optimise access to TIFF tags and IFDs.
    * @param options.prefetch Number of bytes to prefetch when reading TIFF tags and IFDs. Defaults to 32KB, which is enough for most tags and small IFDs. Increase if you have many tags or large IFDs.
+   * @param options.signal An optional {@link AbortSignal} to cancel the header reads.
    */
   static async open(options: {
     dataSource: Pick<Source, "fetch">;
     headerSource: Source;
     prefetch?: number;
+    signal?: AbortSignal;
   }): Promise<GeoTIFF> {
-    const { dataSource, headerSource, prefetch = 32 * 1024 } = options;
+    const { dataSource, headerSource, prefetch = 32 * 1024, signal } = options;
     const tiff = await Tiff.create(headerSource, {
       defaultReadSize: prefetch,
+      signal,
     });
-    return GeoTIFF.fromTiff(tiff, dataSource);
+    return GeoTIFF.fromTiff(tiff, dataSource, { signal });
   }
 
   /**
@@ -118,11 +121,14 @@ export class GeoTIFF {
    * (width, height).  Overviews are sorted from finest to coarsest resolution.
    *
    * @param dataSource A source for fetching tile data. This is separate from the source used to construct the TIFF to allow for separate caching implementations.
+   * @param options.signal An optional {@link AbortSignal} to cancel header tag reads.
    */
   static async fromTiff(
     tiff: Tiff,
     dataSource: Pick<Source, "fetch">,
+    options: { signal?: AbortSignal } = {},
   ): Promise<GeoTIFF> {
+    const { signal } = options;
     const images = tiff.images;
     if (images.length === 0) {
       throw new Error("TIFF does not contain any IFDs");
@@ -130,7 +136,7 @@ export class GeoTIFF {
 
     // Force loading of important tags in sub-images
     // https://github.com/blacha/cogeotiff/blob/4781a6375adf419da9f0319d15c8a67284dfb0c4/packages/core/src/tiff.image.ts#L72-L88
-    await Promise.all(images.map((image) => image.init(true)));
+    await Promise.all(images.map((image) => image.init(true, { signal })));
 
     const primaryImage = images[0]!;
     const gkd = extractGeoKeyDirectory(primaryImage);
@@ -165,7 +171,7 @@ export class GeoTIFF {
       return sb.width * sb.height - sa.width * sa.height;
     });
 
-    const cachedTags = await prefetchTags(primaryImage);
+    const cachedTags = await prefetchTags(primaryImage, { signal });
     const gdalMetadata = parseGDALMetadata(cachedTags.gdalMetadata, {
       count: cachedTags.samplesPerPixel,
     });
@@ -228,6 +234,7 @@ export class GeoTIFF {
    * @param options.chunkSize The minimum size for each request made to the source while reading header metadata. Defaults to 32KB.
    * @param options.cacheSize The size of the cache for recently accessed header chunks. Currently no caching is applied to data fetches. Defaults to 1MB.
    * @param options.prefetch Number of bytes to prefetch when reading TIFF tags and IFDs. Defaults to 32KB, which is enough for most tags and small IFDs. Increase if you have many tags or large IFDs.
+   * @param options.signal An optional {@link AbortSignal} to cancel the header reads.
    * @returns A Promise that resolves to a GeoTIFF instance.
    */
   static async fromUrl(
@@ -236,7 +243,13 @@ export class GeoTIFF {
       chunkSize = 1024 * 1024,
       cacheSize = 10 * 1024 * 1024,
       prefetch = 32 * 1024,
-    }: { chunkSize?: number; cacheSize?: number; prefetch?: number } = {},
+      signal,
+    }: {
+      chunkSize?: number;
+      cacheSize?: number;
+      prefetch?: number;
+      signal?: AbortSignal;
+    } = {},
   ): Promise<GeoTIFF> {
     const source = new SourceHttp(url, {});
 
@@ -258,6 +271,7 @@ export class GeoTIFF {
       dataSource: source,
       headerSource: view,
       prefetch,
+      signal,
     });
   }
 

--- a/packages/geotiff/src/ifd.ts
+++ b/packages/geotiff/src/ifd.ts
@@ -23,7 +23,11 @@ export interface CachedTags {
 }
 
 /** Pre-fetch TIFF tags for easier visualization. */
-export async function prefetchTags(image: TiffImage): Promise<CachedTags> {
+export async function prefetchTags(
+  image: TiffImage,
+  options: { signal?: AbortSignal } = {},
+): Promise<CachedTags> {
+  const { signal } = options;
   // Compression is pre-fetched in init
   const compression = image.value(TiffTag.Compression);
   if (compression === null) {
@@ -47,24 +51,24 @@ export async function prefetchTags(image: TiffImage): Promise<CachedTags> {
     tileByteCounts,
     tileOffsets,
   ] = await Promise.all([
-    image.fetch(TiffTag.BitsPerSample),
-    image.fetch(TiffTag.ColorMap),
-    image.fetch(TiffTag.GdalNoData),
-    image.fetch(TiffTag.GdalMetadata),
-    image.fetch(TiffTag.LercParameters),
-    image.fetch(TiffTag.ModelPixelScale),
-    image.fetch(TiffTag.ModelTiePoint),
-    image.fetch(TiffTag.ModelTransformation),
-    image.fetch(TiffTag.Photometric),
-    image.fetch(TiffTag.PlanarConfiguration),
-    image.fetch(TiffTag.Predictor),
-    image.fetch(TiffTag.SampleFormat),
-    image.fetch(TiffTag.SamplesPerPixel),
+    image.fetch(TiffTag.BitsPerSample, { signal }),
+    image.fetch(TiffTag.ColorMap, { signal }),
+    image.fetch(TiffTag.GdalNoData, { signal }),
+    image.fetch(TiffTag.GdalMetadata, { signal }),
+    image.fetch(TiffTag.LercParameters, { signal }),
+    image.fetch(TiffTag.ModelPixelScale, { signal }),
+    image.fetch(TiffTag.ModelTiePoint, { signal }),
+    image.fetch(TiffTag.ModelTransformation, { signal }),
+    image.fetch(TiffTag.Photometric, { signal }),
+    image.fetch(TiffTag.PlanarConfiguration, { signal }),
+    image.fetch(TiffTag.Predictor, { signal }),
+    image.fetch(TiffTag.SampleFormat, { signal }),
+    image.fetch(TiffTag.SamplesPerPixel, { signal }),
     // Pre-fetch tile offsets and byte counts. If we don't prefetch them,
     // TiffImage.getTileSize will have to fetch them for each tile, which
     // results in many redundant requests.
-    image.fetch(TiffTag.TileByteCounts),
-    image.fetch(TiffTag.TileOffsets),
+    image.fetch(TiffTag.TileByteCounts, { signal }),
+    image.fetch(TiffTag.TileOffsets, { signal }),
   ]);
 
   const missingTag: (tagName: string) => never = (tagName: string) => {


### PR DESCRIPTION
## Summary
- Add optional `signal: AbortSignal` to `GeoTIFF.open`, `GeoTIFF.fromTiff`, `GeoTIFF.fromUrl`, and `prefetchTags`, threading through to `Tiff.create`, `TiffImage.init`, and `TiffImage.fetch` (all already supported by `@cogeotiff/core` v9.5.0).
- Restore signal usage in the naip-mosaic example's `getSource`; the example previously discarded it as `signal: _` with a TODO referencing #292.

Closes #292.

## Test plan
- [x] `pnpm --filter @developmentseed/geotiff typecheck`
- [x] `pnpm --filter @developmentseed/geotiff build`
- [x] `pnpm --filter naip-mosaic-example typecheck`
- [x] `pnpm check:fix` clean
- [ ] Run the naip-mosaic example, pan/zoom rapidly, and confirm in-flight COG header requests get aborted (no orphaned requests in network panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)