### PR TITLE
feat: Expose onTile callbacks through raster tile layers

### DIFF
--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
@@ -54,6 +54,23 @@ export type MosaicLayerProps<
         signal?: AbortSignal;
       },
     ) => Layer | LayersList | null;
+
+    /**
+     * Called after a source's data has loaded successfully. `data` is the
+     * value returned by `getSource`, or `undefined` when no `getSource` was
+     * supplied.
+     */
+    onSourceLoad?: (source: MosaicT, info: { data?: DataT }) => void;
+
+    /**
+     * Called when fetching a source's data fails.
+     */
+    onSourceError?: (source: MosaicT, info: { error: Error }) => void;
+
+    /**
+     * Called when a source is evicted from the tile cache.
+     */
+    onSourceUnload?: (source: MosaicT, info: { data?: DataT }) => void;
   };
 
 const defaultProps: Partial<MosaicLayerProps> = {};
@@ -83,6 +100,9 @@ export class MosaicLayer<
       maxCacheByteSize,
       maxCacheSize,
       maxRequests,
+      onSourceLoad,
+      onSourceError,
+      onSourceUnload,
     } = this.props;
 
     // The arrow function is defined here so its lexical `this` is the
@@ -130,6 +150,30 @@ export class MosaicLayer<
         const { source, signal, data: userData } = data;
         return renderSource(source, { data: userData, signal });
       },
+      ...(onSourceLoad && {
+        onTileLoad: (tile) => {
+          // `tile.index` is a `ResolvedSource<MosaicT>` from
+          // MosaicTileset2D.getTileIndices, which structurally extends
+          // MosaicT.
+          const source = tile.index as unknown as MosaicT;
+          onSourceLoad(source, { data: tile.content?.data });
+        },
+      }),
+      ...(onSourceError && {
+        onTileError: (error, tile) => {
+          if (!tile) {
+            return;
+          }
+          const source = tile.index as unknown as MosaicT;
+          onSourceError(source, { error });
+        },
+      }),
+      ...(onSourceUnload && {
+        onTileUnload: (tile) => {
+          const source = tile.index as unknown as MosaicT;
+          onSourceUnload(source, { data: tile.content?.data });
+        },
+      }),
     });
   }
 

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
@@ -11,12 +11,13 @@ export type MosaicLayerProps<
 > = CompositeLayerProps &
   Pick<
     TileLayerProps,
+    | "debounceTime"
     | "extent"
-    | "minZoom"
-    | "maxZoom"
     | "maxCacheByteSize"
     | "maxCacheSize"
     | "maxRequests"
+    | "maxZoom"
+    | "minZoom"
   > & {
     /**
      * List of mosaic sources to render.
@@ -77,6 +78,7 @@ export class MosaicLayer<
       id,
       minZoom,
       maxZoom,
+      debounceTime,
       extent,
       maxCacheByteSize,
       maxCacheSize,
@@ -102,6 +104,7 @@ export class MosaicLayer<
       TilesetClass: MosaicTileset2DFactory,
       minZoom,
       maxZoom,
+      debounceTime,
       extent,
       ...(maxCacheByteSize !== undefined && { maxCacheByteSize }),
       maxCacheSize,

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
@@ -71,6 +71,14 @@ export type MosaicLayerProps<
      * Called when a source is evicted from the tile cache.
      */
     onSourceUnload?: (source: MosaicT, info: { data?: DataT }) => void;
+
+    /**
+     * Called when all sources currently in the viewport have finished
+     * loading.
+     */
+    onViewportLoad?: (
+      entries: Array<{ source: MosaicT; data?: DataT }>,
+    ) => void;
   };
 
 const defaultProps: Partial<MosaicLayerProps> = {};
@@ -103,6 +111,7 @@ export class MosaicLayer<
       onSourceLoad,
       onSourceError,
       onSourceUnload,
+      onViewportLoad,
     } = this.props;
 
     // The arrow function is defined here so its lexical `this` is the
@@ -172,6 +181,16 @@ export class MosaicLayer<
         onTileUnload: (tile) => {
           const source = tile.index as unknown as MosaicT;
           onSourceUnload(source, { data: tile.content?.data });
+        },
+      }),
+      ...(onViewportLoad && {
+        onViewportLoad: (tiles) => {
+          onViewportLoad(
+            tiles.map((tile) => ({
+              source: tile.index as unknown as MosaicT,
+              data: tile.content?.data,
+            })),
+          );
         },
       }),
     });

--- a/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+++ b/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
@@ -64,16 +64,20 @@ export type RasterTileLayerProps<
 > = CompositeLayerProps &
   Pick<
     TileLayerProps,
-    | "tileSize"
-    | "zoomOffset"
+    | "debounceTime"
+    | "extent"
+    | "maxCacheByteSize"
+    | "maxCacheSize"
+    | "maxRequests"
     | "maxZoom"
     | "minZoom"
-    | "extent"
-    | "debounceTime"
-    | "maxCacheSize"
-    | "maxCacheByteSize"
-    | "maxRequests"
+    | "onTileError"
+    | "onTileLoad"
+    | "onTileUnload"
+    | "onViewportLoad"
     | "refinementStrategy"
+    | "tileSize"
+    | "zoomOffset"
   > & {
     /**
      * Tile pyramid + CRS projection descriptor.
@@ -309,6 +313,10 @@ export class RasterTileLayer<
       maxRequests,
       refinementStrategy,
       updateTriggers,
+      onTileError,
+      onTileLoad,
+      onTileUnload,
+      onViewportLoad,
     } = this.props;
 
     return new TileLayer<DataT>({
@@ -339,6 +347,10 @@ export class RasterTileLayer<
       maxCacheByteSize,
       maxRequests,
       refinementStrategy,
+      onTileError,
+      onTileLoad,
+      onTileUnload,
+      onViewportLoad,
     });
   }
 

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
@@ -26,7 +26,7 @@ import type {
   ZRange,
 } from "./types.js";
 
-/** Type returned by `getTileMetadata` */
+/** Type returned by {@link RasterTileset2D.getTileMetadata} */
 export type TileMetadata = {
   /**
    * **Axis-aligned** bounding box of the tile in **WGS84 coordinates**.


### PR DESCRIPTION
Add more props to RasterTileLayer (and thus also COGLayer and ZarrLayer)

- onTileLoad
- onTileUnload
- onTileError
- onViewportLoad

Also add props to MosaicLayer:

- onSourceLoad
- onSourceUnload
- onSourceError
- onViewportLoad

In the case of the MosaicLayer, it's just an implementation detail that it's a TileLayer under the hood, so we use the term `source` consistently.