### PR TITLE
fix(raster-tileset): memoize tile bounding volumes across traversals

### DIFF
--- a/dev-docs/specs/2026-05-11-traversal-bounding-volume-cache-design.md
+++ b/dev-docs/specs/2026-05-11-traversal-bounding-volume-cache-design.md
@@ -1,0 +1,118 @@
+# Traversal Bounding-Volume Cache
+
+## Problem
+
+`getTileIndices` (the raster tile traversal) runs once per animation frame whenever the viewport changes — a `fitBounds` transition, a pan, a zoom — and it is completely stateless across frames. [`createRootTiles`](../../packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts) allocates fresh `RasterTileNode`s every call, and every visited node's [`getBoundingVolume` → `_getGenericBoundingVolume`](../../packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts) recomputes its bounding volume from scratch: 9 proj4 forward reprojections (`REF_POINTS_9`) plus a `makeOrientedBoundingBoxFromPoints` (covariance + eigendecomposition). The per-node `_boundingVolume` / `_children` caches never survive a frame because the nodes themselves don't.
+
+Per-frame cost ≈ `O(visited nodes) × (9 × proj4.forward + 1 × OBB)`. For the COG path proj4's generic `forward()` pipeline is the heavy term ([`cog-layer.ts`](../../packages/deck.gl-geotiff/src/cog-layer.ts)).
+
+This was made acutely visible by [#513](https://github.com/developmentseed/deck.gl-raster/pull/513) / `4f3e5d0`, which switched the LOD criterion from CSS pixels to *device* pixels. On a 2× display that descends one extra overview level over the whole viewport (~4× more tiles visited) — the device-pixel change is correct (it closes [#64](https://github.com/developmentseed/deck.gl-raster/issues/64)), it just multiplied an already-wasteful per-frame cost. In the `usgs-topo-cutline` example on a Retina display, `getTileIndices` takes ~12 ms/frame and drops frames. Tracked in [#523](https://github.com/developmentseed/deck.gl-raster/issues/523).
+
+## Goals
+
+- Eliminate the per-frame recomputation of tile bounding volumes (proj4 reprojection + OBB construction) during `getTileIndices`, so a steady-state animation frame's traversal cost drops to the inherently per-frame work (frustum culling + the LOD comparison + child-range arithmetic) — well under 1 ms for a typical view.
+- Bound the cache's memory: it caches *visited* tiles only (populated lazily), is LRU-evicted with a generous configurable cap, and is owned by — and dies with — the `RasterTileset2D` instance.
+- No behavior change: the set of selected tile indices for a given viewport/zRange/pixelRatio is identical to today's. Standalone/test callers of `getTileIndices` / `createRootTiles` that pass no cache behave exactly as before.
+- No new public API on `RasterTileLayer` or `RasterTileset2D` beyond an optional, internal-leaning `RasterTileset2DOptions.maxBoundingVolumeCacheSize`.
+
+## Non-Goals
+
+- The EPSG:4326 / mercator-family axis-aligned fast path for `getBoundingVolume` (the "Case 2/3" TODOs in `getBoundingVolume`). Separate follow-up; reduces the *cold* per-node cost but is orthogonal to memoization. (#523)
+- Removing the redundant double-wrap of `makeClampedForwardTo3857` (applied in `cog-layer.ts` and again inside `sampleReferencePointsInEPSG3857`). Separate follow-up. (#523)
+- Promoting `RasterTileNode`s to cached singletons ("cache the whole node tree"). Considered and rejected — see Alternatives.
+- Caching anything that depends on the viewport (frustum-culling results, LOD decisions, the selected set). Those legitimately change every frame and are cheap.
+- Globe-view bounding volumes. `getBoundingVolume` currently `assert(false)`s when `project` is non-null (Globe view), so the bounding volume is a pure function of `(z, x, y, zRange)`. When Globe support lands the cache key will need a viewport-resolution component; this spec leaves a comment marking that.
+
+## Design
+
+### 1. New: `BoundingVolumeCache` (`packages/deck.gl-raster/src/raster-tileset/bounding-volume-cache.ts`)
+
+An LRU `Map` wrapper. Key: the `"z/x/y"` string. Value: `{ zRange: ZRange; boundingVolume: OrientedBoundingBox; commonSpaceBounds: Bounds }` — exactly what `_getGenericBoundingVolume` already returns, plus the `zRange` it was computed for.
+
+```ts
+export interface BoundingVolumeCacheOptions {
+  /** Soft cap on the number of cached tile bounding volumes. When a
+   *  `getTileIndices` traversal starts and the cache is over this size, the
+   *  least-recently-used entries are dropped down to ~half. Eviction never
+   *  runs mid-traversal, so a single frame is never starved of an entry it
+   *  computed earlier that same frame. */
+  maxEntries?: number;
+}
+
+export class BoundingVolumeCache {
+  // implementation: Map<string, Entry>; default maxEntries = 1 << 16
+  get(z: number, x: number, y: number): Entry | undefined; // on hit: delete + re-set to bump recency
+  set(z: number, x: number, y: number, entry: Entry): void;
+  /** Drop LRU entries down to ~maxEntries/2 if over cap. Call once at the
+   *  top of each getTileIndices traversal. No-op if under cap. */
+  sweep(): void;
+  /** test introspection */
+  get size(): number;
+}
+```
+
+`maxEntries` default `1 << 16` (≈65 k entries × ~200 B ≈ ~13 MB worst case). For a single COG the entire overview pyramid is ~10³ tiles, so the cap is never approached in practice; it exists to bound the large-single-level-zarr / long-pan-session case. The cap is a *soft* cap because a single frame's working set could in principle exceed it, and we never evict mid-frame.
+
+LRU via `Map` insertion order: on `get` hit, `delete` then `set` (moves the key to the end = most-recently-used); `sweep` deletes from the front (oldest) until `size <= maxEntries / 2`.
+
+### 2. `RasterTileset2D` owns one cache
+
+- `RasterTileset2DOptions` gains `maxBoundingVolumeCacheSize?: number`, forwarded into `new BoundingVolumeCache({ maxEntries })`.
+- `RasterTileset2D` constructs one `BoundingVolumeCache` in its constructor (alongside `getPixelRatio`).
+- `RasterTileset2D.getTileIndices()` passes the cache to the `getTileIndices` free function via a new optional `opts.boundingVolumeCache`.
+
+No new `RasterTileLayer` prop; the layer uses the default cap.
+
+### 3. Thread the cache through the traversal
+
+- `getTileIndices(descriptor, opts)`: `opts.boundingVolumeCache?: BoundingVolumeCache`. At the top, call `boundingVolumeCache?.sweep()`. Pass it to `createRootTiles(...)` and into every `new RasterTileNode(x, y, z, { descriptor, boundingVolumeCache })`.
+- `createRootTiles(opts)`: gains optional `boundingVolumeCache`, forwards it to the `RasterTileNode`s it creates (both the small-root and large-root paths).
+- `RasterTileNode`: constructor option `boundingVolumeCache?: BoundingVolumeCache`, stored as a field. The `children` getter forwards `this.boundingVolumeCache` to each child `RasterTileNode` it creates. So every node in a traversal tree carries the (same, optional) cache reference.
+- `RasterTileNode.getBoundingVolume(zRange, project)`:
+  - If `this.boundingVolumeCache` is set: look up `(z, x, y)`. On hit *and* `entry.zRange[0] === zRange[0] && entry.zRange[1] === zRange[1]` → return `entry`. On miss or zRange mismatch → `_getGenericBoundingVolume(zRange)`, `cache.set(z, x, y, { zRange, ...result })`, return.
+  - If `this.boundingVolumeCache` is *not* set: existing behavior — use the per-node `_boundingVolume` field exactly as today (zRange-checked). This keeps `create-root-tiles.test.ts`, `tileset-refinement.test.ts`, and any other direct caller bit-for-bit unchanged.
+
+The per-node `_boundingVolume` field stays; with a shared cache present it's effectively dead (nodes are ephemeral), but leaving it keeps the no-cache code path untouched and the diff small. `_getGenericBoundingVolume` is unchanged.
+
+### 4. Everything else unchanged
+
+`createRootTiles`'s two paths, `update()`, the frustum culling, the LOD comparison (`devicePixelsPerSourcePixel <= 1`), `getSelected`, the overdraw / `childVisible` logic, the per-tile output, `pixelRatio` threading. Nodes stay ephemeral (allocated per frame, garbage-collected after) — so there is no stale-state surface to reason about. The only thing that crosses a frame boundary is the bounding-volume cache, whose values are immutable and depend only on `(z, x, y, zRange)`.
+
+### Data flow (steady-state frame, cache warm)
+
+```
+RasterTileLayer (deck.gl TileLayer drives updateState on viewport change)
+  └─ RasterTileset2D.getTileIndices({ viewport, zRange })
+       └─ getTileIndices(descriptor, { ..., boundingVolumeCache })
+            ├─ boundingVolumeCache.sweep()                  // no-op unless over cap
+            ├─ createRootTiles({ ..., boundingVolumeCache }) // ≤ MAX_ROOT_TILES_NO_CULL nodes, or viewport-culled
+            └─ for each root: root.update(params)
+                 per visited node:
+                   getBoundingVolume → cache HIT (Map.get)  // proj4 + OBB skipped
+                   bounds check · cullingVolume.computeVisibility(obb)
+                   children getter → child-range arithmetic + small alloc
+                   LOD: worldToLngLat(obb.center) → getMetersPerPixel → compare
+                   recurse if needed
+            └─ collect selected via getSelected(roots)
+```
+
+## Error handling / edge cases
+
+- **zRange oscillation:** if `zRange` flips between values, the affected key recomputes each flip but the cache doesn't grow (same key overwritten). Pathological and rare (only terrain/elevation use non-`[0,0]` zRange).
+- **Descriptor change:** the descriptor is immutable for a `RasterTileset2D` instance's lifetime. A layer `data`/`geotiff` change produces a new layer → new sublayer `TileLayer` → new `Tileset2D` → fresh cache. No explicit invalidation needed.
+- **No cache passed:** `getBoundingVolume` falls back to the per-node `_boundingVolume` field; identical to current behavior.
+- **Single frame larger than the cap:** `sweep()` only runs at frame start, so the frame completes without evicting anything it needs; the next frame trims back down. The cap is sized so this essentially never happens.
+- **Globe view:** unsupported in `getBoundingVolume` today (`assert(false)`); a comment on the cache key notes a viewport component will be needed when it's implemented.
+
+## Testing
+
+- **Memoization (write first, red):** a fake `TilesetDescriptor` whose `projectTo3857` increments a call counter. Construct a `RasterTileset2D` with `{ getPixelRatio: () => 2 }` and a default cache; call `getTileIndices` with the same viewport twice. Assert: (a) the proj4 counter is unchanged between call 1 and call 2; (b) the returned `TileIndex[]` of call 2 deep-equals that of call 1. Red without the cache (counter doubles); green with it.
+- **Eviction / bound:** construct with a small `maxBoundingVolumeCacheSize` (e.g. 8); step the viewport across enough distinct tiles over several `getTileIndices` calls that the cumulative distinct-tile count exceeds the cap; assert `cache.size <= maxEntries` after each call and that the selected indices each call still match a no-cache reference run (re-warming is correct).
+- **No-cache parity:** a test that `getTileIndices` / `createRootTiles` called without a cache return the same results as before (covered largely by the existing suite — `create-root-tiles.test.ts`, `tileset-refinement.test.ts`, `lod-pixel-ratio.test.ts`, `affine-tileset*.test.ts` — which must pass unchanged).
+- No wall-clock timing assertion (flaky in CI); the proj4-call-count test is the deterministic proxy for "the expensive work is memoized."
+
+## Alternatives considered
+
+- **Cache the whole `RasterTileNode` tree** (singletons keyed `"z/x/y"`, `_children` / `_boundingVolume` surviving across frames; zero per-frame allocation after warmup). Rejected: nodes hold child *references* (a tree), so an LRU evict from the by-key map doesn't free a node while its parent is still cached — forcing a restructure to cache a child *range* instead of refs, plus handling stale `selected` / `childVisible` on reused nodes (a `childVisible`-gated `getSelected` and a `return`-after-push). More memory per entry, more moving parts, the same LRU cap still required, for a marginal extra win (~0.3 ms vs ~1 ms — both far under a 16 ms frame). The chosen approach keeps nodes ephemeral and the diff minimal.
+- **Don't default the LOD criterion to device pixels** (revert #513's default, or clamp `pixelRatio`). Sidesteps the 4× but gives back the #64 sharpness win and doesn't address the underlying per-frame waste. Out of scope here; could still be done independently.
+- **Skip `getTileIndices` when the viewport hasn't moved enough.** Doesn't help during an actual animation, which is exactly the reported case.

--- a/packages/deck.gl-raster/src/raster-tileset/bounding-volume-cache.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/bounding-volume-cache.ts
@@ -24,12 +24,12 @@ export interface BoundingVolumeCacheOptions {
    * so a single frame is never starved of an entry it computed earlier that
    * same frame. `0` makes every traversal start from an empty cache.
    *
-   * @default 65536
+   * @default 65_536
    */
   maxEntries?: number;
 }
 
-const DEFAULT_MAX_ENTRIES = 1 << 16;
+const DEFAULT_MAX_ENTRIES = 65_536;
 
 /**
  * An LRU cache of tile bounding volumes keyed by `"z/x/y"`.

--- a/packages/deck.gl-raster/src/raster-tileset/bounding-volume-cache.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/bounding-volume-cache.ts
@@ -1,0 +1,108 @@
+import type { OrientedBoundingBox } from "@math.gl/culling";
+
+import type { Bounds, ZRange } from "./types.js";
+
+/**
+ * A memoized tile bounding volume, tagged with the elevation range it was
+ * computed for (so a `zRange` change can invalidate it).
+ */
+export interface BoundingVolumeCacheEntry {
+  zRange: ZRange;
+  boundingVolume: OrientedBoundingBox;
+  commonSpaceBounds: Bounds;
+}
+
+/**
+ * Options for {@link BoundingVolumeCache}.
+ */
+export interface BoundingVolumeCacheOptions {
+  /**
+   * Soft cap on the number of cached tile bounding volumes. When a
+   * `getTileIndices` traversal begins and the cache holds more than this many
+   * entries, the least-recently-used entries are dropped down to roughly half.
+   * Eviction never runs mid-traversal (only via {@link BoundingVolumeCache.sweep}),
+   * so a single frame is never starved of an entry it computed earlier that
+   * same frame. `0` makes every traversal start from an empty cache.
+   *
+   * @default 65536
+   */
+  maxEntries?: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 1 << 16;
+
+/**
+ * An LRU cache of tile bounding volumes keyed by `"z/x/y"`.
+ *
+ * The raster tile traversal recomputes a tile's bounding volume (several proj4
+ * reprojections plus an oriented-bounding-box fit) only on a cache miss; on a
+ * hit it returns the stored volume. A tile's bounding volume depends only on
+ * `(z, x, y, zRange)` for a given tileset descriptor, so it is safe to memoize
+ * across `getTileIndices` calls (i.e. across animation frames).
+ *
+ * NOTE: this assumes a non-Globe traversal (`project === null`) — the only kind
+ * `RasterTileNode.getBoundingVolume` currently supports. If Globe-view bounding
+ * volumes are ever implemented, the cache key will need a viewport/resolution
+ * component.
+ */
+export class BoundingVolumeCache {
+  private entries = new Map<string, BoundingVolumeCacheEntry>();
+  private maxEntries: number;
+
+  constructor({
+    maxEntries = DEFAULT_MAX_ENTRIES,
+  }: BoundingVolumeCacheOptions = {}) {
+    this.maxEntries = Math.max(0, maxEntries);
+  }
+
+  /** Number of cached entries. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /**
+   * Look up the cached bounding volume for tile `(z, x, y)`. On a hit the entry
+   * is marked most-recently-used. Returns `undefined` on a miss.
+   */
+  get(z: number, x: number, y: number): BoundingVolumeCacheEntry | undefined {
+    const key = `${z}/${x}/${y}`;
+    const entry = this.entries.get(key);
+    if (entry === undefined) {
+      return undefined;
+    }
+    // Re-insert to move the key to the most-recently-used end of the Map.
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry;
+  }
+
+  /** Store the bounding volume for tile `(z, x, y)` as most-recently-used. */
+  set(z: number, x: number, y: number, entry: BoundingVolumeCacheEntry): void {
+    const key = `${z}/${x}/${y}`;
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+  }
+
+  /**
+   * If the cache is over its soft cap, drop least-recently-used entries down to
+   * roughly half of `maxEntries`. No-op when at or under the cap. Call once at
+   * the start of a traversal, never mid-traversal.
+   */
+  sweep(): void {
+    if (this.entries.size <= this.maxEntries) {
+      return;
+    }
+    const target = Math.floor(this.maxEntries / 2);
+    const excess = this.entries.size - target;
+    const keysToDelete: string[] = [];
+    for (const key of this.entries.keys()) {
+      keysToDelete.push(key);
+      if (keysToDelete.length >= excess) {
+        break;
+      }
+    }
+    for (const key of keysToDelete) {
+      this.entries.delete(key);
+    }
+  }
+}

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
@@ -28,7 +28,7 @@ import {
 } from "@math.gl/culling";
 import { lngLatToWorld, worldToLngLat } from "@math.gl/web-mercator";
 
-import type { BoundingVolumeCache } from "./bounding-volume-cache.js";
+import { BoundingVolumeCache } from "./bounding-volume-cache.js";
 import type { TilesetDescriptor, TilesetLevel } from "./tileset-interface.js";
 import type {
   Bounds,
@@ -143,42 +143,16 @@ export class RasterTileNode {
   /** A cache of the children of this node. */
   private _children?: RasterTileNode[] | null;
 
-  /**
-   * A cached bounding volume for this tile, used for frustum culling
-   *
-   * This stores the result of `getBoundingVolume`.
-   */
-  private _boundingVolume?: {
-    /** The zrange used to compute this bounding volume. */
-    zRange: ZRange;
-    result: { boundingVolume: OrientedBoundingBox; commonSpaceBounds: Bounds };
-  };
-
-  /**
-   * Optional cross-traversal bounding-volume cache, shared by every node in a
-   * traversal. When set, {@link getBoundingVolume} reads/writes it instead of
-   * the per-node `_boundingVolume` field, so bounding volumes survive across
-   * `getTileIndices` calls. Provided by `RasterTileset2D`.
-   */
-  private boundingVolumeCache?: BoundingVolumeCache;
-
   constructor(
     x: number,
     y: number,
     z: number,
-    {
-      descriptor,
-      boundingVolumeCache,
-    }: {
-      descriptor: TilesetDescriptor;
-      boundingVolumeCache?: BoundingVolumeCache;
-    },
+    { descriptor }: { descriptor: TilesetDescriptor },
   ) {
     this.x = x;
     this.y = y;
     this.z = z;
     this.descriptor = descriptor;
-    this.boundingVolumeCache = boundingVolumeCache;
   }
 
   /** Get the level info for this tile's z index. */
@@ -216,15 +190,9 @@ export class RasterTileNode {
 
       const children: RasterTileNode[] = [];
       const { descriptor } = this;
-      const boundingVolumeCache = this.boundingVolumeCache;
       for (let y = minRow; y <= maxRow; y++) {
         for (let x = minCol; x <= maxCol; x++) {
-          children.push(
-            new RasterTileNode(x, y, childZ, {
-              descriptor,
-              boundingVolumeCache,
-            }),
-          );
+          children.push(new RasterTileNode(x, y, childZ, { descriptor }));
         }
       }
 
@@ -272,6 +240,13 @@ export class RasterTileNode {
      * comparison would. See `dev-docs/lod-and-pixel-matching.md` § (A).
      */
     pixelRatio: number;
+    /**
+     * Bounding-volume cache shared by every node in this traversal. Populated
+     * lazily as tiles are visited; reused across `getTileIndices` calls (so
+     * animation frames don't recompute proj4 reprojections + oriented-bounding-
+     * box fits). See {@link BoundingVolumeCache}.
+     */
+    boundingVolumeCache: BoundingVolumeCache;
   }): boolean {
     // Reset state
     this.childVisible = false;
@@ -286,12 +261,14 @@ export class RasterTileNode {
       project,
       bounds,
       pixelRatio,
+      boundingVolumeCache,
     } = params;
 
     // Get bounding volume for this tile
     const { boundingVolume, commonSpaceBounds } = this.getBoundingVolume(
       elevationBounds,
       project,
+      boundingVolumeCache,
     );
 
     // Step 1: Bounds checking
@@ -399,34 +376,22 @@ export class RasterTileNode {
    * Calculate the 3D bounding volume for this tile in deck.gl's common
    * coordinate space for frustum culling.
    *
+   * The result is memoized in `boundingVolumeCache` (keyed by `z/x/y`): a
+   * tile's bounding volume depends only on `(z, x, y, zRange)` for a given
+   * descriptor, so it is reused on a cache hit instead of redoing the proj4
+   * reprojections + oriented-bounding-box fit.
+   *
    * TODO: In the future, we can add a fast path in the case that the source
    * tiling is already in EPSG:3857.
    */
   getBoundingVolume(
     zRange: ZRange,
     project: ((xyz: number[]) => number[]) | null,
+    boundingVolumeCache: BoundingVolumeCache,
   ): { boundingVolume: OrientedBoundingBox; commonSpaceBounds: Bounds } {
-    const boundingVolumeCache = this.boundingVolumeCache;
-
-    // Cache lookup. A tile's bounding volume depends only on (z, x, y, zRange)
-    // for a given descriptor, so the shared cache (when the tileset provides
-    // one) is reused across getTileIndices calls / animation frames. Without a
-    // shared cache we fall back to the per-node `_boundingVolume` field (good
-    // for one traversal only), so standalone callers behave exactly as before.
-    if (boundingVolumeCache) {
-      const hit = boundingVolumeCache.get(this.z, this.x, this.y);
-      if (hit && hit.zRange[0] === zRange[0] && hit.zRange[1] === zRange[1]) {
-        return hit;
-      }
-    } else {
-      const cached = this._boundingVolume;
-      if (
-        cached &&
-        cached.zRange[0] === zRange[0] &&
-        cached.zRange[1] === zRange[1]
-      ) {
-        return cached.result;
-      }
+    const hit = boundingVolumeCache.get(this.z, this.x, this.y);
+    if (hit && hit.zRange[0] === zRange[0] && hit.zRange[1] === zRange[1]) {
+      return hit;
     }
 
     // Case 1: Globe view - need to construct an oriented bounding box from
@@ -447,11 +412,7 @@ export class RasterTileNode {
     // Case 4: Generic case - sample reference points and reproject to
     // Web Mercator, then convert to deck.gl common space
     const result = this._getGenericBoundingVolume(zRange);
-    if (boundingVolumeCache) {
-      boundingVolumeCache.set(this.z, this.x, this.y, { zRange, ...result });
-    } else {
-      this._boundingVolume = { zRange, result };
-    }
+    boundingVolumeCache.set(this.z, this.x, this.y, { zRange, ...result });
     return result;
   }
 
@@ -656,10 +617,8 @@ export function createRootTiles(opts: {
   descriptor: TilesetDescriptor;
   viewport: Pick<Viewport, "getBounds">;
   datasetWgs84Bounds: Bounds;
-  boundingVolumeCache?: BoundingVolumeCache;
 }): RasterTileNode[] {
-  const { descriptor, viewport, datasetWgs84Bounds, boundingVolumeCache } =
-    opts;
+  const { descriptor, viewport, datasetWgs84Bounds } = opts;
   const rootLevel = descriptor.levels[0]!;
 
   const roots: RasterTileNode[] = [];
@@ -670,9 +629,7 @@ export function createRootTiles(opts: {
     // handles the small amount of waste.
     for (let y = 0; y < rootLevel.matrixHeight; y++) {
       for (let x = 0; x < rootLevel.matrixWidth; x++) {
-        roots.push(
-          new RasterTileNode(x, y, 0, { descriptor, boundingVolumeCache }),
-        );
+        roots.push(new RasterTileNode(x, y, 0, { descriptor }));
       }
     }
     return roots;
@@ -700,9 +657,7 @@ export function createRootTiles(opts: {
   const rootRange = rootLevel.crsBoundsToTileRange(minX, minY, maxX, maxY);
   for (let y = rootRange.minRow; y <= rootRange.maxRow; y++) {
     for (let x = rootRange.minCol; x <= rootRange.maxCol; x++) {
-      roots.push(
-        new RasterTileNode(x, y, 0, { descriptor, boundingVolumeCache }),
-      );
+      roots.push(new RasterTileNode(x, y, 0, { descriptor }));
     }
   }
   return roots;
@@ -731,27 +686,26 @@ export function getTileIndices(
      */
     pixelRatio?: number;
     /**
-     * Optional cross-traversal cache for tile bounding volumes. When provided,
-     * a tile's bounding volume (proj4 reprojections + an oriented-bounding-box
-     * fit) is computed once and reused on subsequent `getTileIndices` calls.
-     * Pass the {@link BoundingVolumeCache} owned by the `RasterTileset2D`. Omit
-     * it for a one-shot traversal with no cross-call caching.
+     * Cache for tile bounding volumes, reused across `getTileIndices` calls so
+     * repeated traversals (animation frames) don't redo the proj4 reprojections
+     * + oriented-bounding-box fit. Pass the {@link BoundingVolumeCache} owned by
+     * the `RasterTileset2D`. If omitted, a throwaway cache is used — it still
+     * dedups within a single traversal but provides no cross-call benefit.
      */
     boundingVolumeCache?: BoundingVolumeCache;
   },
 ): TileIndex[] {
-  const {
-    viewport,
-    maxZ,
-    zRange,
-    wgs84Bounds,
-    pixelRatio = 1,
-    boundingVolumeCache,
-  } = opts;
+  const { viewport, maxZ, zRange, wgs84Bounds, pixelRatio = 1 } = opts;
+
+  // Shared by every node in this traversal (the recursion threads it through
+  // `update`'s params). A throwaway one is fine — it still dedups within the
+  // traversal; only a caller-provided cache survives to the next call.
+  const boundingVolumeCache =
+    opts.boundingVolumeCache ?? new BoundingVolumeCache();
 
   // Trim the cache (no-op when under cap) before the traversal — never during,
   // so this frame can never evict an entry it will need again this frame.
-  boundingVolumeCache?.sweep();
+  boundingVolumeCache.sweep();
 
   // Only define `project` function for Globe viewports, same as upstream
   const project: ((xyz: number[]) => number[]) | null =
@@ -811,7 +765,6 @@ export function getTileIndices(
     descriptor,
     viewport,
     datasetWgs84Bounds: wgs84Bounds,
-    boundingVolumeCache,
   });
 
   // Traverse and update visibility
@@ -824,6 +777,7 @@ export function getTileIndices(
     maxZ,
     bounds,
     pixelRatio,
+    boundingVolumeCache,
   };
 
   for (const root of roots) {

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
@@ -373,16 +373,13 @@ export class RasterTileNode {
   }
 
   /**
-   * Calculate the 3D bounding volume for this tile in deck.gl's common
-   * coordinate space for frustum culling.
+   * The 3D bounding volume for this tile in deck.gl's common coordinate space,
+   * used for frustum culling.
    *
-   * The result is memoized in `boundingVolumeCache` (keyed by `z/x/y`): a
-   * tile's bounding volume depends only on `(z, x, y, zRange)` for a given
-   * descriptor, so it is reused on a cache hit instead of redoing the proj4
-   * reprojections + oriented-bounding-box fit.
-   *
-   * TODO: In the future, we can add a fast path in the case that the source
-   * tiling is already in EPSG:3857.
+   * Memoized in `boundingVolumeCache` (keyed by `z/x/y`): a tile's bounding
+   * volume depends only on `(z, x, y, zRange)` for a given descriptor, so on a
+   * cache hit it is returned without rerunning {@link computeBoundingVolume}'s
+   * proj4 reprojections + oriented-bounding-box fit.
    */
   getBoundingVolume(
     zRange: ZRange,
@@ -393,7 +390,22 @@ export class RasterTileNode {
     if (hit && hit.zRange[0] === zRange[0] && hit.zRange[1] === zRange[1]) {
       return hit;
     }
+    const result = this.computeBoundingVolume(zRange, project);
+    boundingVolumeCache.set(this.z, this.x, this.y, { zRange, ...result });
+    return result;
+  }
 
+  /**
+   * Compute (without caching) the 3D bounding volume for this tile in deck.gl's
+   * common coordinate space.
+   *
+   * TODO: In the future, we can add a fast path in the case that the source
+   * tiling is already in EPSG:3857.
+   */
+  private computeBoundingVolume(
+    zRange: ZRange,
+    project: ((xyz: number[]) => number[]) | null,
+  ): { boundingVolume: OrientedBoundingBox; commonSpaceBounds: Bounds } {
     // Case 1: Globe view - need to construct an oriented bounding box from
     // reprojected sample points, but also using the `project` param
     if (project) {
@@ -411,9 +423,7 @@ export class RasterTileNode {
 
     // Case 4: Generic case - sample reference points and reproject to
     // Web Mercator, then convert to deck.gl common space
-    const result = this._getGenericBoundingVolume(zRange);
-    boundingVolumeCache.set(this.z, this.x, this.y, { zRange, ...result });
-    return result;
+    return this._getGenericBoundingVolume(zRange);
   }
 
   /**

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
@@ -28,6 +28,7 @@ import {
 } from "@math.gl/culling";
 import { lngLatToWorld, worldToLngLat } from "@math.gl/web-mercator";
 
+import type { BoundingVolumeCache } from "./bounding-volume-cache.js";
 import type { TilesetDescriptor, TilesetLevel } from "./tileset-interface.js";
 import type {
   Bounds,
@@ -153,16 +154,31 @@ export class RasterTileNode {
     result: { boundingVolume: OrientedBoundingBox; commonSpaceBounds: Bounds };
   };
 
+  /**
+   * Optional cross-traversal bounding-volume cache, shared by every node in a
+   * traversal. When set, {@link getBoundingVolume} reads/writes it instead of
+   * the per-node `_boundingVolume` field, so bounding volumes survive across
+   * `getTileIndices` calls. Provided by `RasterTileset2D`.
+   */
+  private boundingVolumeCache?: BoundingVolumeCache;
+
   constructor(
     x: number,
     y: number,
     z: number,
-    { descriptor }: { descriptor: TilesetDescriptor },
+    {
+      descriptor,
+      boundingVolumeCache,
+    }: {
+      descriptor: TilesetDescriptor;
+      boundingVolumeCache?: BoundingVolumeCache;
+    },
   ) {
     this.x = x;
     this.y = y;
     this.z = z;
     this.descriptor = descriptor;
+    this.boundingVolumeCache = boundingVolumeCache;
   }
 
   /** Get the level info for this tile's z index. */
@@ -200,9 +216,15 @@ export class RasterTileNode {
 
       const children: RasterTileNode[] = [];
       const { descriptor } = this;
+      const boundingVolumeCache = this.boundingVolumeCache;
       for (let y = minRow; y <= maxRow; y++) {
         for (let x = minCol; x <= maxCol; x++) {
-          children.push(new RasterTileNode(x, y, childZ, { descriptor }));
+          children.push(
+            new RasterTileNode(x, y, childZ, {
+              descriptor,
+              boundingVolumeCache,
+            }),
+          );
         }
       }
 
@@ -384,13 +406,27 @@ export class RasterTileNode {
     zRange: ZRange,
     project: ((xyz: number[]) => number[]) | null,
   ): { boundingVolume: OrientedBoundingBox; commonSpaceBounds: Bounds } {
-    const cached = this._boundingVolume;
-    if (
-      cached &&
-      cached.zRange[0] === zRange[0] &&
-      cached.zRange[1] === zRange[1]
-    ) {
-      return cached.result;
+    const boundingVolumeCache = this.boundingVolumeCache;
+
+    // Cache lookup. A tile's bounding volume depends only on (z, x, y, zRange)
+    // for a given descriptor, so the shared cache (when the tileset provides
+    // one) is reused across getTileIndices calls / animation frames. Without a
+    // shared cache we fall back to the per-node `_boundingVolume` field (good
+    // for one traversal only), so standalone callers behave exactly as before.
+    if (boundingVolumeCache) {
+      const hit = boundingVolumeCache.get(this.z, this.x, this.y);
+      if (hit && hit.zRange[0] === zRange[0] && hit.zRange[1] === zRange[1]) {
+        return hit;
+      }
+    } else {
+      const cached = this._boundingVolume;
+      if (
+        cached &&
+        cached.zRange[0] === zRange[0] &&
+        cached.zRange[1] === zRange[1]
+      ) {
+        return cached.result;
+      }
     }
 
     // Case 1: Globe view - need to construct an oriented bounding box from
@@ -411,7 +447,11 @@ export class RasterTileNode {
     // Case 4: Generic case - sample reference points and reproject to
     // Web Mercator, then convert to deck.gl common space
     const result = this._getGenericBoundingVolume(zRange);
-    this._boundingVolume = { zRange, result };
+    if (boundingVolumeCache) {
+      boundingVolumeCache.set(this.z, this.x, this.y, { zRange, ...result });
+    } else {
+      this._boundingVolume = { zRange, result };
+    }
     return result;
   }
 
@@ -616,8 +656,10 @@ export function createRootTiles(opts: {
   descriptor: TilesetDescriptor;
   viewport: Pick<Viewport, "getBounds">;
   datasetWgs84Bounds: Bounds;
+  boundingVolumeCache?: BoundingVolumeCache;
 }): RasterTileNode[] {
-  const { descriptor, viewport, datasetWgs84Bounds } = opts;
+  const { descriptor, viewport, datasetWgs84Bounds, boundingVolumeCache } =
+    opts;
   const rootLevel = descriptor.levels[0]!;
 
   const roots: RasterTileNode[] = [];
@@ -628,7 +670,9 @@ export function createRootTiles(opts: {
     // handles the small amount of waste.
     for (let y = 0; y < rootLevel.matrixHeight; y++) {
       for (let x = 0; x < rootLevel.matrixWidth; x++) {
-        roots.push(new RasterTileNode(x, y, 0, { descriptor }));
+        roots.push(
+          new RasterTileNode(x, y, 0, { descriptor, boundingVolumeCache }),
+        );
       }
     }
     return roots;
@@ -656,7 +700,9 @@ export function createRootTiles(opts: {
   const rootRange = rootLevel.crsBoundsToTileRange(minX, minY, maxX, maxY);
   for (let y = rootRange.minRow; y <= rootRange.maxRow; y++) {
     for (let x = rootRange.minCol; x <= rootRange.maxCol; x++) {
-      roots.push(new RasterTileNode(x, y, 0, { descriptor }));
+      roots.push(
+        new RasterTileNode(x, y, 0, { descriptor, boundingVolumeCache }),
+      );
     }
   }
   return roots;
@@ -684,9 +730,28 @@ export function getTileIndices(
      * on HiDPI displays. See `dev-docs/lod-and-pixel-matching.md` § (A).
      */
     pixelRatio?: number;
+    /**
+     * Optional cross-traversal cache for tile bounding volumes. When provided,
+     * a tile's bounding volume (proj4 reprojections + an oriented-bounding-box
+     * fit) is computed once and reused on subsequent `getTileIndices` calls.
+     * Pass the {@link BoundingVolumeCache} owned by the `RasterTileset2D`. Omit
+     * it for a one-shot traversal with no cross-call caching.
+     */
+    boundingVolumeCache?: BoundingVolumeCache;
   },
 ): TileIndex[] {
-  const { viewport, maxZ, zRange, wgs84Bounds, pixelRatio = 1 } = opts;
+  const {
+    viewport,
+    maxZ,
+    zRange,
+    wgs84Bounds,
+    pixelRatio = 1,
+    boundingVolumeCache,
+  } = opts;
+
+  // Trim the cache (no-op when under cap) before the traversal — never during,
+  // so this frame can never evict an entry it will need again this frame.
+  boundingVolumeCache?.sweep();
 
   // Only define `project` function for Globe viewports, same as upstream
   const project: ((xyz: number[]) => number[]) | null =
@@ -746,6 +811,7 @@ export function getTileIndices(
     descriptor,
     viewport,
     datasetWgs84Bounds: wgs84Bounds,
+    boundingVolumeCache,
   });
 
   // Traverse and update visibility

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
@@ -14,6 +14,7 @@ import type {
 import { _Tileset2D as Tileset2D } from "@deck.gl/geo-layers";
 import { transformBounds } from "@developmentseed/proj";
 import type { Matrix4 } from "@math.gl/core";
+import { BoundingVolumeCache } from "./bounding-volume-cache.js";
 import { getTileIndices } from "./raster-tile-traversal.js";
 import type { TilesetDescriptor } from "./tileset-interface.js";
 import type {
@@ -73,6 +74,17 @@ export interface RasterTileset2DOptions {
    * canvas context per call. See `dev-docs/lod-and-pixel-matching.md` § (A).
    */
   getPixelRatio?: () => number;
+
+  /**
+   * Soft cap on the number of tile bounding volumes cached across
+   * `getTileIndices` calls. Bounding volumes are expensive to compute (proj4
+   * reprojections + an oriented-bounding-box fit) and frame-invariant, so
+   * caching them keeps repeated traversals (animation frames) cheap. See
+   * `dev-docs/specs/2026-05-11-traversal-bounding-volume-cache-design.md`.
+   *
+   * @default 65536
+   */
+  maxBoundingVolumeCacheSize?: number;
 }
 
 /**
@@ -86,15 +98,19 @@ export class RasterTileset2D extends Tileset2D {
   private descriptor: TilesetDescriptor;
   private wgs84Bounds: Bounds;
   private getPixelRatio: () => number;
+  private boundingVolumeCache: BoundingVolumeCache;
 
   constructor(
     opts: Tileset2DProps,
     descriptor: TilesetDescriptor,
-    { getPixelRatio }: RasterTileset2DOptions = {},
+    { getPixelRatio, maxBoundingVolumeCacheSize }: RasterTileset2DOptions = {},
   ) {
     super(opts);
     this.descriptor = descriptor;
     this.getPixelRatio = getPixelRatio ?? (() => 1);
+    this.boundingVolumeCache = new BoundingVolumeCache({
+      maxEntries: maxBoundingVolumeCacheSize,
+    });
 
     const rawBounds = transformBounds(
       this.descriptor.projectTo4326,
@@ -157,6 +173,7 @@ export class RasterTileset2D extends Tileset2D {
       zRange: opts.zRange ?? null,
       wgs84Bounds: this.wgs84Bounds,
       pixelRatio: this.getPixelRatio(),
+      boundingVolumeCache: this.boundingVolumeCache,
     });
 
     return tileIndices;

--- a/packages/deck.gl-raster/tests/raster-tileset/bounding-volume-cache-memoization.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/bounding-volume-cache-memoization.test.ts
@@ -1,0 +1,135 @@
+import { WebMercatorViewport } from "@deck.gl/core";
+import { describe, expect, it } from "vitest";
+import { BoundingVolumeCache } from "../../src/raster-tileset/bounding-volume-cache.js";
+import { getTileIndices } from "../../src/raster-tileset/raster-tile-traversal.js";
+import type {
+  TilesetDescriptor,
+  TilesetLevel,
+} from "../../src/raster-tileset/tileset-interface.js";
+import type { Bounds, Corners } from "../../src/raster-tileset/types.js";
+
+const identity = (x: number, y: number): [number, number] => [x, y];
+
+/** Single-tile level covering [-1, -1, 1, 1] with the given metersPerPixel. */
+function makeLevel(metersPerPixel: number): TilesetLevel {
+  const corners: Corners = {
+    topLeft: [-1, 1],
+    topRight: [1, 1],
+    bottomLeft: [-1, -1],
+    bottomRight: [1, -1],
+  };
+  return {
+    matrixWidth: 1,
+    matrixHeight: 1,
+    tileWidth: 256,
+    tileHeight: 256,
+    metersPerPixel,
+    projectedTileCorners: () => corners,
+    tileTransform: () => {
+      throw new Error("not used");
+    },
+    crsBoundsToTileRange: () => ({
+      minCol: 0,
+      maxCol: 0,
+      minRow: 0,
+      maxRow: 0,
+    }),
+  };
+}
+
+/**
+ * A descriptor whose `projectTo3857` counts its invocations, so a test can
+ * assert that a second traversal does not recompute bounding volumes.
+ */
+function makeCountingDescriptor(metersPerPixelByLevel: number[]): {
+  descriptor: TilesetDescriptor;
+  projectCallCount: () => number;
+} {
+  let count = 0;
+  return {
+    descriptor: {
+      levels: metersPerPixelByLevel.map(makeLevel),
+      projectTo3857: (x: number, y: number): [number, number] => {
+        count++;
+        return [x, y];
+      },
+      projectTo4326: identity,
+      projectFrom3857: identity,
+      projectFrom4326: identity,
+      projectedBounds: [-1, -1, 1, 1],
+    },
+    projectCallCount: () => count,
+  };
+}
+
+function makeViewport(): WebMercatorViewport {
+  return new WebMercatorViewport({
+    longitude: 0,
+    latitude: 0,
+    zoom: 18,
+    width: 100,
+    height: 100,
+  });
+}
+
+function indicesOpts(viewport: WebMercatorViewport) {
+  return {
+    viewport,
+    maxZ: 2,
+    zRange: null,
+    wgs84Bounds: [-1, -1, 1, 1] as Bounds,
+    pixelRatio: 1,
+  };
+}
+
+// `getTileIndices` returns RasterTileNode instances (which carry the
+// descriptor, child caches, etc.), so compare only the tile coordinates.
+function tileKeys(indices: { x: number; y: number; z: number }[]): string[] {
+  return indices.map((i) => `${i.z}/${i.x}/${i.y}`).sort();
+}
+
+describe("getTileIndices: bounding-volume cache", () => {
+  it("recomputes bounding volumes on every call without a cache", () => {
+    const { descriptor, projectCallCount } = makeCountingDescriptor([
+      1.0, 0.4, 0.1,
+    ]);
+    const viewport = makeViewport();
+    getTileIndices(descriptor, indicesOpts(viewport));
+    const afterFirst = projectCallCount();
+    expect(afterFirst).toBeGreaterThan(0);
+    getTileIndices(descriptor, indicesOpts(viewport));
+    expect(projectCallCount()).toBe(afterFirst * 2);
+  });
+
+  it("does not recompute bounding volumes on a second call when a cache is reused", () => {
+    const { descriptor, projectCallCount } = makeCountingDescriptor([
+      1.0, 0.4, 0.1,
+    ]);
+    const cache = new BoundingVolumeCache();
+    const viewport = makeViewport();
+    const first = getTileIndices(descriptor, {
+      ...indicesOpts(viewport),
+      boundingVolumeCache: cache,
+    });
+    const afterFirst = projectCallCount();
+    expect(afterFirst).toBeGreaterThan(0);
+    const second = getTileIndices(descriptor, {
+      ...indicesOpts(viewport),
+      boundingVolumeCache: cache,
+    });
+    expect(projectCallCount()).toBe(afterFirst); // cache hits only
+    expect(tileKeys(second)).toEqual(tileKeys(first)); // identical selection
+  });
+
+  it("selects the same tiles whether or not a cache is used", () => {
+    const a = makeCountingDescriptor([1.0, 0.4, 0.1]);
+    const b = makeCountingDescriptor([1.0, 0.4, 0.1]);
+    const viewport = makeViewport();
+    const withoutCache = getTileIndices(a.descriptor, indicesOpts(viewport));
+    const withCache = getTileIndices(b.descriptor, {
+      ...indicesOpts(viewport),
+      boundingVolumeCache: new BoundingVolumeCache(),
+    });
+    expect(tileKeys(withCache)).toEqual(tileKeys(withoutCache));
+  });
+});

--- a/packages/deck.gl-raster/tests/raster-tileset/bounding-volume-cache.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/bounding-volume-cache.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { BoundingVolumeCacheEntry } from "../../src/raster-tileset/bounding-volume-cache.js";
+import { BoundingVolumeCache } from "../../src/raster-tileset/bounding-volume-cache.js";
+
+// The cache never inspects entry contents, so a tagged stub is enough.
+function entry(tag: number): BoundingVolumeCacheEntry {
+  return {
+    zRange: [0, 0],
+    boundingVolume: { tag } as any,
+    commonSpaceBounds: [0, 0, 1, 1],
+  };
+}
+
+function tagOf(e: BoundingVolumeCacheEntry | undefined): number | undefined {
+  return e === undefined ? undefined : (e.boundingVolume as any).tag;
+}
+
+describe("BoundingVolumeCache", () => {
+  it("returns undefined on a miss and the stored entry on a hit", () => {
+    const cache = new BoundingVolumeCache();
+    expect(cache.get(1, 2, 3)).toBeUndefined();
+    const e = entry(42);
+    cache.set(1, 2, 3, e);
+    expect(cache.get(1, 2, 3)).toBe(e);
+    expect(cache.size).toBe(1);
+  });
+
+  it("keys by (z, x, y) independently", () => {
+    const cache = new BoundingVolumeCache();
+    cache.set(0, 0, 0, entry(1));
+    cache.set(1, 0, 0, entry(2));
+    cache.set(0, 1, 0, entry(3));
+    cache.set(0, 0, 1, entry(4));
+    expect(cache.size).toBe(4);
+    expect(tagOf(cache.get(0, 0, 0))).toBe(1);
+    expect(tagOf(cache.get(1, 0, 0))).toBe(2);
+    expect(tagOf(cache.get(0, 1, 0))).toBe(3);
+    expect(tagOf(cache.get(0, 0, 1))).toBe(4);
+  });
+
+  it("sweep is a no-op when at or under the cap", () => {
+    const cache = new BoundingVolumeCache({ maxEntries: 4 });
+    for (let i = 0; i < 4; i++) {
+      cache.set(0, i, 0, entry(i));
+    }
+    cache.sweep();
+    expect(cache.size).toBe(4);
+  });
+
+  it("sweep drops least-recently-used entries down to ~half the cap", () => {
+    const cache = new BoundingVolumeCache({ maxEntries: 4 });
+    // Insert 0..5 (oldest -> newest): 6 entries > cap 4.
+    for (let i = 0; i < 6; i++) {
+      cache.set(0, i, 0, entry(i));
+    }
+    expect(cache.size).toBe(6);
+    cache.sweep();
+    // target = floor(4 / 2) = 2 -> the two most-recently-used survive.
+    expect(cache.size).toBe(2);
+    expect(cache.get(0, 4, 0)).toBeDefined();
+    expect(cache.get(0, 5, 0)).toBeDefined();
+    expect(cache.get(0, 0, 0)).toBeUndefined();
+    expect(cache.get(0, 3, 0)).toBeUndefined();
+  });
+
+  it("get() refreshes recency so the entry survives the next sweep", () => {
+    const cache = new BoundingVolumeCache({ maxEntries: 4 });
+    for (let i = 0; i < 5; i++) {
+      cache.set(0, i, 0, entry(i)); // 5 entries > cap 4
+    }
+    expect(cache.get(0, 0, 0)).toBeDefined(); // touch the oldest -> now MRU
+    cache.sweep(); // target 2 -> the two MRU survive: (0,4,0) and (0,0,0)
+    expect(cache.get(0, 0, 0)).toBeDefined();
+    expect(cache.get(0, 4, 0)).toBeDefined();
+    expect(cache.size).toBe(2);
+  });
+
+  it("re-setting an existing key updates the value and refreshes recency", () => {
+    const cache = new BoundingVolumeCache({ maxEntries: 4 });
+    cache.set(0, 0, 0, entry(1));
+    for (let i = 1; i < 5; i++) {
+      cache.set(0, i, 0, entry(i)); // 5 entries total
+    }
+    cache.set(0, 0, 0, entry(99)); // re-set: value 99, now MRU; still 5 entries
+    expect(cache.size).toBe(5);
+    cache.sweep(); // target 2 -> MRU two survive: (0,4,0) then (0,0,0)
+    expect(cache.size).toBe(2);
+    expect(tagOf(cache.get(0, 0, 0))).toBe(99);
+    expect(cache.get(0, 4, 0)).toBeDefined();
+  });
+
+  it("maxEntries 0 means sweep clears everything", () => {
+    const cache = new BoundingVolumeCache({ maxEntries: 0 });
+    cache.set(0, 0, 0, entry(1));
+    cache.set(0, 1, 0, entry(2));
+    expect(cache.size).toBe(2);
+    cache.sweep();
+    expect(cache.size).toBe(0);
+  });
+});

--- a/packages/deck.gl-raster/tests/raster-tileset/raster-tileset-2d-cache.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/raster-tileset-2d-cache.test.ts
@@ -1,0 +1,119 @@
+import { WebMercatorViewport } from "@deck.gl/core";
+import type { _Tileset2DProps as Tileset2DProps } from "@deck.gl/geo-layers";
+import { describe, expect, it } from "vitest";
+import { RasterTileset2D } from "../../src/raster-tileset/raster-tileset-2d.js";
+import type {
+  TilesetDescriptor,
+  TilesetLevel,
+} from "../../src/raster-tileset/tileset-interface.js";
+import type { Corners } from "../../src/raster-tileset/types.js";
+
+const identity = (x: number, y: number): [number, number] => [x, y];
+
+function makeLevel(metersPerPixel: number): TilesetLevel {
+  const corners: Corners = {
+    topLeft: [-1, 1],
+    topRight: [1, 1],
+    bottomLeft: [-1, -1],
+    bottomRight: [1, -1],
+  };
+  return {
+    matrixWidth: 1,
+    matrixHeight: 1,
+    tileWidth: 256,
+    tileHeight: 256,
+    metersPerPixel,
+    projectedTileCorners: () => corners,
+    tileTransform: () => {
+      throw new Error("not used");
+    },
+    crsBoundsToTileRange: () => ({
+      minCol: 0,
+      maxCol: 0,
+      minRow: 0,
+      maxRow: 0,
+    }),
+  };
+}
+
+function makeCountingDescriptor(metersPerPixelByLevel: number[]): {
+  descriptor: TilesetDescriptor;
+  projectCallCount: () => number;
+} {
+  let count = 0;
+  return {
+    descriptor: {
+      levels: metersPerPixelByLevel.map(makeLevel),
+      projectTo3857: (x: number, y: number): [number, number] => {
+        count++;
+        return [x, y];
+      },
+      projectTo4326: identity,
+      projectFrom3857: identity,
+      projectFrom4326: identity,
+      projectedBounds: [-1, -1, 1, 1],
+    },
+    projectCallCount: () => count,
+  };
+}
+
+function makeViewport(): WebMercatorViewport {
+  return new WebMercatorViewport({
+    longitude: 0,
+    latitude: 0,
+    zoom: 18,
+    width: 100,
+    height: 100,
+  });
+}
+
+function tilesetProps(): Tileset2DProps {
+  return { getTileData: () => new Promise(() => {}) } as Tileset2DProps;
+}
+
+// `getTileIndices` returns RasterTileNode instances, so compare only the
+// tile coordinates.
+function tileKeys(indices: { x: number; y: number; z: number }[]): string[] {
+  return indices.map((i) => `${i.z}/${i.x}/${i.y}`).sort();
+}
+
+describe("RasterTileset2D bounding-volume cache", () => {
+  it("reuses bounding volumes across getTileIndices calls", () => {
+    const { descriptor, projectCallCount } = makeCountingDescriptor([
+      1.0, 0.4, 0.1,
+    ]);
+    const tileset = new RasterTileset2D(tilesetProps(), descriptor);
+    const viewport = makeViewport();
+    const first = tileset.getTileIndices({ viewport, zRange: null });
+    const afterFirst = projectCallCount();
+    expect(afterFirst).toBeGreaterThan(0);
+    const second = tileset.getTileIndices({ viewport, zRange: null });
+    expect(projectCallCount()).toBe(afterFirst); // cache hits only
+    expect(tileKeys(second)).toEqual(tileKeys(first));
+  });
+
+  it("selects the right tiles with a tiny cache that evicts before every traversal", () => {
+    const { descriptor } = makeCountingDescriptor([1.0, 0.4, 0.1]);
+    const cached = new RasterTileset2D(tilesetProps(), descriptor, {
+      // sweep() runs at the top of each traversal; maxEntries 0 empties it
+      maxBoundingVolumeCacheSize: 0,
+    });
+    const { descriptor: refDescriptor } = makeCountingDescriptor([
+      1.0, 0.4, 0.1,
+    ]);
+    const reference = new RasterTileset2D(tilesetProps(), refDescriptor);
+    const viewport = makeViewport();
+    const expected = tileKeys(
+      reference.getTileIndices({ viewport, zRange: null }),
+    );
+    expect(tileKeys(cached.getTileIndices({ viewport, zRange: null }))).toEqual(
+      expected,
+    );
+    expect(tileKeys(cached.getTileIndices({ viewport, zRange: null }))).toEqual(
+      expected,
+    );
+    expect(tileKeys(cached.getTileIndices({ viewport, zRange: null }))).toEqual(
+      expected,
+    );
+  });
+});


### PR DESCRIPTION
Closes #523 

This is a whole lot better than in #523. In particular we have almost no dropped frames in the usgs topo cutline example:

<img width="1014" height="802" alt="image" src="https://github.com/user-attachments/assets/6847889b-83d5-46bf-8542-17b598b4f072" />

There's still more perf improvements we could do in the future, but this is still a big improvement.


-------------

## What I am changing

Fixes the per-frame tile-traversal regression in #523. On a HiDPI display, `getTileIndices` (the raster tile traversal) was taking ~12 ms/frame — visible as dropped frames in the `usgs-topo-cutline` example during the load `fitBounds` transition / panning. `getTileIndices` runs once per animation frame and was recomputing every visited tile's bounding volume from scratch (≈9 proj4 reprojections + an oriented-bounding-box fit per tile), because nothing survived between calls. #513's switch to a device-pixel LOD criterion — correct, and kept — made this ~4× worse on 2× displays by descending one extra overview level over the viewport.

## How I did it

Memoize bounding volumes across `getTileIndices` calls. A tile's bounding volume depends only on `(z, x, y, zRange)` for a given tileset descriptor — frame-invariant — so it's safe to cache.

- **`BoundingVolumeCache`** (new, internal): an LRU `Map` keyed `"z/x/y"`, soft-capped (default 65 536 entries), `sweep()`ed once at the top of each traversal so a single frame is never starved of an entry it computed earlier that frame. It caches only *visited* tiles, populated lazily — for a single COG that's ~10³ entries total; the cap exists to bound huge single-level zarrs / long pan sessions.
- **`RasterTileset2D`** owns one cache for its lifetime (so it persists across animation frames) and threads it into the traversal. New `RasterTileset2DOptions.maxBoundingVolumeCacheSize` tunes the cap; no new layer prop. Standalone callers of `getTileIndices` that don't pass a cache get a throwaway one (still dedups within a traversal).
- The cache flows through `update()`'s params (alongside the viewport / frustum / etc., which already propagate down the recursion), and `getBoundingVolume(zRange, project, cache)` is now just a cache wrapper around a lower-level `computeBoundingVolume` that holds the case dispatch (Globe assert, future mercator fast-path slots, generic Case 4). The old per-node `_boundingVolume` field is removed — it never actually hit (`update` calls `getBoundingVolume` once per node).

Steady-state per-frame traversal cost drops from `O(visited nodes) × (≈9 proj4 + OBB fit)` to `O(visited nodes) × (Map lookup + frustum cull + LOD compare)` — well under a millisecond. No behavior change: the selected tile set for a given viewport / `zRange` / `pixelRatio` is identical.

Design doc: [`dev-docs/specs/2026-05-11-traversal-bounding-volume-cache-design.md`](dev-docs/specs/2026-05-11-traversal-bounding-volume-cache-design.md).

## How you can test it

- `pnpm --filter @developmentseed/deck.gl-raster test` — 93 tests pass, including new `bounding-volume-cache.test.ts` (LRU / sweep behavior), `bounding-volume-cache-memoization.test.ts` (a `projectTo3857`-counting descriptor proves a second `getTileIndices` call does zero reprojections), and `raster-tileset-2d-cache.test.ts` (cache reuse + correctness with a tiny / zero cap).
- Manually: open the `usgs-topo-cutline` example on a HiDPI display and profile in the Chrome DevTools performance panel — per-frame `getTileIndices` is now sub-millisecond after the first frame, with no dropped frames during the load `fitBounds` transition / panning.

## Related Issues

Fixes #523.

Out of scope, tracked in #523 as follow-ups: an axis-aligned fast path in `computeBoundingVolume` for EPSG:4326 / mercator-family sources (cheaper *cold* compute), and removing the redundant double-wrap of `makeClampedForwardTo3857`.
