### PR TITLE
perf(raster-layer): avoid re-compiling shader Model as much as possible

### DIFF
--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -433,11 +433,12 @@ export default function App() {
                       colormapReversed: colormapChoice.reversed,
                     }),
           signal,
+          maxCacheSize: 10,
         });
       },
       // Smaller cache for MosaicLayer cache, since it caches full COGLayer
       // instances
-      maxCacheSize: 5,
+      maxCacheSize: 0,
       // @ts-expect-error beforeId is injected by @deck.gl/mapbox; LayerProps
       // doesn't know about it.
       beforeId: "boundary_country_outline",

--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -60,16 +60,14 @@ export class MeshTextureLayer extends SimpleMeshLayer<
   }
 
   override updateState(params: UpdateParameters<this>): void {
-    // SimpleMeshLayer.updateState rebuilds the Model when
-    // `changeFlags.extensionsChanged` is set (alongside mesh-ref changes).
-    // It has no notion of our `renderPipeline`, but its rebuild path calls
-    // getShaders() — which our override composes from renderPipeline. So
-    // to make super rebuild on a module-list change (e.g. render-mode
-    // switch), flip the flag and let super own the destroy/recreate/
-    // invalidate dance.
+    // Ensure the SimpleMeshLayer rebuilds the model when the renderPipeline has
+    // changed.
     if (this.hasRenderPipelineChanged(params.oldProps, params.props)) {
+      // Setting extensionsChanged to true causes recompiling the shader
+      // https://github.com/visgl/deck.gl/blob/70adde2f1fcdf5e99195df81512e6d01ee7a5edc/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts#L284-L297
       params.changeFlags.extensionsChanged = true;
     }
+
     super.updateState(params);
   }
 

--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -1,4 +1,8 @@
-import type { DefaultProps, TextureSource } from "@deck.gl/core";
+import type {
+  DefaultProps,
+  TextureSource,
+  UpdateParameters,
+} from "@deck.gl/core";
 import type { SimpleMeshLayerProps } from "@deck.gl/mesh-layers";
 import { SimpleMeshLayer } from "@deck.gl/mesh-layers";
 import type { Texture } from "@luma.gl/core";
@@ -53,6 +57,26 @@ export class MeshTextureLayer extends SimpleMeshLayer<
       ? [{ module: CreateTexture, props: { textureName: image as Texture } }]
       : [];
     return [...imageModule, ...(renderPipeline ?? [])];
