### PR TITLE
ci: Avoid npm caching in publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
 name: Publish Package
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
+          package-manager-cache: false # never use caching in release builds
       - run: pnpm install
       - run: pnpm build
       - run: pnpm test


### PR DESCRIPTION
Trying to publish 0.7.0-beta.1 [failed](https://github.com/developmentseed/deck.gl-raster/actions/runs/25821422344/job/75863747993) with 

```
npm notice Publishing to https://registry.npmjs.org/ with tag beta and default access
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1525512661
npm error code E400
npm error 400 Bad Request - PUT https://registry.npmjs.org/@developmentseed%2faffine - OIDC publish authorize: Invalid token
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-05-13T19_29_09_586Z-debug-0.log
```
not sure why