### PR TITLE
feat(geotiff): New internal method to fetch multiple tiles concurrently, with range coalescing

### DIFF
--- a/packages/geotiff/src/coalesce.ts
+++ b/packages/geotiff/src/coalesce.ts
@@ -7,7 +7,7 @@ export const COALESCE_DEFAULT = 1024 * 1024;
 export const MAX_RANGE_SIZE_DEFAULT = 16 * 1024 * 1024;
 
 /** Up to this number of merged-range requests are dispatched in parallel. */
-export const COALESCE_PARALLEL = 10;
+export const COALESCE_PARALLEL = 6;
 
 /** Options controlling how {@link coalesceRanges} merges and dispatches byte ranges. */
 export interface CoalesceOptions {

--- a/packages/geotiff/src/coalesce.ts
+++ b/packages/geotiff/src/coalesce.ts
@@ -1,0 +1,139 @@
+import type { Source } from "@cogeotiff/core";
+
+/** Range requests with a gap less than or equal to this default will be coalesced. */
+export const COALESCE_DEFAULT = 1024 * 1024;
+
+/** No merged range will exceed this default size. */
+export const MAX_RANGE_SIZE_DEFAULT = 16 * 1024 * 1024;
+
+/** Up to this number of merged-range requests are dispatched in parallel. */
+export const COALESCE_PARALLEL = 10;
+
+/** Options controlling how {@link coalesceRanges} merges and dispatches byte ranges. */
+export interface CoalesceOptions {
+  /** Max gap (bytes) between two ranges before they're merged. Default: 1 MiB. */
+  coalesce?: number;
+  /** Max size (bytes) of any merged range. Default: 16 MiB. */
+  maxRangeSize?: number;
+  /** Forwarded to `source.fetch`. */
+  signal?: AbortSignal;
+}
+
+/** A byte range: `length` bytes starting at `offset`. */
+export interface ByteRange {
+  offset: number;
+  length: number;
+}
+
+/**
+ * Fetch the given byte ranges from a source, coalescing nearby ranges into a
+ * smaller number of underlying `source.fetch` calls. Returns one `ArrayBuffer`
+ * per input range, in input order.
+ *
+ * Vendored from cogeotiff PR #1463 (`packages/core/src/source.coalesce.ts`),
+ * reformatted to this repo's conventions. Kept here (rather than relying on the
+ * upstream `Source.fetchRanges` hook) because `@developmentseed/geotiff` routes
+ * tile-data reads through an uncached `dataSource` typed as `Pick<Source, "fetch">`.
+ */
+export async function coalesceRanges(
+  source: Pick<Source, "fetch">,
+  ranges: ByteRange[],
+  options?: CoalesceOptions,
+): Promise<ArrayBuffer[]> {
+  if (ranges.length === 0) {
+    return [];
+  }
+
+  const coalesce = options?.coalesce ?? COALESCE_DEFAULT;
+  const maxRangeSize = options?.maxRangeSize ?? MAX_RANGE_SIZE_DEFAULT;
+  const signal = options?.signal;
+
+  const merged = mergeRanges(ranges, coalesce, maxRangeSize);
+  const fetched = await dispatchMerged(source, merged, signal);
+
+  const result = new Array<ArrayBuffer>(ranges.length);
+  for (let i = 0; i < ranges.length; i++) {
+    const range = ranges[i]!;
+    const groupIndex = findGroupIndex(merged, range.offset);
+    const group = merged[groupIndex]!;
+    const groupBytes = fetched[groupIndex]!;
+    const start = range.offset - group.offset;
+    const end = start + range.length;
+    if (end > groupBytes.byteLength) {
+      throw new Error(
+        `Failed to fetch bytes from offset:${range.offset} wanted:${range.length} got:${groupBytes.byteLength - start}`,
+      );
+    }
+    result[i] = groupBytes.slice(start, end);
+  }
+  return result;
+}
+
+/**
+ * Sort ranges by offset and merge consecutive ones whose gap is `<= coalesce`
+ * and whose merged size stays `<= maxRangeSize`.
+ */
+function mergeRanges(
+  ranges: ByteRange[],
+  coalesce: number,
+  maxRangeSize: number,
+): ByteRange[] {
+  const sorted = [...ranges].sort((a, b) => a.offset - b.offset);
+  const out: ByteRange[] = [];
+  let current: ByteRange | null = null;
+  for (const r of sorted) {
+    if (current == null) {
+      current = { offset: r.offset, length: r.length };
+      continue;
+    }
+    const currentEnd = current.offset + current.length;
+    const nextEnd = r.offset + r.length;
+    const gap = r.offset - currentEnd;
+    const mergedEnd = Math.max(currentEnd, nextEnd);
+    const mergedSize = mergedEnd - current.offset;
+    if (gap <= coalesce && mergedSize <= maxRangeSize) {
+      current.length = mergedEnd - current.offset;
+    } else {
+      out.push(current);
+      current = { offset: r.offset, length: r.length };
+    }
+  }
+  if (current != null) {
+    out.push(current);
+  }
+  return out;
+}
+
+/** Binary search for the merged group whose offset is the largest `<= target`. */
+function findGroupIndex(merged: ByteRange[], target: number): number {
+  let lo = 0;
+  let hi = merged.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if (merged[mid]!.offset <= target) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo;
+}
+
+/** Fetch every merged range, at most {@link COALESCE_PARALLEL} requests in flight. */
+async function dispatchMerged(
+  source: Pick<Source, "fetch">,
+  merged: ByteRange[],
+  signal?: AbortSignal,
+): Promise<ArrayBuffer[]> {
+  const out = new Array<ArrayBuffer>(merged.length);
+  for (let i = 0; i < merged.length; i += COALESCE_PARALLEL) {
+    const batch = merged.slice(i, i + COALESCE_PARALLEL);
+    const results = await Promise.all(
+      batch.map((g) => source.fetch(g.offset, g.length, { signal })),
+    );
+    for (let j = 0; j < results.length; j++) {
+      out[i + j] = results[j]!;
+    }
+  }
+  return out;
+}

--- a/packages/geotiff/src/fetch.ts
+++ b/packages/geotiff/src/fetch.ts
@@ -3,6 +3,7 @@ import { Compression, PlanarConfiguration, TiffTag } from "@cogeotiff/core";
 import { compose, translation } from "@developmentseed/affine";
 import type { ProjJson } from "@developmentseed/proj";
 import type { RasterArray } from "./array.js";
+import { coalesceRanges } from "./coalesce.js";
 import type { DecodedPixels, DecoderMetadata } from "./decode.js";
 import { decode } from "./decode.js";
 import type { CachedTags } from "./ifd.js";
@@ -425,6 +426,144 @@ async function getBytes(
     };
   }
   return { bytes, compression };
