### PR TITLE
feat(geotiff): route fetchTiles through batched, range-coalescing getTiles

### DIFF
--- a/dev-docs/specs/2026-05-12-fetch-tiles-coalesce-design.md
+++ b/dev-docs/specs/2026-05-12-fetch-tiles-coalesce-design.md
@@ -1,0 +1,88 @@
+# Route `fetchTiles` through batched `getTiles` / `getMultipleBytes`
+
+**Date:** 2026-05-12
+**Issue:** [#407](https://github.com/developmentseed/deck.gl-raster/issues/407)
+**Status:** Design — builds on [#530](https://github.com/developmentseed/deck.gl-raster/pull/530) (which vendored `getTiles` / `getMultipleBytes` / `coalesceRanges` but left `fetchTiles` unchanged).
+
+## Background
+
+`fetchTiles` was added in [#406](https://github.com/developmentseed/deck.gl-raster/pull/406) but currently just does `Promise.all(xy.map(fetchTile))` — one independent HTTP range request (or `N` for band-planar COGs) per tile. Its only consumer today, `multi-cog-layer.ts`, calls it with a small grid of spatially-adjacent covering tiles, whose byte ranges in a COG are typically contiguous or near-contiguous on disk — the exact case range coalescing helps. A follow-up plan is to also feed deck.gl's per-tile fetches through `fetchTiles` (a debounce-coalesce middleware, [#273](https://github.com/developmentseed/deck.gl-raster/issues/273)), so `fetchTiles` is becoming a central batched-read primitive rather than a multi-cog helper.
+
+[#530](https://github.com/developmentseed/deck.gl-raster/pull/530) vendored the pieces needed (from [cogeotiff PR #1463](https://github.com/blacha/cogeotiff/pull/1463)):
+
+- `coalesceRanges(dataSource, ranges, opts)` — merges nearby byte ranges into fewer `dataSource.fetch` calls.
+- `getMultipleBytes(image, ranges, dataSource, opts)` — vectorized `getBytes`; dispatches through `coalesceRanges`; returns one entry per input range in input order, `null` for sparse ranges.
+- `getTiles(image, xy, dataSource, opts)` — resolves each tile's offset/size via `image.getTileSize` (header source, chunk-cached), then fetches the data via `getMultipleBytes`.
+
+This change wires `fetchTiles` onto those helpers.
+
+## Goals
+
+1. `fetchTiles` issues coalesced batched range requests for the data tiles (and the mask tiles, if any) instead of `N` independent ones.
+2. Both planar configurations benefit: pixel-interleaved (`Contig`) and band-planar (`Separate`). Band-planar is the worst case today (`N × bands` independent requests).
+3. No behavior change for `fetchTile`, and no behavior change for `fetchTiles` other than the I/O batching (same results, same order, same errors).
+
+## Non-goals
+
+- Exposing `coalesce` / `maxRangeSize` knobs through `fetchTiles`' options object. Use `coalesceRanges` defaults; add knobs later if needed.
+- Unifying `fetchTile` onto the batched path (`fetchTile = fetchTiles([[x,y]])[0]`) or deleting `getTile` / `fetchCogBytes` / `fetchBandSeparateTileBytes`. `fetchTile` keeps its existing single-range I/O path.
+- The deck.gl debounce-coalesce middleware ([#273](https://github.com/developmentseed/deck.gl-raster/issues/273)).
+
+## Solution
+
+Split `fetchTile`'s body into "fetch the compressed bytes" and "decode + assemble the `RasterArray`". `fetchTile` and `fetchTiles` share the second half; only the I/O half differs.
+
+```
+fetchTile(self, x, y, opts)                         ← I/O path unchanged
+  ├─ fetchCogBytes(self, x, y, {signal})                       (1 range; N for band-planar)
+  ├─ maskImage ? getTile(maskImage, x, y, dataSource, …) : null
+  └─ assembleTile(self, x, y, tileBytes, maskBytes, {boundless, pool})   ←★ extracted
+
+fetchTiles(self, xy, opts)                          ← rewritten
+  ├─ data:  fetchCogBytesMultiple(self, xy, {signal})          ←★ new
+  │           Contig    → getTiles(self.image, xy, dataSource, {signal, debug:"data"})
+  │                       map null → throw `Tile at (x, y) not found`
+  │           Separate  → fetchBandSeparateTileBytesMultiple(self, xy, {signal})   ←★ new
+  │                       Promise.all(findBandSeparateTileByteRanges per tile)
+  │                       → flatten (tile × band) ranges → one getMultipleBytes call
+  │                       → regroup `bands.length` results per tile; null → throw
+  ├─ mask:  maskImage ? getTiles(self.maskImage, xy, dataSource, {signal, debug:"mask"})
+  │                   : xy.map(() => null)
+  └─ const [data, mask] = await Promise.all([dataPromise, maskPromise])
+     Promise.all(xy.map(([x,y], i) => assembleTile(self, x, y, data[i], mask[i], {boundless, pool})))
+```
+
+`assembleTile` is exactly the post-fetch tail of today's `fetchTile`: `getUniqueSampleFormat` → build `decoderMetadata` → `decodeTile` / `decodeMask` (concurrent) → build `RasterArray` → `clipToImageBounds` when `boundless === false`. Pure relocation.
+
+Net: one extraction (`assembleTile`) plus three small new functions (`fetchCogBytesMultiple`, `fetchBandSeparateTileBytesMultiple`, and `fetchTiles` rewritten). No new dependencies.
+
+### Why flatten band ranges *and* tile ranges into one `getMultipleBytes`?
+
+For a band-planar COG, tile `(x, y)`'s `N` bands live in `N` different regions of the file, and the same band of adjacent tiles is contiguous. Flattening every `(tile, band)` range into a single `getMultipleBytes` call lets `coalesceRanges` merge across both axes. Regrouping afterwards is mechanical: results come back in input order, so slice `bands.length` per tile (the band count is fixed across tiles).
+
+### Error / edge behavior — mirrors `fetchTile`
+
+- `getTiles` returns `null` for a sparse data tile → throw `Tile at (x, y) not found` (same message `fetchCogBytes`/`fetchBandSeparateTileBytes` throw today).
+- `null` band slot in a band-planar tile → same throw.
+- `xy.length === 0` → return `[]`, no I/O (matches `getTiles`/`getMultipleBytes`).
+- Data and mask batches run concurrently (`Promise.all`).
+- `_debug` → pass `{ label: "data" }` / `{ label: "mask" }`; per-fetch logging now reports the post-coalesce ranges.
+
+### Doc / comment cleanup
+
+- Rewrite the `fetchTiles` JSDoc — it currently says "For now, this simply calls `fetchTile` in parallel"; describe the batched coalesced behavior and `@see getTiles`.
+- Delete the stale `// TODO: coalesce contiguous byte ranges for fewer HTTP requests` line.
+
+## Testing
+
+Integration tests in `packages/geotiff/tests/fetch.test.ts`, against the real fixtures (same style as the existing `fetchTile` tests):
+
+1. **Contig correctness** — `fetchTiles` over a 2×2 grid on a multi-tile deflate fixture deep-equals `[await fetchTile(x,y), …]` (x, y, layout, data bytes, dims, transform, nodata, crs).
+2. **Band-separate correctness** — same against `int8_3band_zstd_block64`.
+3. **Order preserved** — shuffled `xy` input round-trips to the matching per-tile results.
+4. **`boundless: false` propagates** — edge tiles clipped, via the `uint8_1band_deflate_block128_unaligned` fixture.
+5. **Mask parity** — `cog_uint8_rgb_mask` fixture: `fetchTiles` tiles carry the same `mask` as `fetchTile`.
+6. **Coalescing actually happens** — open the fixture with `GeoTIFF.open` passing a `dataSource` wrapped in a `.fetch()`-call-recording proxy; `fetchTiles` over an adjacent grid issues strictly fewer `.fetch()` calls than the tile count, and the bytes still decode identically to `N × fetchTile`.
+7. **Empty input** — `fetchTiles([])` → `[]`, zero fetches.
+
+If `cog_uint8_rgb_mask` turns out to be single-tile (no adjacent grid possible), test 5 still works as a 1×1 parity check; tests 1/3/6 use a larger fixture.

--- a/packages/geotiff/src/fetch.ts
+++ b/packages/geotiff/src/fetch.ts
@@ -69,6 +69,23 @@ export async function fetchTile(
 
   const [tileBytes, maskBytes] = await Promise.all([tileFetch, maskFetch]);
 
+  return assembleTile(self, x, y, tileBytes, maskBytes, { boundless, pool });
+}
+
+/**
+ * Decode already-fetched compressed tile (and optional mask) bytes into a
+ * {@link Tile}. Performs no I/O — the bytes are supplied by the caller. Shared
+ * by {@link fetchTile} (single-tile fetch) and {@link fetchTiles} (batched
+ * fetch with range coalescing).
+ */
+async function assembleTile(
+  self: HasTiffReference,
+  x: number,
+  y: number,
+  tileBytes: GetBytesResponse | GetBytesResponse[],
+  maskBytes: GetBytesResponse | null,
+  { boundless, pool }: { boundless: boolean; pool?: DecoderPool },
+): Promise<Tile> {
   const {
     bitsPerSample: bitsPerSamples,
     predictor,

--- a/packages/geotiff/src/fetch.ts
+++ b/packages/geotiff/src/fetch.ts
@@ -141,12 +141,16 @@ async function assembleTile(
 }
 
 /**
- * Fetch multiple tiles from a GeoTIFF or Overview in parallel.
+ * Fetch multiple tiles from a GeoTIFF or Overview, batching the underlying
+ * reads.
  *
- * The benefit of using this over multiple calls to {@link fetchTile} is that
- * a future implementation can coalesce requests for tiles stored contiguously
- * on disk, reducing the number of HTTP range requests. For now, this simply
- * calls {@link fetchTile} in parallel for each coordinate.
+ * Unlike repeated {@link fetchTile} calls, this resolves every requested
+ * tile's byte range up front and fetches the data through {@link getTiles} /
+ * {@link getMultipleBytes}, which coalesce nearby ranges into far fewer HTTP
+ * range requests — a big win when the coordinates form a contiguous block, as
+ * they do when assembling a coarse tile from finer covering tiles. Decoding is
+ * still done per tile (via the shared {@link assembleTile}); only the I/O is
+ * batched.
  *
  * @param self - The GeoTIFF or Overview to fetch tiles from.
  * @param xy - Array of `[x, y]` tile coordinates.
@@ -154,6 +158,7 @@ async function assembleTile(
  * @returns Array of {@link Tile} objects in the same order as `xy`.
  *
  * @see {@link fetchTile} for single-tile fetching.
+ * @see {@link getTiles} for the batched, range-coalescing byte reader.
  */
 export async function fetchTiles(
   self: HasTiffReference,
@@ -168,9 +173,31 @@ export async function fetchTiles(
     signal?: AbortSignal;
   } = {},
 ): Promise<Tile[]> {
-  // TODO: coalesce contiguous byte ranges for fewer HTTP requests
+  if (xy.length === 0) {
+    return [];
+  }
+
+  const dataFetch = fetchCogBytesMultiple(self, xy, { signal });
+  const maskFetch: Promise<Array<GetBytesResponse | null>> =
+    self.maskImage != null
+      ? getTiles(self.maskImage, xy, self.dataSource, {
+          signal,
+          debug: self._debug ? { label: "mask" } : undefined,
+        })
+      : Promise.resolve(xy.map(() => null));
+
+  const [allTileBytes, allMaskBytes] = await Promise.all([
+    dataFetch,
+    maskFetch,
+  ]);
+
   return Promise.all(
-    xy.map(([x, y]) => fetchTile(self, x, y, { boundless, pool, signal })),
+    xy.map(([x, y], i) =>
+      assembleTile(self, x, y, allTileBytes[i]!, allMaskBytes[i] ?? null, {
+        boundless,
+        pool,
+      }),
+    ),
   );
 }
 
@@ -339,6 +366,92 @@ async function fetchBandSeparateTileBytes(
     return tile;
   });
   return Promise.all(buffers);
+}
+
+/**
+ * Batched, range-coalescing counterpart to {@link fetchCogBytes}: fetch the
+ * compressed bytes for many tiles in as few HTTP range requests as possible.
+ * Returns one entry per input coordinate, in input order. Throws (matching
+ * {@link fetchCogBytes}) if a requested tile is sparse / not present.
+ */
+async function fetchCogBytesMultiple(
+  self: HasTiffReference,
+  xy: Array<[number, number]>,
+  {
+    signal,
+  }: {
+    signal?: AbortSignal;
+  } = {},
+): Promise<Array<GetBytesResponse | GetBytesResponse[]>> {
+  const debug: DebugTag | undefined = self._debug
+    ? { label: "data" }
+    : undefined;
+  switch (self.cachedTags.planarConfiguration) {
+    case PlanarConfiguration.Contig: {
+      const tiles = await getTiles(self.image, xy, self.dataSource, {
+        signal,
+        debug,
+      });
+      return tiles.map((tile, i) => {
+        if (tile === null) {
+          const [x, y] = xy[i]!;
+          throw new Error(`Tile at (${x}, ${y}) not found`);
+        }
+        return tile;
+      });
+    }
+    case PlanarConfiguration.Separate:
+      return fetchBandSeparateTileBytesMultiple(self, xy, { signal });
+    default:
+      throw new Error(
+        `Unsupported PlanarConfiguration: ${self.cachedTags.planarConfiguration}`,
+      );
+  }
+}
+
+/**
+ * Batched, range-coalescing counterpart to {@link fetchBandSeparateTileBytes}.
+ * Every band of every requested tile is flattened into a single
+ * {@link getMultipleBytes} call, so coalescing can merge ranges across both
+ * bands and neighbouring tiles; the results are regrouped per tile afterwards.
+ */
+async function fetchBandSeparateTileBytesMultiple(
+  self: HasTiffReference,
+  xy: Array<[number, number]>,
+  {
+    signal,
+  }: {
+    signal?: AbortSignal;
+  } = {},
+): Promise<GetBytesResponse[][]> {
+  const debug: DebugTag | undefined = self._debug
+    ? { label: "data" }
+    : undefined;
+  const numBands = self.cachedTags.samplesPerPixel;
+  const perTileRanges = await Promise.all(
+    xy.map(([x, y]) => findBandSeparateTileByteRanges(self, x, y)),
+  );
+  const flatRanges = perTileRanges.flatMap((ranges) =>
+    ranges.map(({ offset, imageSize }) => ({
+      offset,
+      byteCount: imageSize,
+    })),
+  );
+  const flatResults = await getMultipleBytes(
+    self.image,
+    flatRanges,
+    self.dataSource,
+    { signal, debug },
+  );
+
+  return xy.map(([x, y], t) =>
+    flatResults.slice(t * numBands, t * numBands + numBands).map((res) => {
+      if (res === null) {
+        throw new Error(`Tile at (${x}, ${y}) not found`);
+      }
+      return res;
+    }),
+  );
 }
 
 /**

--- a/packages/geotiff/tests/fetch.test.ts
+++ b/packages/geotiff/tests/fetch.test.ts
@@ -1,12 +1,50 @@
 /**
- * Tests for fetchTile's `boundless` option.
+ * Tests for fetchTile and fetchTiles.
  *
  * Uses the unaligned fixture (265×266, 128×128 tiles) which has partial edge
  * tiles: right edge is 9px wide (265 % 128), bottom edge is 10px tall (266 % 128).
  */
 
+import { SourceFile } from "@chunkd/source-file";
+import type { Source } from "@cogeotiff/core";
 import { describe, expect, it } from "vitest";
-import { loadGeoTIFF } from "./helpers.js";
+import { GeoTIFF } from "../src/geotiff.js";
+import { fixturePath, loadGeoTIFF } from "./helpers.js";
+
+/** A `dataSource` wrapper that records every `fetch` call (offset + length). */
+class RecordingDataSource implements Pick<Source, "fetch"> {
+  readonly calls: Array<{ offset: number; length: number | undefined }> = [];
+
+  constructor(private readonly inner: Pick<Source, "fetch">) {}
+
+  fetch(
+    offset: number,
+    length?: number,
+    options?: { signal: AbortSignal },
+  ): Promise<ArrayBuffer> {
+    this.calls.push({ offset, length });
+    return this.inner.fetch(offset, length, options);
+  }
+}
+
+/**
+ * Open a fixture with the tile-data reads routed through a {@link
+ * RecordingDataSource}, so a test can count how many underlying `fetch`
+ * calls the tile-data path made. Header/metadata reads use a separate plain
+ * source and are not recorded.
+ */
+async function loadGeoTIFFRecordingData(
+  name: string,
+  variant: string,
+): Promise<{ tiff: GeoTIFF; dataSource: RecordingDataSource }> {
+  const path = fixturePath(name, variant);
+  const dataSource = new RecordingDataSource(new SourceFile(path));
+  const tiff = await GeoTIFF.open({
+    dataSource,
+    headerSource: new SourceFile(path),
+  });
+  return { tiff, dataSource };
+}
 
 describe("fetchTile band-separate", () => {
   it("returns band-separate layout for a multi-band planar TIFF", async () => {
@@ -126,5 +164,33 @@ describe("fetchTile boundless option", () => {
         }
       }
     });
+  });
+});
+
+describe("fetchTiles", () => {
+  const GRID: Array<[number, number]> = [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+    [1, 1],
+  ];
+
+  it("coalesces a contiguous grid into fewer reads than per-tile fetches (pixel-interleaved)", async () => {
+    const perTile = await loadGeoTIFFRecordingData(
+      "uint8_rgb_deflate_block64_cog",
+      "rasterio",
+    );
+    for (const [x, y] of GRID) {
+      await perTile.tiff.fetchTile(x, y);
+    }
+    // One data read per tile when fetched individually.
+    expect(perTile.dataSource.calls).toHaveLength(GRID.length);
+
+    const batched = await loadGeoTIFFRecordingData(
+      "uint8_rgb_deflate_block64_cog",
+      "rasterio",
+    );
+    await batched.tiff.fetchTiles(GRID);
+    expect(batched.dataSource.calls.length).toBeLessThan(GRID.length);
   });
 });

--- a/packages/geotiff/tests/fetch.test.ts
+++ b/packages/geotiff/tests/fetch.test.ts
@@ -193,4 +193,98 @@ describe("fetchTiles", () => {
     await batched.tiff.fetchTiles(GRID);
     expect(batched.dataSource.calls.length).toBeLessThan(GRID.length);
   });
+
+  it("returns the same tiles as per-tile fetchTile (pixel-interleaved)", async () => {
+    const tiff = await loadGeoTIFF("uint8_rgb_deflate_block64_cog", "rasterio");
+    const batched = await tiff.fetchTiles(GRID);
+    const individual = await Promise.all(
+      GRID.map(([x, y]) => tiff.fetchTile(x, y)),
+    );
+    expect(batched).toEqual(individual);
+  });
+
+  it("returns the same tiles as per-tile fetchTile (band-separate)", async () => {
+    const tiff = await loadGeoTIFF("int8_3band_zstd_block64", "rasterio");
+    const batched = await tiff.fetchTiles(GRID);
+    const individual = await Promise.all(
+      GRID.map(([x, y]) => tiff.fetchTile(x, y)),
+    );
+    expect(batched).toEqual(individual);
+  });
+
+  it("attaches masks the same way fetchTile does", async () => {
+    const tiff = await loadGeoTIFF("cog_uint8_rgb_mask", "rasterio");
+    const batched = await tiff.fetchTiles(GRID);
+    const individual = await Promise.all(
+      GRID.map(([x, y]) => tiff.fetchTile(x, y)),
+    );
+    expect(batched).toEqual(individual);
+    // sanity: this fixture really does carry a mask
+    expect(batched[0]!.array.mask).not.toBeNull();
+  });
+
+  it("preserves input order for a shuffled request", async () => {
+    const tiff = await loadGeoTIFF("uint8_rgb_deflate_block64_cog", "rasterio");
+    const shuffled: Array<[number, number]> = [
+      [1, 1],
+      [0, 0],
+      [1, 0],
+      [0, 1],
+    ];
+    const batched = await tiff.fetchTiles(shuffled);
+    expect(batched.map((t) => [t.x, t.y])).toEqual(shuffled);
+    const individual = await Promise.all(
+      shuffled.map(([x, y]) => tiff.fetchTile(x, y)),
+    );
+    expect(batched).toEqual(individual);
+  });
+
+  it("propagates boundless: false (clips edge tiles)", async () => {
+    const tiff = await loadGeoTIFF(
+      "uint8_1band_deflate_block128_unaligned",
+      "rasterio",
+    );
+    // 265×266 image, 128×128 tiles → 3×3; (2,2) is the partial corner tile.
+    const corner: Array<[number, number]> = [
+      [0, 0],
+      [2, 2],
+    ];
+    const batched = await tiff.fetchTiles(corner, { boundless: false });
+    const individual = await Promise.all(
+      corner.map(([x, y]) => tiff.fetchTile(x, y, { boundless: false })),
+    );
+    expect(batched).toEqual(individual);
+    // sanity: the corner tile really was clipped to the image bounds
+    expect(batched[1]!.array.width).toBe(tiff.width % tiff.tileWidth);
+    expect(batched[1]!.array.height).toBe(tiff.height % tiff.tileHeight);
+  });
+
+  it("coalesces band-separate tiles across bands and tiles", async () => {
+    const perTile = await loadGeoTIFFRecordingData(
+      "int8_3band_zstd_block64",
+      "rasterio",
+    );
+    for (const [x, y] of GRID) {
+      await perTile.tiff.fetchTile(x, y);
+    }
+    // 4 tiles × 3 bands = 12 independent reads via repeated fetchTile.
+    expect(perTile.dataSource.calls).toHaveLength(GRID.length * 3);
+
+    const batched = await loadGeoTIFFRecordingData(
+      "int8_3band_zstd_block64",
+      "rasterio",
+    );
+    await batched.tiff.fetchTiles(GRID);
+    expect(batched.dataSource.calls.length).toBeLessThan(GRID.length * 3);
+  });
+
+  it("returns [] for an empty request without any reads", async () => {
+    const { tiff, dataSource } = await loadGeoTIFFRecordingData(
+      "uint8_rgb_deflate_block64_cog",
+      "rasterio",
+    );
+    const result = await tiff.fetchTiles([]);
+    expect(result).toEqual([]);
+    expect(dataSource.calls).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
`fetchTiles` now issues **coalesced batched** HTTP range requests for tile (and mask) data, instead of `Promise.all(xy.map(fetchTile))` — one independent request (or `N` for band-planar COGs) per tile. This is the follow-up to #530, which vendored `getTiles` / `getMultipleBytes` / `coalesceRanges` but left `fetchTiles` unchanged. Closes #407.

When the requested coordinates form a contiguous block — e.g. assembling a coarse tile from its finer covering tiles, or (future, #273) a debounce-coalesce middleware in front of deck.gl's per-tile fetches — the byte ranges are contiguous or near-contiguous on disk, so they collapse into far fewer reads (a 2×2 pixel-interleaved COG: 4 → 1; a 2×2 band-planar COG: 12 → 1).

`fetchTile`'s observable behavior is unchanged.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- **`refactor(geotiff): extract assembleTile from fetchTile`** — split `fetchTile` into "fetch the compressed bytes" + "decode/assemble the `RasterArray`". The decode half (`assembleTile`) is now shared by `fetchTile` and `fetchTiles`; only the I/O half differs.
- **`feat(geotiff): batch + coalesce reads in fetchTiles`**:
  - `fetchTiles` resolves every requested tile's byte range up front, fetches data and mask concurrently, then decodes per tile via `assembleTile`, in input order. Early-returns `[]` for empty input. Stale `// TODO: coalesce …` removed; JSDoc rewritten.
  - `fetchCogBytesMultiple` (new): pixel-interleaved → `getTiles`; band-planar → `fetchBandSeparateTileBytesMultiple`; a sparse/missing tile throws `Tile at (x, y) not found`, matching `fetchCogBytes`.
  - `fetchBandSeparateTileBytesMultiple` (new): flattens every `(tile, band)` byte range into a single `getMultipleBytes` call so coalescing can merge across both bands and neighbouring tiles, then regroups `samplesPerPixel` results per tile.
  - The mask IFD, if any, is fetched the same batched way (`getTiles(self.maskImage, xy, …)`).
  - `_debug` logging still fires (now reporting the post-coalesce ranges).
- **`test(geotiff): parity + coalescing tests for batched fetchTiles`** — see below.
- Not in this PR (separate follow-ups): exposing `coalesce` / `maxRangeSize` knobs through `fetchTiles`' options; unifying `fetchTile` onto the batched path; the deck.gl debounce-coalesce middleware (#273).
- Design notes: [`dev-docs/specs/2026-05-12-fetch-tiles-coalesce-design.md`](dev-docs/specs/2026-05-12-fetch-tiles-coalesce-design.md).

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- `pnpm --filter @developmentseed/geotiff exec vitest run tests/fetch.test.ts` — 18 passing. New `describe("fetchTiles")` suite covers:
  - `fetchTiles` results are byte-for-byte equal to `[fetchTile(x,y), …]` for pixel-interleaved, band-planar, and masked fixtures;
  - input order preserved for a shuffled request;
  - `boundless: false` propagates (edge tiles clipped to image bounds);
  - coalescing actually happens — a recording `dataSource` proxy shows a 2×2 pixel-interleaved COG drop from 4 reads to fewer, and a 2×2×3-band COG from 12 to fewer;
  - empty input → `[]` with zero reads.
- `pnpm --filter @developmentseed/geotiff typecheck` and `pnpm biome check packages/geotiff` — clean.
- Note: `tests/integration-rasterio.test.ts` failures are pre-existing (the `.npy` reference fixtures under `rasterio_generated/fixtures/<name>/` aren't generated locally) and unrelated to this change — they fail identically on `main`.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Closes #407
- Builds on #530 (and cogeotiff PR blacha/cogeotiff#1463); cogeotiff issue blacha/cogeotiff#1432
- Sets up #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)