+  }
+
+  override updateState(params: UpdateParameters<this>): void {
+    // Temporary diagnostic for evaluating PR #540: SimpleMeshLayer rebuilds
+    // its Model only when `props.mesh !== oldProps.mesh` or
+    // `changeFlags.extensionsChanged`. Log whichever (if either) was the
+    // trigger so we can confirm the mesh fix is taking effect and identify
+    // unexpected rebuild causes.
+    const { props, oldProps, changeFlags } = params;
+    const meshChanged = props.mesh !== oldProps.mesh;
+    const extensionsChanged = changeFlags.extensionsChanged;
+    if (meshChanged || extensionsChanged) {
+      console.log("[MeshTextureLayer] model rebuild", this.props.id, {
+        meshChanged,
+        extensionsChanged,
+        hadOldMesh: Boolean(oldProps.mesh),
+        hasNewMesh: Boolean(props.mesh),
+      });
+    }
+    super.updateState(params);
   }
 
   override getShaders() {

--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -71,7 +71,7 @@ export class MeshTextureLayer extends SimpleMeshLayer<
     if (props.mesh !== oldProps.mesh || changeFlags.extensionsChanged) {
       return;
     }
-    if (!this._renderPipelineModulesChanged(oldProps, props)) {
+    if (!this.hasRenderPipelineChanged(oldProps, props)) {
       return;
     }
     if (!props.mesh || !this.state.model) {
@@ -82,23 +82,27 @@ export class MeshTextureLayer extends SimpleMeshLayer<
     this.getAttributeManager()?.invalidateAll();
   }
 
-  private _renderPipelineModulesChanged(
+  /** Returns true if the render pipeline has changed between the old and new props. */
+  private hasRenderPipelineChanged(
     oldProps: MeshTextureLayerProps,
     newProps: MeshTextureLayerProps,
   ): boolean {
     if (Boolean(oldProps.image) !== Boolean(newProps.image)) {
       return true;
     }
-    const oldP = oldProps.renderPipeline ?? [];
-    const newP = newProps.renderPipeline ?? [];
-    if (oldP.length !== newP.length) {
+
+    const oldPipeline = oldProps.renderPipeline ?? [];
+    const newPipeline = newProps.renderPipeline ?? [];
+    if (oldPipeline.length !== newPipeline.length) {
       return true;
     }
-    for (let i = 0; i < oldP.length; i++) {
-      if (oldP[i]?.module !== newP[i]?.module) {
+
+    for (let i = 0; i < oldPipeline.length; i++) {
+      if (oldPipeline[i]?.module.name !== newPipeline[i]?.module.name) {
         return true;
       }
     }
+
     return false;
   }
 

--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -62,7 +62,7 @@ export class MeshTextureLayer extends SimpleMeshLayer<
   override updateState(params: UpdateParameters<this>): void {
     // Ensure the SimpleMeshLayer rebuilds the model when the renderPipeline has
     // changed.
-    if (this.hasRenderPipelineChanged(params.oldProps, params.props)) {
+    if (this.hasRenderPipelineChanged(params)) {
       // Setting extensionsChanged to true causes recompiling the shader
       // https://github.com/visgl/deck.gl/blob/70adde2f1fcdf5e99195df81512e6d01ee7a5edc/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts#L284-L297
       params.changeFlags.extensionsChanged = true;
@@ -72,10 +72,8 @@ export class MeshTextureLayer extends SimpleMeshLayer<
   }
 
   /** Returns true if the render pipeline has changed between the old and new props. */
-  private hasRenderPipelineChanged(
-    oldProps: MeshTextureLayerProps,
-    newProps: MeshTextureLayerProps,
-  ): boolean {
+  private hasRenderPipelineChanged(params: UpdateParameters<this>): boolean {
+    const { oldProps, props: newProps } = params;
     if (Boolean(oldProps.image) !== Boolean(newProps.image)) {
       return true;
     }

--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -56,6 +56,10 @@ export class MeshTextureLayer extends SimpleMeshLayer<
   }
 
   override getShaders() {
+    // Temporary diagnostic for evaluating PR #540: each call corresponds to a
+    // Model construction. After the mesh-reference fix, the count should NOT
+    // grow per frame for already-loaded tiles.
+    console.log("[MeshTextureLayer] getShaders()", this.props.id);
     const upstreamShaders = super.getShaders();
 
     const modules: ShaderModule[] = upstreamShaders.modules;

--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -60,30 +60,17 @@ export class MeshTextureLayer extends SimpleMeshLayer<
   }
 
   override updateState(params: UpdateParameters<this>): void {
-    const previousModel = this.state.model;
-    super.updateState(params);
-    const superRebuiltModel = this.state.model !== previousModel;
-
-    // When SimpleMeshLayer rebuilds the Model (mesh/extension change), our
-    // overridden getShaders() runs and the new shader picks up the latest
-    // renderPipeline. We only need to step in when super did NOT rebuild
-    // but the module list still changed (e.g. render-mode switch);
-    // otherwise the cached Model would silently keep running the stale
-    // shader.
-    const { props, oldProps } = params;
-    const { model } = this.state;
-    if (
-      superRebuiltModel ||
-      !model ||
-      !props.mesh ||
-      !this.hasRenderPipelineChanged(oldProps, props)
-    ) {
-      return;
+    // SimpleMeshLayer.updateState rebuilds the Model when
+    // `changeFlags.extensionsChanged` is set (alongside mesh-ref changes).
+    // It has no notion of our `renderPipeline`, but its rebuild path calls
+    // getShaders() — which our override composes from renderPipeline. So
+    // to make super rebuild on a module-list change (e.g. render-mode
+    // switch), flip the flag and let super own the destroy/recreate/
+    // invalidate dance.
+    if (this.hasRenderPipelineChanged(params.oldProps, params.props)) {
+      params.changeFlags.extensionsChanged = true;
     }
-
-    model.destroy();
-    this.state.model = this.getModel(props.mesh as any);
-    this.getAttributeManager()?.invalidateAll();
+    super.updateState(params);
   }
 
   /** Returns true if the render pipeline has changed between the old and new props. */

--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -60,24 +60,28 @@ export class MeshTextureLayer extends SimpleMeshLayer<
   }
 
   override updateState(params: UpdateParameters<this>): void {
+    const previousModel = this.state.model;
     super.updateState(params);
+    const superRebuiltModel = this.state.model !== previousModel;
 
-    // SimpleMeshLayer rebuilds its Model on mesh/extension changes. Modules
-    // aren't on its radar, but our shader source depends on them — when the
-    // renderPipeline module list changes (e.g. render-mode switch), the
-    // existing Model's shader is stale and would silently keep running the
-    // old pipeline. Force a rebuild in that case.
-    const { props, oldProps, changeFlags } = params;
-    if (props.mesh !== oldProps.mesh || changeFlags.extensionsChanged) {
+    // When SimpleMeshLayer rebuilds the Model (mesh/extension change), our
+    // overridden getShaders() runs and the new shader picks up the latest
+    // renderPipeline. We only need to step in when super did NOT rebuild
+    // but the module list still changed (e.g. render-mode switch);
+    // otherwise the cached Model would silently keep running the stale
+    // shader.
+    const { props, oldProps } = params;
+    const { model } = this.state;
+    if (
+      superRebuiltModel ||
+      !model ||
+      !props.mesh ||
+      !this.hasRenderPipelineChanged(oldProps, props)
+    ) {
       return;
     }
-    if (!this.hasRenderPipelineChanged(oldProps, props)) {
-      return;
-    }
-    if (!props.mesh || !this.state.model) {
-      return;
-    }
-    this.state.model.destroy();
+
+    model.destroy();
     this.state.model = this.getModel(props.mesh as any);
     this.getAttributeManager()?.invalidateAll();
   }

--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -60,30 +60,49 @@ export class MeshTextureLayer extends SimpleMeshLayer<
   }
 
   override updateState(params: UpdateParameters<this>): void {
-    // Temporary diagnostic for evaluating PR #540: SimpleMeshLayer rebuilds
-    // its Model only when `props.mesh !== oldProps.mesh` or
-    // `changeFlags.extensionsChanged`. Log whichever (if either) was the
-    // trigger so we can confirm the mesh fix is taking effect and identify
-    // unexpected rebuild causes.
-    const { props, oldProps, changeFlags } = params;
-    const meshChanged = props.mesh !== oldProps.mesh;
-    const extensionsChanged = changeFlags.extensionsChanged;
-    if (meshChanged || extensionsChanged) {
-      console.log("[MeshTextureLayer] model rebuild", this.props.id, {
-        meshChanged,
-        extensionsChanged,
-        hadOldMesh: Boolean(oldProps.mesh),
-        hasNewMesh: Boolean(props.mesh),
-      });
-    }
     super.updateState(params);
+
+    // SimpleMeshLayer rebuilds its Model on mesh/extension changes. Modules
+    // aren't on its radar, but our shader source depends on them — when the
+    // renderPipeline module list changes (e.g. render-mode switch), the
+    // existing Model's shader is stale and would silently keep running the
+    // old pipeline. Force a rebuild in that case.
+    const { props, oldProps, changeFlags } = params;
+    if (props.mesh !== oldProps.mesh || changeFlags.extensionsChanged) {
+      return;
+    }
+    if (!this._renderPipelineModulesChanged(oldProps, props)) {
+      return;
+    }
+    if (!props.mesh || !this.state.model) {
+      return;
+    }
+    this.state.model.destroy();
+    this.state.model = this.getModel(props.mesh as any);
+    this.getAttributeManager()?.invalidateAll();
+  }
+
+  private _renderPipelineModulesChanged(
+    oldProps: MeshTextureLayerProps,
+    newProps: MeshTextureLayerProps,
+  ): boolean {
+    if (Boolean(oldProps.image) !== Boolean(newProps.image)) {
+      return true;
+    }
+    const oldP = oldProps.renderPipeline ?? [];
+    const newP = newProps.renderPipeline ?? [];
+    if (oldP.length !== newP.length) {
+      return true;
+    }
+    for (let i = 0; i < oldP.length; i++) {
+      if (oldP[i]?.module !== newP[i]?.module) {
+        return true;
+      }
+    }
+    return false;
   }
 
   override getShaders() {
-    // Temporary diagnostic for evaluating PR #540: each call corresponds to a
-    // Model construction. After the mesh-reference fix, the count should NOT
-    // grow per frame for already-loaded tiles.
-    console.log("[MeshTextureLayer] getShaders()", this.props.id);
     const upstreamShaders = super.getShaders();
 
     const modules: ShaderModule[] = upstreamShaders.modules;

--- a/packages/deck.gl-raster/src/raster-layer.ts
+++ b/packages/deck.gl-raster/src/raster-layer.ts
@@ -133,12 +133,11 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
   declare state: {
     reprojector?: RasterReprojector;
     /**
-     * Mesh in the exact shape SimpleMeshLayer expects. Stored as a stable
-     * reference so MeshTextureLayer's `props.mesh` doesn't change identity
-     * across renders — SimpleMeshLayer rebuilds its Model whenever
-     * `props.mesh !== oldProps.mesh`, and rebuilding the Model triggers
-     * `assembleGLSLShaderPair` plus vertex-buffer setup. With many tile
-     * sublayers active that becomes a major per-frame cost.
+     * Mesh in the exact shape SimpleMeshLayer expects.
+     *
+     * It's important for this to be passed to MeshTextureLayer as a stable
+     * reference so `props.mesh` equality holds across renders. This avoids
+     * unnecessarily recreating the model.
      */
     mesh?: {
       indices: { value: Uint32Array; size: number };

--- a/packages/deck.gl-raster/src/raster-layer.ts
+++ b/packages/deck.gl-raster/src/raster-layer.ts
@@ -132,10 +132,20 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
 
   declare state: {
     reprojector?: RasterReprojector;
+    /**
+     * Mesh in the exact shape SimpleMeshLayer expects. Stored as a stable
+     * reference so MeshTextureLayer's `props.mesh` doesn't change identity
+     * across renders — SimpleMeshLayer rebuilds its Model whenever
+     * `props.mesh !== oldProps.mesh`, and rebuilding the Model triggers
+     * `assembleGLSLShaderPair` plus vertex-buffer setup. With many tile
+     * sublayers active that becomes a major per-frame cost.
+     */
     mesh?: {
-      positions: Float32Array;
-      indices: Uint32Array;
-      texCoords: Float32Array;
+      indices: { value: Uint32Array; size: number };
+      attributes: {
+        POSITION: { value: Float32Array; size: number };
+        TEXCOORD_0: { value: Float32Array; size: number };
+      };
     };
   };
 
@@ -199,9 +209,11 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
     this.setState({
       reprojector,
       mesh: {
-        positions,
-        indices,
-        texCoords,
+        indices: { value: indices, size: 1 },
+        attributes: {
+          POSITION: { value: positions, size: 3 },
+          TEXCOORD_0: { value: texCoords, size: 2 },
+        },
       },
     });
   }
@@ -275,8 +287,6 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
       return null;
     }
 
-    const { indices, positions, texCoords } = mesh;
-
     const meshLayer = new MeshTextureLayer(
       this.getSubLayerProps({
         id: "raster",
@@ -285,19 +295,7 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
         // Dummy data because we're only rendering _one_ instance of this mesh
         // https://github.com/visgl/deck.gl/blob/93111b667b919148da06ff1918410cf66381904f/modules/geo-layers/src/terrain-layer/terrain-layer.ts#L241
         data: [1],
-        mesh: {
-          indices: { value: indices, size: 1 },
-          attributes: {
-            POSITION: {
-              value: positions,
-              size: 3,
-            },
-            TEXCOORD_0: {
-              value: texCoords,
-              size: 2,
-            },
-          },
-        },
+        mesh,
         // We're only rendering a single mesh, without instancing
         // https://github.com/visgl/deck.gl/blob/93111b667b919148da06ff1918410cf66381904f/modules/geo-layers/src/terrain-layer/terrain-layer.ts#L244
         _instanced: false,

--- a/packages/deck.gl-raster/tests/raster-layer.test.ts
+++ b/packages/deck.gl-raster/tests/raster-layer.test.ts
@@ -1,0 +1,86 @@
+import type { ReprojectionFns } from "@developmentseed/raster-reproject";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/mesh-layer/mesh-layer.js", () => ({
+  MeshTextureLayer: class CapturingMeshTextureLayer {
+    public props: Record<string, unknown>;
+    constructor(props: Record<string, unknown>) {
+      this.props = props;
+    }
+  },
+}));
+
+const { RasterLayer } = await import("../src/raster-layer.js");
+
+const identity = (x: number, y: number): [number, number] => [x, y];
+const REPROJECTION_FNS: ReprojectionFns = {
+  forwardTransform: identity,
+  inverseTransform: identity,
+  forwardReproject: identity,
+  inverseReproject: identity,
+};
+
+/**
+ * Build a {@link RasterLayer} ready for direct lifecycle invocation: bypasses
+ * deck.gl's `LayerManager` by replacing `state` and `setState` with a plain
+ * object + assign, and short-circuits `getSubLayerProps` so MeshTextureLayer
+ * receives the exact prop shape we hand it.
+ */
+function makeBareLayer() {
+  const layer = new RasterLayer({
+    id: "test",
+    width: 4,
+    height: 4,
+    reprojectionFns: REPROJECTION_FNS,
+    image: {} as never,
+  });
+  const internalState: Record<string, unknown> = {};
+  Object.assign(layer as object, { state: internalState });
+  Object.assign(layer as object, {
+    setState: (updates: Record<string, unknown>) =>
+      Object.assign(internalState, updates),
+    getSubLayerProps: <T>(props: T) => props,
+  });
+  return { layer, internalState };
+}
+
+type WrappedMesh = {
+  indices: { value: Uint32Array; size: number };
+  attributes: {
+    POSITION: { value: Float32Array; size: number };
+    TEXCOORD_0: { value: Float32Array; size: number };
+  };
+};
+
+describe("RasterLayer.state.mesh", () => {
+  it("stores the mesh in SimpleMeshLayer's expected wrapper shape", () => {
+    const { layer, internalState } = makeBareLayer();
+
+    (layer as unknown as { _generateMesh: () => void })._generateMesh();
+
+    const mesh = internalState.mesh as WrappedMesh;
+    expect(mesh.indices.value).toBeInstanceOf(Uint32Array);
+    expect(mesh.indices.size).toBe(1);
+    expect(mesh.attributes.POSITION.value).toBeInstanceOf(Float32Array);
+    expect(mesh.attributes.POSITION.size).toBe(3);
+    expect(mesh.attributes.TEXCOORD_0.value).toBeInstanceOf(Float32Array);
+    expect(mesh.attributes.TEXCOORD_0.size).toBe(2);
+  });
+
+  it("passes state.mesh to MeshTextureLayer by reference across renders", () => {
+    const { layer, internalState } = makeBareLayer();
+
+    (layer as unknown as { _generateMesh: () => void })._generateMesh();
+    const meshRef = internalState.mesh;
+
+    const renderOnce = layer as unknown as {
+      renderLayers: () => { props: { mesh: unknown } }[];
+    };
+    const layers1 = renderOnce.renderLayers();
+    const layers2 = renderOnce.renderLayers();
+
+    expect(layers1[0]!.props.mesh).toBe(meshRef);
+    expect(layers2[0]!.props.mesh).toBe(meshRef);
+    expect(layers1[0]!.props.mesh).toBe(layers2[0]!.props.mesh);
+  });
+});


### PR DESCRIPTION
It's very important to reduce shader recompiles as much as possible. Changing a pixel filter slider should be nearly instant; it should just be updating the uniforms to pass into the existing GPU pipeline.

Previously we were re-compiling the shader model on every render, because the mesh instance was not passing instance equality.

Significant performance improvement in the NAIP mosaic pixel filter slider:

Before:

https://github.com/user-attachments/assets/24b1fd4e-965b-42be-b9a9-c6bc362fccd7

After:

https://github.com/user-attachments/assets/3f5e2308-9ddd-4917-8271-b13cf9fa9e2e



-----


## Summary

Two-part fix that lets `RasterLayer`/`MeshTextureLayer` reuse the same luma.gl `Model` (and its compiled shader) across renders, while still rebuilding it the rare times the shader source actually has to change.

1. **`RasterLayer`** — store the full `{indices, attributes}` mesh wrapper in `state.mesh` and pass it directly to `MeshTextureLayer`, so the reference stays stable across renders.
2. **`MeshTextureLayer`** — override `updateState` to force a Model rebuild when the `renderPipeline` *module list* changes (which the upstream `SimpleMeshLayer` has no way to know about, since it only checks `mesh` and `extensions`).

## Why

`SimpleMeshLayer.updateState` rebuilds its `Model` whenever `props.mesh !== oldProps.mesh` ([reference equality check](https://github.com/visgl/deck.gl/blob/93111b667b919148da06ff1918410cf66381904f/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts#L284)). Before this change, [`RasterLayer.renderLayers()`](https://github.com/developmentseed/deck.gl-raster/blob/3cc97f9/packages/deck.gl-raster/src/raster-layer.ts#L288-L300) built a fresh wrapper object on every render — so every tile sublayer destroyed and recreated its Model every frame, running full `assembleGLSLShaderPair` and vertex-buffer setup per tile per frame.

In the naip-mosaic example, moving the NDVI range slider dropped a single redraw frame to ~120ms in profiles, with `warnIfGLSLUniformBlocksAreNotStd140` (11.5ms) and `extractShaderUniformBlockFieldNames` (9.0ms) dominating self-time — both functions only run inside `assembleGLSLShaderPair`.

## Relation to #543

#543 fixed an upstream churn source (`tileTransform` returning fresh arrow functions every call) and ended the constant `_generateMesh` re-runs in `RasterLayer`. That was sufficient for scenarios where the changing prop didn't propagate to `RasterLayer`'s `renderPipeline` (e.g. the `debug` overlay toggle tested there). It's **not** sufficient when the changing prop is `renderPipeline` itself — which is the common case for any interactive uniform (sliders, color pickers, etc.). The mesh wrapper is still rebuilt in `renderLayers()` for those, and the Model still churns. This PR closes that gap.

## Why the mesh-only fix wasn't enough

The first iteration of this PR (`18f32ca`) only stabilized the mesh reference. That broke render-mode switching: with the Model preserved, the shader source froze at whatever `renderPipeline` was active when the Model was first built. Switching `renderMode: trueColor → ndvi` in the naip-mosaic example produced new modules in `renderPipeline`, but the GPU silently kept running the original RGB shader.

The second commit fixes this in `MeshTextureLayer.updateState`: it compares old vs. new module identities (plus `image` presence) and forces a single Model rebuild when they differ. Prop-only changes within the same module list — the slider case — skip the rebuild and update uniforms via `shaderInputs.setProps` in `draw()`.

## Verified

In the naip-mosaic example:

- **NDVI slider** (same module list, different uniform values): no Model rebuilds. Frame cost drops to roughly uniform-update + redraw. Slider feels instantaneous.
- **Render-mode switch** (different module list): one Model rebuild per visible tile, at the moment of the switch. Imagery updates correctly. No per-frame cost after.
- **Initial tile load**: one Model build per tile, as before.

## Test plan

- [x] Unit test asserts `state.mesh` reference is stable across renders when mesh-affecting props haven't changed (`0d21f83`)
- [x] Typecheck + 96 existing unit tests passing
- [x] End-to-end functional check in naip-mosaic: slider and mode-switch both work
- [x] Profile-driven verification in naip-mosaic: ~120ms frame → instant slider
- [ ] Add unit test for `MeshTextureLayer` module-list-change rebuild path
- [ ] Verify no visual regression in `usgs-topo-cutline` example
- [ ] Investigate the `DECKGL_FILTER_COLOR` shader compile error previously seen in usgs-topo (likely orthogonal — that error was bisected as preexisting in initial testing of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)