+}
+
+/**
+ * Read image bytes for multiple ranges in a single batched I/O round trip.
+ *
+ * Vectorized counterpart to {@link getBytes}. The non-sparse ranges are
+ * dispatched through {@link coalesceRanges}, which merges nearby byte ranges
+ * into fewer `dataSource.fetch` calls. Returns one entry per input range, in
+ * input order; sparse ranges (`offset === 0` or `byteCount === 0`) yield `null`,
+ * matching {@link getBytes}.
+ *
+ * Vendored from cogeotiff PR #1463 (`TiffImage.getMultipleBytes`) for the same
+ * reason as {@link getBytes}: tile data must read through the uncached
+ * `dataSource` rather than the cached header source. Upstream also lets a
+ * `Source` provide its own `fetchRanges`; `@cogeotiff/core@9.5.0` has no such
+ * interface method and `dataSource` is only `Pick<Source, "fetch">`, so the
+ * coalescing here is always done locally.
+ */
+export async function getMultipleBytes(
+  image: TiffImage,
+  ranges: { offset: number; byteCount: number }[],
+  dataSource: Pick<Source, "fetch">,
+  options?: {
+    signal?: AbortSignal;
+    debug?: DebugTag;
+    coalesce?: number;
+    maxRangeSize?: number;
+  },
+): Promise<Array<{ bytes: ArrayBuffer; compression: Compression } | null>> {
+  if (ranges.length === 0) {
+    return [];
+  }
+
+  const results = new Array<{
+    bytes: ArrayBuffer;
+    compression: Compression;
+  } | null>(ranges.length);
+  const realRanges: { offset: number; length: number }[] = [];
+  const realIndices: number[] = [];
+  for (let i = 0; i < ranges.length; i++) {
+    const range = ranges[i]!;
+    if (range.offset === 0 || range.byteCount === 0) {
+      results[i] = null;
+    } else {
+      realIndices.push(i);
+      realRanges.push({ offset: range.offset, length: range.byteCount });
+    }
+  }
+
+  if (realRanges.length === 0) {
+    return results;
+  }
+
+  if (options?.debug !== undefined) {
+    for (const r of realRanges) {
+      console.log(
+        `[geotiff dataSource] ${options.debug.label}: offset=${r.offset} length=${r.length}`,
+      );
+    }
+  }
+
+  const fetched = await coalesceRanges(dataSource, realRanges, {
+    coalesce: options?.coalesce,
+    maxRangeSize: options?.maxRangeSize,
+    signal: options?.signal,
+  });
+
+  const compression = image.value(TiffTag.Compression) ?? Compression.None;
+  for (let k = 0; k < fetched.length; k++) {
+    const i = realIndices[k]!;
+    const raw = fetched[k]!;
+    const bytes =
+      compression === Compression.Jpeg ? image.getJpegHeader(raw) : raw;
+    results[i] = { bytes, compression };
+  }
+
+  return results;
+}
+
+/**
+ * Load multiple tiles in a single batched I/O round trip.
+ *
+ * Resolves the offset/size of every requested tile via `image.getTileSize`
+ * (header-source reads — small entries, served by the chunk cache), then fetches
+ * the tile data through {@link getMultipleBytes} (uncached `dataSource`, with
+ * range coalescing). Returns one entry per input tile, in input order; sparse
+ * tiles yield `null` matching {@link getBytes}.
+ *
+ * Vendored from cogeotiff PR #1463 (`TiffImage.getTiles`) for the same reason as
+ * {@link getTile}: the tile-data read must route through `dataSource`.
+ */
+export async function getTiles(
+  image: TiffImage,
+  xy: Array<[number, number]>,
+  dataSource: Pick<Source, "fetch">,
+  options?: {
+    signal?: AbortSignal;
+    debug?: DebugTag;
+    coalesce?: number;
+    maxRangeSize?: number;
+  },
+): Promise<Array<{ bytes: ArrayBuffer; compression: Compression } | null>> {
+  if (xy.length === 0) {
+    return [];
+  }
+
+  const { size, tileSize } = image;
+  if (tileSize == null) {
+    throw new Error("Tiff is not tiled");
+  }
+
+  // TODO support GhostOptionTileOrder
+  const nyTiles = Math.ceil(size.height / tileSize.height);
+  const nxTiles = Math.ceil(size.width / tileSize.width);
+  const totalTiles = nxTiles * nyTiles;
+
+  const indices = xy.map(([x, y]) => {
+    if (x >= nxTiles || y >= nyTiles) {
+      throw new Error(
+        `Tile index is outside of range x:${x} >= ${nxTiles} or y:${y} >= ${nyTiles}`,
+      );
+    }
+    const idx = y * nxTiles + x;
+    if (idx >= totalTiles) {
+      throw new Error(
+        `Tile index is outside of tile range: ${idx} >= ${totalTiles}`,
+      );
+    }
+    return idx;
+  });
+
+  const sizes = await Promise.all(indices.map((i) => image.getTileSize(i)));
+  return getMultipleBytes(
+    image,
+    sizes.map((s) => ({ offset: s.offset, byteCount: s.imageSize })),
+    dataSource,
+    options,
+  );
 }
 
 /**

--- a/packages/geotiff/tests/coalesce.test.ts
+++ b/packages/geotiff/tests/coalesce.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+import { coalesceRanges } from "../src/coalesce.js";
+
+/**
+ * In-memory source that records every fetch. `delayTicks` makes each fetch await
+ * that many microtasks before resolving, so concurrency is observable.
+ */
+class RecordingSource {
+  fetches: { offset: number; length: number }[] = [];
+  inflight = 0;
+  peakInflight = 0;
+  delayTicks = 0;
+
+  constructor(private readonly buffer: Uint8Array) {}
+
+  async fetch(offset: number, length: number): Promise<ArrayBuffer> {
+    this.fetches.push({ offset, length });
+    this.inflight++;
+    if (this.inflight > this.peakInflight) {
+      this.peakInflight = this.inflight;
+    }
+    try {
+      for (let i = 0; i < this.delayTicks; i++) {
+        await Promise.resolve();
+      }
+      const slice = this.buffer.slice(offset, offset + length);
+      return slice.buffer.slice(
+        slice.byteOffset,
+        slice.byteOffset + slice.byteLength,
+      ) as ArrayBuffer;
+    } finally {
+      this.inflight--;
+    }
+  }
+}
+
+/** Build a buffer where each byte equals `index % 256`. */
+function makeBuffer(size: number): Uint8Array {
+  const buf = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    buf[i] = i & 0xff;
+  }
+  return buf;
+}
+
+describe("coalesceRanges", () => {
+  it("returns [] and makes no fetches for empty input", async () => {
+    const source = new RecordingSource(makeBuffer(64));
+    const result = await coalesceRanges(source, []);
+    expect(result).toEqual([]);
+    expect(source.fetches.length).toBe(0);
+  });
+
+  it("fetches a single range as one source call", async () => {
+    const source = new RecordingSource(makeBuffer(64));
+    const result = await coalesceRanges(source, [{ offset: 10, length: 5 }]);
+
+    expect(result.length).toBe(1);
+    expect(new Uint8Array(result[0]!)).toEqual(
+      new Uint8Array([10, 11, 12, 13, 14]),
+    );
+    expect(source.fetches).toEqual([{ offset: 10, length: 5 }]);
+  });
+
+  it("merges two adjacent ranges within coalesce gap into one fetch", async () => {
+    const source = new RecordingSource(makeBuffer(128));
+    const result = await coalesceRanges(
+      source,
+      [
+        { offset: 10, length: 4 },
+        { offset: 20, length: 4 },
+      ],
+      { coalesce: 16 },
+    );
+
+    expect(source.fetches).toEqual([{ offset: 10, length: 14 }]);
+    expect(new Uint8Array(result[0]!)).toEqual(
+      new Uint8Array([10, 11, 12, 13]),
+    );
+    expect(new Uint8Array(result[1]!)).toEqual(
+      new Uint8Array([20, 21, 22, 23]),
+    );
+  });
+
+  it("does not merge ranges with gap larger than coalesce", async () => {
+    const source = new RecordingSource(makeBuffer(256));
+    const result = await coalesceRanges(
+      source,
+      [
+        { offset: 0, length: 4 },
+        { offset: 100, length: 4 },
+      ],
+      { coalesce: 16 },
+    );
+
+    expect(source.fetches).toEqual([
+      { offset: 0, length: 4 },
+      { offset: 100, length: 4 },
+    ]);
+    expect(new Uint8Array(result[0]!)).toEqual(new Uint8Array([0, 1, 2, 3]));
+    expect(new Uint8Array(result[1]!)).toEqual(
+      new Uint8Array([100, 101, 102, 103]),
+    );
+  });
+
+  it("refuses to merge when the result would exceed maxRangeSize", async () => {
+    const source = new RecordingSource(makeBuffer(1000));
+    const result = await coalesceRanges(
+      source,
+      [
+        { offset: 0, length: 100 },
+        { offset: 110, length: 100 },
+      ],
+      { coalesce: 32, maxRangeSize: 150 },
+    );
+
+    expect(source.fetches).toEqual([
+      { offset: 0, length: 100 },
+      { offset: 110, length: 100 },
+    ]);
+    expect(result[0]!.byteLength).toBe(100);
+    expect(result[1]!.byteLength).toBe(100);
+  });
+
+  it("fetches a single oversized range in full (does not truncate input)", async () => {
+    const source = new RecordingSource(makeBuffer(500));
+    const result = await coalesceRanges(source, [{ offset: 0, length: 400 }], {
+      maxRangeSize: 100,
+    });
+
+    expect(source.fetches).toEqual([{ offset: 0, length: 400 }]);
+    expect(result[0]!.byteLength).toBe(400);
+  });
+
+  it("handles duplicate input ranges by reusing the same merged group", async () => {
+    const source = new RecordingSource(makeBuffer(64));
+    const result = await coalesceRanges(source, [
+      { offset: 5, length: 3 },
+      { offset: 5, length: 3 },
+    ]);
+
+    expect(source.fetches.length).toBe(1);
+    expect(new Uint8Array(result[0]!)).toEqual(new Uint8Array([5, 6, 7]));
+    expect(new Uint8Array(result[1]!)).toEqual(new Uint8Array([5, 6, 7]));
+  });
+
+  it("handles overlapping input ranges", async () => {
+    const source = new RecordingSource(makeBuffer(64));
+    const result = await coalesceRanges(
+      source,
+      [
+        { offset: 5, length: 10 },
+        { offset: 10, length: 10 },
+      ],
+      { coalesce: 16 },
+    );
+
+    expect(source.fetches).toEqual([{ offset: 5, length: 15 }]);
+    expect(new Uint8Array(result[0]!)).toEqual(
+      new Uint8Array([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]),
+    );
+    expect(new Uint8Array(result[1]!)).toEqual(
+      new Uint8Array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]),
+    );
+  });
+
+  it("throws when source.fetch returns fewer bytes than requested", async () => {
+    const source = {
+      fetch(_offset: number, length: number): Promise<ArrayBuffer> {
+        return Promise.resolve(new ArrayBuffer(length - 1));
+      },
+    };
+
+    await expect(
+      coalesceRanges(source, [{ offset: 0, length: 10 }]),
+    ).rejects.toThrow(/Failed to fetch bytes from offset:0 wanted:10 got:9/);
+  });
+
+  it("forwards AbortSignal to source.fetch", async () => {
+    const seenSignals: (AbortSignal | undefined)[] = [];
+    const source = {
+      fetch(
+        _offset: number,
+        length: number,
+        options?: { signal?: AbortSignal },
+      ): Promise<ArrayBuffer> {
+        seenSignals.push(options?.signal);
+        return Promise.resolve(new ArrayBuffer(length));
+      },
+    };
+    const controller = new AbortController();
+
+    await coalesceRanges(
+      source,
+      [
+        { offset: 0, length: 4 },
+        { offset: 100, length: 4 },
+      ],
+      { coalesce: 8, signal: controller.signal },
+    );
+
+    expect(seenSignals.length).toBe(2);
+    for (const s of seenSignals) {
+      expect(s).toBe(controller.signal);
+    }
+  });
+
+  it("caps in-flight source.fetch calls at 10", async () => {
+    const source = new RecordingSource(makeBuffer(10_000));
+    source.delayTicks = 5;
+
+    const ranges = Array.from({ length: 25 }, (_, i) => ({
+      offset: i * 200,
+      length: 4,
+    }));
+    await coalesceRanges(source, ranges, { coalesce: 8 });
+
+    expect(source.fetches.length).toBe(25);
+    expect(source.peakInflight).toBeLessThanOrEqual(10);
+  });
+
+  it("returns results in input order even when input is out of offset order", async () => {
+    const source = new RecordingSource(makeBuffer(256));
+    const result = await coalesceRanges(
+      source,
+      [
+        { offset: 200, length: 4 },
+        { offset: 0, length: 4 },
+        { offset: 100, length: 4 },
+      ],
+      { coalesce: 8 },
+    );
+
+    expect(new Uint8Array(result[0]!)).toEqual(
+      new Uint8Array([200, 201, 202, 203]),
+    );
+    expect(new Uint8Array(result[1]!)).toEqual(new Uint8Array([0, 1, 2, 3]));
+    expect(new Uint8Array(result[2]!)).toEqual(
+      new Uint8Array([100, 101, 102, 103]),
+    );
+  });
+});

