### PR TITLE
perf(raster-tileset): Reduce re-renders of RasterLayer for same per-tile transforms

### DIFF
--- a/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+++ b/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
@@ -380,12 +380,13 @@ export class RasterTileLayer<
       return debugLayers;
     }
 
-    const { x, y, z } = tile.index;
-    const level = descriptor.levels[z];
-    if (!level) {
-      return debugLayers;
-    }
-    const { forwardTransform, inverseTransform } = level.tileTransform(x, y);
+    // `forwardTransform`/`inverseTransform` come from the tile metadata that
+    // `RasterTileset2D.getTileMetadata` attaches at tile-creation time. Reading
+    // them off the tile gives us reference-stable functions across renders,
+    // which `RasterLayer`'s `reprojectionFnsChanged` check needs to avoid
+    // unnecessary `_generateMesh` calls (and the downstream Model rebuild that
+    // follows).
+    const { forwardTransform, inverseTransform } = tile;
     const tileResult = renderTile(props.data);
     if (!tileResult) {
       return debugLayers;

--- a/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+++ b/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
@@ -380,12 +380,8 @@ export class RasterTileLayer<
       return debugLayers;
     }
 
-    // `forwardTransform`/`inverseTransform` come from the tile metadata that
-    // `RasterTileset2D.getTileMetadata` attaches at tile-creation time. Reading
-    // them off the tile gives us reference-stable functions across renders,
-    // which `RasterLayer`'s `reprojectionFnsChanged` check needs to avoid
-    // unnecessary `_generateMesh` calls (and the downstream Model rebuild that
-    // follows).
+    // Access forwardTransform/inverseTransform from tile metadata so that
+    // reference equality holds across renders.
     const { forwardTransform, inverseTransform } = tile;
     const tileResult = renderTile(props.data);
     if (!tileResult) {

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
@@ -58,17 +58,20 @@ export type TileMetadata = {
   tileHeight: number;
 
   /**
-   * Forward (tile-local pixel → CRS) transform for this tile. Stable across
-   * the tile's lifetime; computed once at tile creation. Stored on the tile
-   * so downstream layers (e.g. `RasterTileLayer._renderSubLayers`) receive a
-   * reference-stable function across renders, which is what `RasterLayer`'s
-   * `reprojectionFnsChanged` check needs to avoid spurious mesh regeneration.
+   * Forward (tile-local pixel → CRS) transform for this tile.
+   *
+   * Stable across the tile's lifetime; computed once at tile creation. Stored
+   * on the tile so downstream layers (e.g. `RasterTileLayer._renderSubLayers`)
+   * receive a reference-stable function across renders, which is what
+   * `RasterLayer`'s `reprojectionFnsChanged` check needs to avoid spurious mesh
+   * regeneration.
    */
   forwardTransform: ProjectionFunction;
 
   /**
-   * Inverse (CRS → tile-local pixel) transform. Same stability guarantees as
-   * {@link TileMetadata.forwardTransform}.
+   * Inverse (CRS → tile-local pixel) transform.
+   *
+   * Same stability guarantees as {@link TileMetadata.forwardTransform}.
    */
   inverseTransform: ProjectionFunction;
 };

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
@@ -21,6 +21,7 @@ import type {
   Bounds,
   Corners,
   ProjectedBoundingBox,
+  ProjectionFunction,
   TileIndex,
   ZRange,
 } from "./types.js";
@@ -55,6 +56,21 @@ export type TileMetadata = {
    * Tile height in pixels.
    */
   tileHeight: number;
+
+  /**
+   * Forward (tile-local pixel → CRS) transform for this tile. Stable across
+   * the tile's lifetime; computed once at tile creation. Stored on the tile
+   * so downstream layers (e.g. `RasterTileLayer._renderSubLayers`) receive a
+   * reference-stable function across renders, which is what `RasterLayer`'s
+   * `reprojectionFnsChanged` check needs to avoid spurious mesh regeneration.
+   */
+  forwardTransform: ProjectionFunction;
+
+  /**
+   * Inverse (CRS → tile-local pixel) transform. Same stability guarantees as
+   * {@link TileMetadata.forwardTransform}.
+   */
+  inverseTransform: ProjectionFunction;
 };
 
 /**
@@ -253,6 +269,9 @@ export class RasterTileset2D extends Tileset2D {
       ...projectedBounds,
     );
 
+    const { forwardTransform, inverseTransform } =
+      levelDescriptor.tileTransform(x, y);
+
     return {
       bbox: {
         west,
@@ -269,6 +288,8 @@ export class RasterTileset2D extends Tileset2D {
       projectedCorners,
       tileWidth,
       tileHeight,
+      forwardTransform,
+      inverseTransform,
     };
   }
 }

--- a/packages/deck.gl-raster/tests/raster-tileset/raster-tileset-2d-tile-transform.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/raster-tileset-2d-tile-transform.test.ts
@@ -1,0 +1,53 @@
+import type { _Tileset2DProps as Tileset2DProps } from "@deck.gl/geo-layers";
+import { compose, scale, translation } from "@developmentseed/affine";
+import { describe, expect, it } from "vitest";
+import { AffineTileset } from "../../src/raster-tileset/affine-tileset.js";
+import { AffineTilesetLevel } from "../../src/raster-tileset/affine-tileset-level.js";
+import { RasterTileset2D } from "../../src/raster-tileset/raster-tileset-2d.js";
+
+const identity = (x: number, y: number): [number, number] => [x, y];
+
+const PROJECTIONS = {
+  projectTo3857: identity,
+  projectFrom3857: identity,
+  projectTo4326: identity,
+  projectFrom4326: identity,
+};
+
+function tilesetProps(): Tileset2DProps {
+  return { getTileData: () => new Promise(() => {}) } as Tileset2DProps;
+}
+
+describe("RasterTileset2D.getTileMetadata", () => {
+  it("attaches per-tile forwardTransform/inverseTransform to TileMetadata", () => {
+    const level = new AffineTilesetLevel({
+      affine: compose(translation(100, 200), scale(10, -10)),
+      arrayWidth: 8,
+      arrayHeight: 8,
+      tileWidth: 4,
+      tileHeight: 4,
+      mpu: 1,
+    });
+    const descriptor = new AffineTileset({
+      levels: [level],
+      ...PROJECTIONS,
+    });
+    const tileset = new RasterTileset2D(tilesetProps(), descriptor);
+
+    const metadata = tileset.getTileMetadata({ x: 1, y: 1, z: 0 });
+
+    expect(typeof metadata.forwardTransform).toBe("function");
+    expect(typeof metadata.inverseTransform).toBe("function");
+
+    // Tile (1,1) at pixel (0,0) should map to the CRS origin of that tile.
+    // Tile is 4x4 pixels at 10 CRS units/pixel from origin (100, 200), Y flipped.
+    const [x, y] = metadata.forwardTransform(0, 0);
+    expect(x).toBeCloseTo(140, 10);
+    expect(y).toBeCloseTo(160, 10);
+
+    // Round-trip via inverseTransform.
+    const [px, py] = metadata.inverseTransform(x, y);
+    expect(px).toBeCloseTo(0, 10);
+    expect(py).toBeCloseTo(0, 10);
+  });
+});


### PR DESCRIPTION
I validated by hand with some console.log statements that this avoids the recreation of the MeshLayer model for the raster layer for each tile, at least in the cog-basic example when toggling the debug layer. 

I think the core issue was that with new arrow functions, every change to the tile would cause a new re-render of the RasterLayer.

----

## Summary

Compute each tile's `forwardTransform` / `inverseTransform` once at tile construction (inside `RasterTileset2D.getTileMetadata`) and attach them to the tile's `TileMetadata`. `RasterTileLayer._renderSubLayers` reads them off the tile instead of recomputing on every render.

## Why

Before this change, every call to `level.tileTransform(col, row)` constructed two fresh arrow functions:

```ts
return {
  forwardTransform: (x, y) => affine.apply(tileAffine, x, y),
  inverseTransform: (x, y) => affine.apply(invTileAffine, x, y),
};
```

[`RasterTileLayer._renderSubLayers`](https://github.com/developmentseed/deck.gl-raster/blob/3cc97f9/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts#L388) calls this on every render for every visible tile, so the references churned constantly. That instability tripped `reprojectionFnsChanged` in [`RasterLayer.updateState`](https://github.com/developmentseed/deck.gl-raster/blob/3cc97f9/packages/deck.gl-raster/src/raster-layer.ts#L154), which re-ran `_generateMesh`, which produced a fresh `state.mesh` wrapper, which tripped `props.mesh !== oldProps.mesh` in [`SimpleMeshLayer.updateState`](https://github.com/visgl/deck.gl/blob/93111b667b919148da06ff1918410cf66381904f/modules/mesh-layers/src/simple-mesh-layer/simple-mesh-layer.ts#L284), which destroyed and rebuilt the GPU `Model` — incurring full shader assembly (`assembleGLSLShaderPair`, `extractShaderUniformBlockFieldNames`, etc.) per tile per render.

In a usgs-topo mosaic with ~411 active tile sublayers, this dominated frame time during any layer prop change (e.g. toggling a debug overlay).

## Why tile-attached vs. level-cached

Earlier draft of this PR cached `tileTransform(col, row)` on the level itself. That worked, but the cache had no eviction — entries accumulated for every `(col, row)` ever queried across the level's lifetime.

Attaching to `TileMetadata` instead gives correct lifetime semantics for free:

- Tile is constructed by `TileLayer` → `getTileMetadata` runs once → transforms computed once
- While the tile is in `TileLayer`'s cache, every render reads the same references off the tile
- When the tile is evicted from `TileLayer`'s cache, the transforms go with it
- Cache size is automatically bounded by `TileLayer.maxCacheSize` — no separate growth concern

Transforms are also co-located with the `(x, y, z)` identity that defines them, which is conceptually cleaner.

## Verified

In `cog-basic` with diagnostic logs in place: toggling the debug overlay used to fire `RasterLayer._generateMesh` and `MeshTextureLayer.getShaders` once per tile per toggle. With this change, neither fires — only `RasterLayer.renderLayers` runs, and it's cheap because it just reads stable references off the tile.

## Test plan

- [x] Unit test asserts `RasterTileset2D.getTileMetadata` attaches functioning `forwardTransform` / `inverseTransform` to the metadata
- [x] Existing tile-transform behavior tests still pass (94 / 94)
- [ ] Visual regression check in `usgs-topo-cutline` example
- [ ] Profile-driven verification in a real mosaic app (usgs-topo)

## Supersedes

Replaces #540 (mesh-shape refactor in `RasterLayer`), which was treating a symptom of this same instability. #540 should be closed in favor of this PR. #541 (shader-assembler memoization) becomes optional defensive caching with this fix in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)