### PR TITLE
fix(geotiff): Turn off HTTP request bounds checking

### DIFF
--- a/packages/geotiff/src/geotiff.ts
+++ b/packages/geotiff/src/geotiff.ts
@@ -253,6 +253,23 @@ export class GeoTIFF {
   ): Promise<GeoTIFF> {
     const source = new SourceHttp(url, {});
 
+    // TEMPORARY workaround for
+    // https://github.com/developmentseed/deck.gl-raster/issues/524
+    //
+    // `@chunkd/source-http` records `source.metadata.size` from the first range
+    // response, preferring `Content-Range` and falling back to `Content-Length`.
+    // In a browser, `Content-Range` is only readable when the server lists it in
+    // `Access-Control-Expose-Headers` (S3 does not by default), so the
+    // `Content-Length` fallback — the length of a single *chunk*, not the file —
+    // gets recorded as the file size. `@chunkd/middleware`'s chunk layer then
+    // rejects any later read past that bogus size with
+    // "SourceError: Request outside of bounds".
+    //
+    // Seed `metadata` ourselves so `SourceHttp` never records a size (it only
+    // fills in `metadata` while it is still null), treating the source as having
+    // unbounded length. Remove once the upstream fix lands.
+    source.metadata = { size: Number.POSITIVE_INFINITY };
+
     // Figure out optimal defaults in light of
     // https://github.com/blacha/cogeotiff/issues/1431
     // Defaulting to 32KB chunks is too small for tile data.

--- a/packages/geotiff/tests/fromurl.test.ts
+++ b/packages/geotiff/tests/fromurl.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression test for https://github.com/developmentseed/deck.gl-raster/issues/524
+ *
+ * In a browser, S3 (and many other hosts) don't list `Content-Range` in
+ * `Access-Control-Expose-Headers`, so `@chunkd/source-http` can only read the
+ * `Content-Length` of a range response — the length of a single *chunk*, not
+ * the file. That value used to be recorded as `source.metadata.size`, after
+ * which `@chunkd/middleware`'s chunk layer rejected any later read past it with
+ * "SourceError: Request outside of bounds". `GeoTIFF.fromUrl` must guard
+ * against that.
+ */
+
+import { readFileSync } from "node:fs";
+import { SourceHttp } from "@chunkd/source-http";
+import { afterEach, describe, expect, it } from "vitest";
+import { GeoTIFF } from "../src/geotiff.js";
+import { fixturePath } from "./helpers.js";
+
+const FIXTURE = readFileSync(
+  fixturePath("uint8_rgb_deflate_block64_cog", "rasterio"),
+);
+
+/** Minimal `Response`-like object for the {@link SourceHttp.fetch} stub. */
+function makeResponse(
+  status: number,
+  headers: Record<string, string>,
+  body: Uint8Array,
+): {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: { get(key: string): string | null };
+  body: null;
+  arrayBuffer(): Promise<ArrayBuffer>;
+} {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "",
+    headers: { get: (key) => headers[key.toLowerCase()] ?? null },
+    body: null,
+    arrayBuffer: async () =>
+      body.buffer.slice(
+        body.byteOffset,
+        body.byteOffset + body.byteLength,
+      ) as ArrayBuffer,
+  };
+}
+
+/**
+ * A stand-in for {@link SourceHttp.fetch} that mimics S3 as seen from a
+ * browser: range GETs answer with `Content-Length` (the bytes actually
+ * returned) but never expose `Content-Range`; HEAD answers with the full file
+ * size.
+ */
+function browserLikeS3Fetch(file: Uint8Array) {
+  return async (
+    _url: string | URL,
+    init?: { method?: string; headers?: Record<string, string> },
+  ) => {
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (method === "HEAD") {
+      return makeResponse(
+        200,
+        { "content-length": String(file.byteLength) },
+        new Uint8Array(),
+      );
+    }
+    const range = init?.headers?.range ?? "";
+    const match = /^bytes=(\d+)-(\d+)?$/.exec(range);
+    const start = match ? Number(match[1]) : 0;
+    const end =
+      match?.[2] != null
+        ? Math.min(Number(match[2]), file.byteLength - 1)
+        : file.byteLength - 1;
+    const body = file.subarray(start, end + 1);
+    // Deliberately no `content-range` header — that is what triggers the bug.
+    return makeResponse(
+      206,
+      { "content-length": String(body.byteLength) },
+      body,
+    );
+  };
+}
+
+describe("GeoTIFF.fromUrl", () => {
+  const realFetch = SourceHttp.fetch;
+  afterEach(() => {
+    SourceHttp.fetch = realFetch;
+  });
+
+  it("reads ranges past the first chunk when the server hides Content-Range (issue #524)", async () => {
+    SourceHttp.fetch = browserLikeS3Fetch(FIXTURE) as typeof SourceHttp.fetch;
+
+    // A small chunk size makes the file span many chunks; without the fix the
+    // first chunk's `Content-Length` gets mistaken for the file size.
+    const tiff = await GeoTIFF.fromUrl("https://example.test/cog.tif", {
+      chunkSize: 1024,
+    });
+
+    // A header-source read near the end of the file must not be rejected by
+    // the chunk middleware (this is the read that `TiffImage.getTileSize`
+    // performs for GDAL "tile leader" bytes).
+    const tail = await tiff.tiff.source.fetch(FIXTURE.byteLength - 16, 16);
+    expect(tail.byteLength).toBe(16);
+  });
+});