--- a/packages/geotiff/tests/get-multiple-bytes.test.ts
+++ b/packages/geotiff/tests/get-multiple-bytes.test.ts
@@ -1,0 +1,243 @@
+import type { TiffImage } from "@cogeotiff/core";
+import { Compression, TiffTag } from "@cogeotiff/core";
+import { describe, expect, it } from "vitest";
+import { getMultipleBytes, getTiles } from "../src/fetch.js";
+
+/** Build a buffer where each byte equals `index % 256`. */
+function makeBuffer(size: number): Uint8Array {
+  const buf = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    buf[i] = i & 0xff;
+  }
+  return buf;
+}
+
+/** Recording mock `dataSource` backed by an in-memory buffer. */
+function recordingDataSource(buffer: Uint8Array) {
+  const fetches: { offset: number; length: number }[] = [];
+  return {
+    fetches,
+    fetch(offset: number, length: number): Promise<ArrayBuffer> {
+      fetches.push({ offset, length });
+      const slice = buffer.slice(offset, offset + length);
+      return Promise.resolve(
+        slice.buffer.slice(
+          slice.byteOffset,
+          slice.byteOffset + slice.byteLength,
+        ) as ArrayBuffer,
+      );
+    },
+  };
+}
+
+/**
+ * Minimal `TiffImage` stand-in exposing only what `getMultipleBytes` / `getTiles`
+ * touch: `size`, `tileSize`, `value(Compression)`, `getTileSize(idx)`,
+ * `getJpegHeader(bytes)`. `getJpegHeader` here prepends a `0xff` marker byte so
+ * tests can detect that the JPEG path ran.
+ */
+function mockImage(opts: {
+  tileCount: { x: number; y: number };
+  tileSize: { width: number; height: number };
+  tiles: Map<number, { offset: number; imageSize: number }>;
+  compression?: Compression;
+}): TiffImage {
+  return {
+    size: {
+      width: opts.tileCount.x * opts.tileSize.width,
+      height: opts.tileCount.y * opts.tileSize.height,
+    },
+    tileSize: opts.tileSize,
+    value: (tag: number) =>
+      tag === TiffTag.Compression
+        ? (opts.compression ?? Compression.None)
+        : undefined,
+    getTileSize: (idx: number) =>
+      Promise.resolve(opts.tiles.get(idx) ?? { offset: 0, imageSize: 0 }),
+    getJpegHeader: (bytes: ArrayBuffer) => {
+      const out = new Uint8Array(bytes.byteLength + 1);
+      out[0] = 0xff;
+      out.set(new Uint8Array(bytes), 1);
+      return out.buffer;
+    },
+  } as unknown as TiffImage;
+}
+
+describe("getMultipleBytes", () => {
+  it("returns [] and makes no fetches for empty input", async () => {
+    const ds = recordingDataSource(makeBuffer(64));
+    const image = mockImage({
+      tileCount: { x: 1, y: 1 },
+      tileSize: { width: 16, height: 16 },
+      tiles: new Map(),
+    });
+    expect(await getMultipleBytes(image, [], ds)).toEqual([]);
+    expect(ds.fetches.length).toBe(0);
+  });
+
+  it("returns bytes in input order, coalescing nearby ranges", async () => {
+    const ds = recordingDataSource(makeBuffer(256));
+    const image = mockImage({
+      tileCount: { x: 2, y: 1 },
+      tileSize: { width: 16, height: 16 },
+      tiles: new Map(),
+    });
+
+    const result = await getMultipleBytes(
+      image,
+      [
+        { offset: 120, byteCount: 10 },
+        { offset: 100, byteCount: 10 },
+      ],
+      ds,
+    );
+
+    // gap (120 - 110 = 10) is well under the 1 MiB default → one fetch.
+    expect(ds.fetches.length).toBe(1);
+    expect(result[0]!.compression).toBe(Compression.None);
+    expect(new Uint8Array(result[0]!.bytes)).toEqual(
+      makeBuffer(256).slice(120, 130),
+    );
+    expect(new Uint8Array(result[1]!.bytes)).toEqual(
+      makeBuffer(256).slice(100, 110),
+    );
+  });
+
+  it("yields null for sparse ranges (offset 0 or byteCount 0)", async () => {
+    const ds = recordingDataSource(makeBuffer(64));
+    const image = mockImage({
+      tileCount: { x: 1, y: 1 },
+      tileSize: { width: 16, height: 16 },
+      tiles: new Map(),
+    });
+
+    const result = await getMultipleBytes(
+      image,
+      [
+        { offset: 0, byteCount: 10 },
+        { offset: 10, byteCount: 0 },
+        { offset: 5, byteCount: 4 },
+      ],
+      ds,
+    );
+
+    expect(result[0]).toBeNull();
+    expect(result[1]).toBeNull();
+    expect(new Uint8Array(result[2]!.bytes)).toEqual(
+      new Uint8Array([5, 6, 7, 8]),
+    );
+  });
+
+  it("prepends the JPEG header for JPEG-compressed tiles", async () => {
+    const ds = recordingDataSource(makeBuffer(64));
+    const image = mockImage({
+      tileCount: { x: 1, y: 1 },
+      tileSize: { width: 16, height: 16 },
+      tiles: new Map(),
+      compression: Compression.Jpeg,
+    });
+
+    const [tile] = await getMultipleBytes(
+      image,
+      [{ offset: 5, byteCount: 4 }],
+      ds,
+    );
+
+    expect(tile!.compression).toBe(Compression.Jpeg);
+    const out = new Uint8Array(tile!.bytes);
+    expect(out.length).toBe(5);
+    expect(out[0]).toBe(0xff);
+    expect(Array.from(out.slice(1))).toEqual([5, 6, 7, 8]);
+  });
+});
+
+describe("getTiles", () => {
+  it("returns [] for empty input", async () => {
+    const ds = recordingDataSource(makeBuffer(64));
+    const image = mockImage({
+      tileCount: { x: 2, y: 2 },
+      tileSize: { width: 16, height: 16 },
+      tiles: new Map(),
+    });
+    expect(await getTiles(image, [], ds)).toEqual([]);
+  });
+
+  it("resolves tile offsets and returns bytes in input order", async () => {
+    const ds = recordingDataSource(makeBuffer(512));
+    const image = mockImage({
+      tileCount: { x: 2, y: 1 },
+      tileSize: { width: 16, height: 16 },
+      tiles: new Map([
+        [0, { offset: 100, imageSize: 10 }],
+        [1, { offset: 200, imageSize: 10 }],
+      ]),
+    });
+
+    const result = await getTiles(
+      image,
+      [
+        [1, 0],
+        [0, 0],
+      ],
+      ds,
+    );
+
+    expect(result.length).toBe(2);
+    expect(new Uint8Array(result[0]!.bytes)).toEqual(
+      makeBuffer(512).slice(200, 210),
+    );
+    expect(new Uint8Array(result[1]!.bytes)).toEqual(
+      makeBuffer(512).slice(100, 110),
+    );
+  });
+
+  it("returns null for sparse tiles", async () => {
+    const ds = recordingDataSource(makeBuffer(64));
+    const image = mockImage({
+      tileCount: { x: 2, y: 1 },
+      tileSize: { width: 16, height: 16 },
+      tiles: new Map([
+        [0, { offset: 0, imageSize: 0 }],
+        [1, { offset: 0, imageSize: 0 }],
+      ]),
+    });
+
+    const result = await getTiles(
+      image,
+      [
+        [0, 0],
+        [1, 0],
+      ],
+      ds,
+    );
+    expect(result).toEqual([null, null]);
+  });
+
+  it("throws on out-of-range tile coordinates", async () => {
+    const ds = recordingDataSource(makeBuffer(64));
+    const image = mockImage({
+      tileCount: { x: 2, y: 2 },
+      tileSize: { width: 16, height: 16 },
+      tiles: new Map(),
+    });
+
+    await expect(getTiles(image, [[2, 0]], ds)).rejects.toThrow(
+      /Tile index is outside of range/,
+    );
+    await expect(getTiles(image, [[0, 2]], ds)).rejects.toThrow(
+      /Tile index is outside of range/,
+    );
+  });
+
+  it("throws when called on an untiled image", async () => {
+    const ds = recordingDataSource(makeBuffer(64));
+    const untiled = {
+      size: { width: 32, height: 32 },
+      tileSize: null,
+    } as unknown as TiffImage;
+
+    await expect(getTiles(untiled, [[0, 0]], ds)).rejects.toThrow(
+      /Tiff is not tiled/,
+    );
+  });
+});


