### PR TITLE
fix(examples): correct NDVI range filter in naip-mosaic

### DIFF
--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -11,6 +11,7 @@ import {
   CreateTexture,
   createColormapTexture,
   decodeColormapSprite,
+  LinearRescale,
 } from "@developmentseed/deck.gl-raster/gpu-modules";
 import colormapsPngUrl from "@developmentseed/deck.gl-raster/gpu-modules/colormaps.png";
 import type { Overview } from "@developmentseed/geotiff";
@@ -170,7 +171,14 @@ const setFalseColorInfrared = {
   },
 } as const satisfies ShaderModule;
 
-/** Shader module that calculates NDVI. */
+/**
+ * Shader module that computes NDVI into `color.r`.
+ *
+ * The result is the raw NDVI value in `[-1, 1]`, so the downstream
+ * {@link ndviFilter} can compare it directly against the user-facing range
+ * (also `[-1, 1]`). A {@link LinearRescale} step later in the pipeline maps it
+ * to `[0, 1]` for the {@link Colormap} texture lookup.
+ */
 const ndvi = {
   name: "ndvi",
   inject: {
@@ -178,9 +186,7 @@ const ndvi = {
     "fs:DECKGL_FILTER_COLOR": /* glsl */ `
       float nir = color[3];
       float red = color[0];
-      float ndvi = (nir - red) / (nir + red);
-      // normalize to 0-1 range
-      color.r = (ndvi + 1.0) / 2.0;
+      color.r = (nir - red) / (nir + red);
     `,
   },
 };
@@ -217,8 +223,8 @@ const ndviFilter = {
   },
   getUniforms: (props) => {
     return {
-      ndviMin: props.ndviMin || -1.0,
-      ndviMax: props.ndviMax || 1.0,
+      ndviMin: props.ndviMin ?? -1.0,
+      ndviMax: props.ndviMax ?? 1.0,
     };
   },
 } as const satisfies ShaderModule<{ ndviMin: number; ndviMax: number }>;
@@ -289,6 +295,8 @@ function renderNDVI(
       module: ndviFilter,
       props: { ndviMin: ndviRange[0], ndviMax: ndviRange[1] },
     },
+    // NDVI is computed in [-1, 1]; remap to [0, 1] for the colormap lookup.
+    { module: LinearRescale, props: { rescaleMin: -1, rescaleMax: 1 } },
     {
       module: Colormap,
       props: {

--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -179,8 +179,8 @@ const setFalseColorInfrared = {
  * (also `[-1, 1]`). A {@link LinearRescale} step later in the pipeline maps it
  * to `[0, 1]` for the {@link Colormap} texture lookup.
  */
-const ndvi = {
-  name: "ndvi",
+const normalizedDifference = {
+  name: "normalizedDifference",
   inject: {
     // Colors in the original image are ordered as: R, G, B, NIR
     "fs:DECKGL_FILTER_COLOR": /* glsl */ `
@@ -290,12 +290,15 @@ function renderNDVI(
   const { texture } = tileData;
   const renderPipeline: RasterModule[] = [
     { module: CreateTexture, props: { textureName: texture } },
-    { module: ndvi },
+    // Call normalized difference, creating a range of [-1, 1] in the red
+    // channel
+    { module: normalizedDifference },
+    // Filter pixels based on range of [-1, 1]
     {
       module: ndviFilter,
       props: { ndviMin: ndviRange[0], ndviMax: ndviRange[1] },
     },
-    // NDVI is computed in [-1, 1]; remap to [0, 1] for the colormap lookup.
+    // Rescale channel from [-1, 1] to [0, 1] for the colormap lookup
     { module: LinearRescale, props: { rescaleMin: -1, rescaleMax: 1 } },
     {
       module: Colormap,


### PR DESCRIPTION
### Before:

See how the filter and colormap isn't lining up with what's displayed? The colormap implies that no blue pixels should be rendered, but a bunch of blue pixels are still being rendered...
<img width="945" height="589" alt="image" src="https://github.com/user-attachments/assets/e534b7f5-0b83-455f-b53b-42fb4e39436b" />

This is because we were accidentally rescaling the NDVI output with range `[-1, 1]` to range `[0, 1]` _before_ applying the filtering.

### After:

Now, we ensure that we apply the filter **before** doing any filtering: 

<img width="985" height="864" alt="image" src="https://github.com/user-attachments/assets/9aa399e7-d12d-4457-99cf-066f24036a04" />

---

## Bug

In the `naip-mosaic` example, the NDVI render pipeline was:

```
CreateTexture → ndvi → ndviFilter → Colormap → SetAlpha1
```

The `ndvi` shader module pre-normalized raw NDVI from `[-1, 1]` to `[0, 1]` (`color.r = (ndvi + 1.0) / 2.0`) so the `Colormap` module — which samples `color.r` as a `[0, 1]` index — read it correctly. But `ndviFilter` runs *after* `ndvi` and compared the already-normalized `color.r ∈ [0, 1]` against `ndviMin`/`ndviMax` that come straight from the NDVI-range slider, which is in **raw NDVI units `[-1, 1]`**. So a slider value of `0.5` actually filtered at raw NDVI `0.0`, not `0.5` — the filter was effectively `(ndviMin + 1) / 2` … `(ndviMax + 1) / 2`.

## Fix

- The `ndvi` module now writes the **raw** value (`color.r = (nir - red) / (nir + red)`, range `[-1, 1]`) so `ndviFilter` compares like-for-like.
- Inserted `{ module: LinearRescale, props: { rescaleMin: -1, rescaleMax: 1 } }` into the `renderNDVI` pipeline right before `Colormap`, remapping `[-1, 1] → [0, 1]` for the colormap-texture lookup. Pipeline is now `CreateTexture → ndvi → ndviFilter → LinearRescale → Colormap → SetAlpha1`.
- Also switched `ndviFilter.getUniforms` from `||` to `??` so a slider min/max of exactly `0` isn't silently replaced by the `-1`/`1` defaults.

The slider stays `[-1, 1]` — that's the correct user-facing range.

## Verification

- `pnpm --filter naip-mosaic-example typecheck` ✓
- `pnpm --filter naip-mosaic-example build` ✓
- `pnpm check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)