### PR DESCRIPTION
Closes #524.

<img width="2168" height="1421" alt="image" src="https://github.com/user-attachments/assets/a2ac676a-e579-4d05-8635-caa7231a3a43" />

cc @gadomski 




-----

## Problem

The land-cover example fails on `main` with `SourceError: Request outside of bounds` (#524).

`@chunkd/source-http` derives `source.metadata.size` from the **first range response**, preferring `Content-Range` and falling back to `Content-Length`. In a browser, `Content-Range` is only readable when the server lists it in `Access-Control-Expose-Headers` — **S3 does not by default** — so the `Content-Length` fallback (the length of a single *chunk*, not the file) gets recorded as the file size. `@chunkd/middleware`'s chunk layer then rejects any later read whose end is past that bogus size with `SourceError: Request outside of bounds` — which is exactly the leader-byte read `TiffImage.getTileSize` performs.

**Why land-cover specifically?** The NLCD COG is 160000×105000 px → ~64K full-res tiles, so its `TileOffsets`/`TileByteCounts` arrays alone are ~1 MB and push the whole IFD/tag section past the 1 MB mark. So even the *coarsest overview's* tile data lives past the first chunk, and the layer breaks on initial load. Other examples have small headers, so the data deck.gl reads at the initial coarse zoom is within the first chunk — they'd hit the same bug fully zoomed in (cf. developmentseed/stac-map#459), it's just less obvious.

## Fix

Seed `source.metadata` in `GeoTIFF.fromUrl` so `SourceHttp` never records a size (it only fills in `metadata` while it's still `null`), treating the source as having unbounded length. This makes `@chunkd/middleware`'s bounds check a no-op and stops cogeotiff's `getMaxLength` from clamping — i.e. it behaves like `@chunkd/middleware` did before the bounds check was added. No dependency changes, no extra round-trip.

Trade-offs: we lose `@chunkd/source-http`'s ETag-changed-mid-read detection and the legit "don't read past EOF" guard — both edge cases, acceptable for a temporary patch. **TODO:** remove once the upstream `@chunkd` fix lands.

## Tests

New regression test (`packages/geotiff/tests/fromurl.test.ts`) stubs `SourceHttp.fetch` to mimic S3-as-seen-from-a-browser (range GETs report `Content-Length` but no `Content-Range`), opens a fixture COG via `GeoTIFF.fromUrl({ chunkSize: 1024 })`, and asserts a header-source read near EOF doesn't throw. Confirmed red (`Request outside of bounds` from `SourceChunk.fetch`) → green.

`pnpm --filter @developmentseed/geotiff test`, `... typecheck`, `pnpm check`, and the `deck.gl-geotiff` suite all pass. (The 17 `integration-rasterio` failures present on this branch are pre-existing — missing local `.npy` fixtures — and unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)