### PR DESCRIPTION
Vendored from https://github.com/blacha/cogeotiff/pull/1463

As explained in https://github.com/blacha/cogeotiff/issues/1432 and https://github.com/developmentseed/deck.gl-raster/issues/407 I would like a method to fetch multiple tiles so that we can merge ranges for neighboring requests.

This is modeled after the Rust [`object-store`](https://docs.rs/object_store/latest/object_store/) crate and its [`get_ranges` method](https://docs.rs/object_store/latest/object_store/trait.ObjectStore.html#method.get_ranges)

### Modifications

- New internal (unexposed) methods for `getMultipleBytes` and `getTiles`
- These apply range coalescing before passing to the `fetch` method of a normal source.
- This doesn't include the change to underlying sources from https://github.com/blacha/cogeotiff/pull/1463


Vendored from https://github.com/blacha/cogeotiff/pull/1463

For https://github.com/developmentseed/deck.gl-raster/issues/273 and https://github.com/developmentseed/deck.gl-raster/issues/407


-----------



Vendors the range-coalescing + batched byte/tile readers from [cogeotiff PR #1463](https://github.com/blacha/cogeotiff/pull/1463) into `@developmentseed/geotiff`, so we can use them before that PR is merged/released. A `pnpm patch` wouldn't work here — patches live in the root workspace and don't propagate to consumers of a published library — so the code is vendored into the package itself, mirroring the existing `getTile`/`getBytes` vendoring in `fetch.ts`.

## Changes

- **`packages/geotiff/src/coalesce.ts`** (new) — near-verbatim port of the PR's `source.coalesce.ts`: `coalesceRanges(source, ranges, options?)` plus the `COALESCE_*` constants and `mergeRanges`/`findGroupIndex`/`dispatchMerged` helpers. Typed against `Pick<Source, "fetch">`.
- **`packages/geotiff/src/fetch.ts`** — adds `getMultipleBytes` and `getTiles`, sitting next to the already-vendored `getTile`/`getBytes` and routing tile data through the uncached `dataSource`. Exported package-internally; **not** added to `index.ts`. The PR's `Source.fetchRanges` branch is dropped (no such interface in `@cogeotiff/core@9.5.0`).
- **Tests** — `tests/coalesce.test.ts` (ported from the PR's `source.coalesce.test.ts`, converted to Vitest) and `tests/get-multiple-bytes.test.ts` (mocked `TiffImage` + recording data source).

`fetchTiles` is intentionally **unchanged** — wiring it to actually coalesce is a follow-up PR.

## Test plan

- [x] `pnpm --filter @developmentseed/geotiff exec vitest run tests/coalesce.test.ts tests/get-multiple-bytes.test.ts` — 21 passing
- [x] `pnpm --filter @developmentseed/geotiff typecheck` — clean
- [x] `pnpm biome check packages/geotiff` — clean
- Note: `tests/integration-rasterio.test.ts` failures are pre-existing (the `fixtures/geotiff-test-data` submodule isn't initialized locally), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)