### PR TITLE
chore!: Rename TilesetDescriptor to RasterTilesetDescriptor

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -112,7 +112,9 @@ const crossPackageLinks: Record<string, Record<string, string>> = {
     RasterTileLayer: `${BASE_DECK_GL_RASTER}/classes/RasterTileLayer/`,
     RasterTileLayerProps: `${BASE_DECK_GL_RASTER}/type-aliases/RasterTileLayerProps/`,
     RenderTileResult: `${BASE_DECK_GL_RASTER}/type-aliases/RenderTileResult/`,
-    TilesetDescriptor: `${BASE_DECK_GL_RASTER}/interfaces/TilesetDescriptor/`,
+    RasterTilesetDescriptor: `${BASE_DECK_GL_RASTER}/interfaces/RasterTilesetDescriptor/`,
+    RasterTileMetadata: `${BASE_DECK_GL_RASTER}/type-aliases/RasterTileMetadata/`,
+    RasterTilesetLevel: `${BASE_DECK_GL_RASTER}/interfaces/RasterTilesetLevel/`,
   },
   "@developmentseed/deck.gl-raster/gpu-modules": {
     BlackIsZero: `${BASE_DECK_GL_RASTER_GPU_MODULES}/variables/BlackIsZero/`,

--- a/packages/deck.gl-geotiff/src/cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/cog-layer.ts
@@ -3,8 +3,8 @@ import type {
   MinimalTileData,
   GetTileDataOptions as RasterTileGetTileDataOptions,
   RasterTileLayerProps,
+  RasterTilesetDescriptor,
   RenderTileResult,
-  TilesetDescriptor,
 } from "@developmentseed/deck.gl-raster";
 import { RasterTileLayer } from "@developmentseed/deck.gl-raster";
 import type { DecoderPool, GeoTIFF, Overview } from "@developmentseed/geotiff";
@@ -154,7 +154,7 @@ export class COGLayer<
 
   declare state: {
     geotiff?: GeoTIFF;
-    tilesetDescriptor?: TilesetDescriptor;
+    tilesetDescriptor?: RasterTilesetDescriptor;
     defaultGetTileData?: COGLayerProps<TextureDataT>["getTileData"];
     defaultRenderTile?: COGLayerProps<TextureDataT>["renderTile"];
   };

--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -12,16 +12,16 @@ import { PathLayer, TextLayer } from "@deck.gl/layers";
 import type {
   Corners,
   GetTileDataOptions,
-  MultiTilesetDescriptor,
+  MultiRasterTilesetDescriptor,
   ProjectionFunction,
   RasterModule,
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
   RenderTileResult,
-  TilesetDescriptor,
-  TilesetLevel,
   UvTransform,
 } from "@developmentseed/deck.gl-raster";
 import {
-  createMultiTilesetDescriptor,
+  createMultiRasterTilesetDescriptor,
   RasterTileLayer,
   resolveSecondaryTiles,
   selectSecondaryLevel,
@@ -211,7 +211,7 @@ export type MultiCOGLayerProps = CompositeLayerProps &
 
     /**
      * Called once all configured sources have been opened and the
-     * {@link MultiTilesetDescriptor} has been built.
+     * {@link MultiRasterTilesetDescriptor} has been built.
      *
      * `geographicBounds` is computed from the primary (finest-resolution)
      * source and reprojected to WGS84; it matches the shape returned by
@@ -267,15 +267,15 @@ const defaultProps = {
 
 /**
  * A deck.gl {@link CompositeLayer} that opens multiple Cloud-Optimized GeoTIFFs
- * (COGs) in parallel, builds a {@link TilesetDescriptor} for each, and groups
- * them into a single {@link MultiTilesetDescriptor}.
+ * (COGs) in parallel, builds a {@link RasterTilesetDescriptor} for each, and groups
+ * them into a single {@link MultiRasterTilesetDescriptor}.
  *
  * The finest-resolution source is automatically selected as the primary
  * tileset, which drives the tile grid. Secondary sources are sampled at the
  * closest matching resolution.
  *
  * @see {@link MultiCOGLayerProps} for accepted props.
- * @see {@link createMultiTilesetDescriptor} for the grouping logic.
+ * @see {@link createMultiRasterTilesetDescriptor} for the grouping logic.
  * @see {@link geoTiffToDescriptor} for the per-source tileset descriptor.
  */
 export class MultiCOGLayer extends RasterTileLayer<
@@ -291,7 +291,7 @@ export class MultiCOGLayer extends RasterTileLayer<
 
   declare state: {
     sources: Map<string, SourceState> | null;
-    multiDescriptor: MultiTilesetDescriptor | null;
+    multiDescriptor: MultiRasterTilesetDescriptor | null;
   };
 
   override initializeState(): void {
@@ -320,7 +320,7 @@ export class MultiCOGLayer extends RasterTileLayer<
 
   /**
    * Open all configured COG sources in parallel, compute shared projection
-   * functions, and build the {@link MultiTilesetDescriptor}.
+   * functions, and build the {@link MultiRasterTilesetDescriptor}.
    *
    * All sources are assumed to share the same CRS; the projection of the
    * first source is used for the shared coordinate converters.
@@ -379,7 +379,7 @@ export class MultiCOGLayer extends RasterTileLayer<
     });
 
     // Build TilesetDescriptors
-    const tilesetMap = new Map<string, TilesetDescriptor>();
+    const tilesetMap = new Map<string, RasterTilesetDescriptor>();
     const sourceMap = new Map<string, SourceState>();
 
     for (const cogSource of cogSources) {
@@ -394,7 +394,7 @@ export class MultiCOGLayer extends RasterTileLayer<
       sourceMap.set(cogSource.name, { geotiff: cogSource.geotiff });
     }
 
-    const multiDescriptor = createMultiTilesetDescriptor(tilesetMap);
+    const multiDescriptor = createMultiRasterTilesetDescriptor(tilesetMap);
 
     this.setState({
       sources: sourceMap,
@@ -523,7 +523,7 @@ export class MultiCOGLayer extends RasterTileLayer<
     };
   }
 
-  protected override _tilesetDescriptor(): TilesetDescriptor | undefined {
+  protected override _tilesetDescriptor(): RasterTilesetDescriptor | undefined {
     return this.state.multiDescriptor?.primary;
   }
 
@@ -660,8 +660,8 @@ export class MultiCOGLayer extends RasterTileLayer<
     name: string,
     sourceState: SourceState,
     opts: {
-      descriptor: TilesetDescriptor;
-      primaryLevel: TilesetLevel;
+      descriptor: RasterTilesetDescriptor;
+      primaryLevel: RasterTilesetLevel;
       primaryCol: number;
       primaryRow: number;
       primaryZ: number;

--- a/packages/deck.gl-raster/src/index.ts
+++ b/packages/deck.gl-raster/src/index.ts
@@ -2,13 +2,13 @@ export type { RasterModule } from "./gpu-modules/types.js";
 // Not a public API; exported for use in COGLayer and ZarrLayer
 export { renderDebugTileOutline as _renderDebugTileOutline } from "./layer-utils.js";
 export type {
-  MultiTilesetDescriptor,
+  MultiRasterTilesetDescriptor,
   SecondaryTileIndex,
   SecondaryTileResolution,
   UvTransform,
 } from "./multi-raster-tileset/index.js";
 export {
-  createMultiTilesetDescriptor,
+  createMultiRasterTilesetDescriptor,
   resolveSecondaryTiles,
   selectSecondaryLevel,
   tilesetLevelsEqual,
@@ -28,9 +28,9 @@ export type {
   CornerBounds,
   Corners,
   ProjectionFunction,
-  TileMetadata,
-  TilesetDescriptor,
-  TilesetLevel,
+  RasterTileMetadata,
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
 } from "./raster-tileset/index.js";
 export {
   AffineTileset,

--- a/packages/deck.gl-raster/src/layer-utils.ts
+++ b/packages/deck.gl-raster/src/layer-utils.ts
@@ -1,11 +1,11 @@
 import type { _Tile2DHeader as Tile2DHeader } from "@deck.gl/geo-layers";
 import { PathLayer, TextLayer } from "@deck.gl/layers";
 import type { ReprojectionFns } from "@developmentseed/raster-reproject";
-import type { TileMetadata } from "./raster-tileset/index.js";
+import type { RasterTileMetadata } from "./raster-tileset/index.js";
 
 export function renderDebugTileOutline(
   id: string,
-  tile: Tile2DHeader & TileMetadata,
+  tile: Tile2DHeader & RasterTileMetadata,
   forwardTo4326: ReprojectionFns["forwardReproject"],
 ) {
   const { projectedCorners } = tile;

--- a/packages/deck.gl-raster/src/multi-raster-tileset/index.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/index.ts
@@ -1,9 +1,9 @@
 export type {
-  MultiTilesetDescriptor,
+  MultiRasterTilesetDescriptor,
   SecondaryLevelStrategy,
 } from "./multi-tileset-descriptor.js";
 export {
-  createMultiTilesetDescriptor,
+  createMultiRasterTilesetDescriptor,
   selectSecondaryLevel,
   tilesetLevelsEqual,
 } from "./multi-tileset-descriptor.js";

--- a/packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/multi-tileset-descriptor.ts
@@ -1,27 +1,27 @@
 import type {
-  TilesetDescriptor,
-  TilesetLevel,
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
 } from "../raster-tileset/tileset-interface.js";
 import type { Bounds, ProjectionFunction } from "../raster-tileset/types.js";
 
 /**
- * Groups N {@link TilesetDescriptor}s representing the same geographic extent
+ * Groups N {@link RasterTilesetDescriptor}s representing the same geographic extent
  * at different native resolutions.
  *
  * The {@link primary} tileset (finest resolution) drives tile traversal;
  * {@link secondaries} are consulted at fetch time to resolve covering tiles
  * and compute UV transforms.
  *
- * @see {@link createMultiTilesetDescriptor} to construct from a named map of tilesets
+ * @see {@link createMultiRasterTilesetDescriptor} to construct from a named map of tilesets
  */
-export interface MultiTilesetDescriptor {
+export interface MultiRasterTilesetDescriptor {
   /** Highest-resolution tileset — drives tile traversal. */
-  primary: TilesetDescriptor;
-  /** The key under which the primary was provided to {@link createMultiTilesetDescriptor}. */
+  primary: RasterTilesetDescriptor;
+  /** The key under which the primary was provided to {@link createMultiRasterTilesetDescriptor}. */
   primaryKey: string;
   /** Lower-resolution tilesets, keyed by user-defined name. */
-  secondaries: Map<string, TilesetDescriptor>;
-  /** Shared CRS bounds (from primary's {@link TilesetDescriptor.projectedBounds}). */
+  secondaries: Map<string, RasterTilesetDescriptor>;
+  /** Shared CRS bounds (from primary's {@link RasterTilesetDescriptor.projectedBounds}). */
   bounds: Bounds;
   /** Shared projection: source CRS -> EPSG:3857. */
   projectTo3857: ProjectionFunction;
@@ -30,18 +30,18 @@ export interface MultiTilesetDescriptor {
 }
 
 /**
- * Create a {@link MultiTilesetDescriptor} from a map of named tilesets.
+ * Create a {@link MultiRasterTilesetDescriptor} from a map of named tilesets.
  *
  * Automatically selects the tileset with the finest
- * {@link TilesetLevel.metersPerPixel} at its highest-resolution level as the
+ * {@link RasterTilesetLevel.metersPerPixel} at its highest-resolution level as the
  * primary. All others become secondaries.
  *
  * @param tilesets - Named tilesets, e.g. `new Map([["B04", band10m], ["B11", band20m]])`
  * @throws If `tilesets` is empty
  */
-export function createMultiTilesetDescriptor(
-  tilesets: Map<string, TilesetDescriptor>,
-): MultiTilesetDescriptor {
+export function createMultiRasterTilesetDescriptor(
+  tilesets: Map<string, RasterTilesetDescriptor>,
+): MultiRasterTilesetDescriptor {
   if (tilesets.size === 0) {
     throw new Error("At least one tileset is required");
   }
@@ -55,7 +55,7 @@ export function createMultiTilesetDescriptor(
     }
   }
   const primary = tilesets.get(primaryKey!)!;
-  const secondaries = new Map<string, TilesetDescriptor>();
+  const secondaries = new Map<string, RasterTilesetDescriptor>();
   for (const [key, descriptor] of tilesets) {
     if (key !== primaryKey) {
       secondaries.set(key, descriptor);
@@ -85,28 +85,28 @@ export function createMultiTilesetDescriptor(
 export type SecondaryLevelStrategy = "closest" | "closest-finer";
 
 /**
- * Select the best {@link TilesetLevel} from a secondary tileset for a given
- * primary {@link TilesetLevel.metersPerPixel}.
+ * Select the best {@link RasterTilesetLevel} from a secondary tileset for a given
+ * primary {@link RasterTilesetLevel.metersPerPixel}.
  *
  * @param levels - Ordered coarsest-first (index 0 = coarsest), matching
- *   {@link TilesetDescriptor.levels} convention
+ *   {@link RasterTilesetDescriptor.levels} convention
  * @param primaryMetersPerPixel - The `metersPerPixel` of the current primary
  *   tile's zoom level
  * @param strategy - Selection strategy. Defaults to `"closest-finer"`.
- * @returns The selected {@link TilesetLevel}
+ * @returns The selected {@link RasterTilesetLevel}
  *
  * @see {@link SecondaryLevelStrategy} for available strategies
  */
 export function selectSecondaryLevel(
-  levels: TilesetLevel[],
+  levels: RasterTilesetLevel[],
   primaryMetersPerPixel: number,
   strategy: SecondaryLevelStrategy = "closest-finer",
-): TilesetLevel {
+): RasterTilesetLevel {
   if (strategy === "closest-finer") {
     // Among levels that are finer-or-equal to the primary, pick the closest
     // (coarsest of the finer-or-equal set). Walk from coarsest to finest,
     // tracking the last level that's <= primary.
-    let bestFiner: TilesetLevel | null = null;
+    let bestFiner: RasterTilesetLevel | null = null;
     for (let i = 0; i < levels.length; i++) {
       if (levels[i]!.metersPerPixel <= primaryMetersPerPixel) {
         bestFiner = levels[i]!;
@@ -131,16 +131,19 @@ export function selectSecondaryLevel(
 }
 
 /**
- * Check if two {@link TilesetLevel}s have the same grid parameters.
+ * Check if two {@link RasterTilesetLevel}s have the same grid parameters.
  *
  * Used to detect when sources share a tile grid and can skip UV transform
  * computation (e.g., all 10m Sentinel-2 bands share the same grid).
  *
- * Compares {@link TilesetLevel.matrixWidth}, {@link TilesetLevel.matrixHeight},
- * {@link TilesetLevel.tileWidth}, {@link TilesetLevel.tileHeight}, and
- * {@link TilesetLevel.metersPerPixel}.
+ * Compares {@link RasterTilesetLevel.matrixWidth}, {@link RasterTilesetLevel.matrixHeight},
+ * {@link RasterTilesetLevel.tileWidth}, {@link RasterTilesetLevel.tileHeight}, and
+ * {@link RasterTilesetLevel.metersPerPixel}.
  */
-export function tilesetLevelsEqual(a: TilesetLevel, b: TilesetLevel): boolean {
+export function tilesetLevelsEqual(
+  a: RasterTilesetLevel,
+  b: RasterTilesetLevel,
+): boolean {
   return (
     a.matrixWidth === b.matrixWidth &&
     a.matrixHeight === b.matrixHeight &&

--- a/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
+++ b/packages/deck.gl-raster/src/multi-raster-tileset/secondary-tile-resolver.ts
@@ -1,4 +1,4 @@
-import type { TilesetLevel } from "../raster-tileset/tileset-interface.js";
+import type { RasterTilesetLevel } from "../raster-tileset/tileset-interface.js";
 
 /**
  * UV transform mapping primary tile UV space to the correct sub-region of a
@@ -124,10 +124,10 @@ export interface SecondaryTileResolution {
  * upward (north), so `offsetY` is computed as
  * `(stitchedMaxY - primaryMaxY) / stitchedCrsHeight` to account for the flip.
  *
- * @param primaryLevel - The {@link TilesetLevel} describing the primary tileset.
+ * @param primaryLevel - The {@link RasterTilesetLevel} describing the primary tileset.
  * @param primaryCol - Column index of the primary tile.
  * @param primaryRow - Row index of the primary tile.
- * @param secondaryLevel - The {@link TilesetLevel} describing the secondary tileset.
+ * @param secondaryLevel - The {@link RasterTilesetLevel} describing the secondary tileset.
  * @param secondaryZ - The zoom level index of `secondaryLevel` within its
  *   {@link TilesetDescriptor.levels} array. Stored in the returned
  *   {@link SecondaryTileResolution.z} so the consumer knows which COG overview
@@ -136,10 +136,10 @@ export interface SecondaryTileResolution {
  *   stitched dimensions, and the min col/row of the covered range.
  */
 export function resolveSecondaryTiles(
-  primaryLevel: TilesetLevel,
+  primaryLevel: RasterTilesetLevel,
   primaryCol: number,
   primaryRow: number,
-  secondaryLevel: TilesetLevel,
+  secondaryLevel: RasterTilesetLevel,
   secondaryZ: number,
 ): SecondaryTileResolution {
   // Step 1: Get the CRS extent of the primary tile

--- a/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+++ b/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
@@ -17,9 +17,9 @@ import type { Device } from "@luma.gl/core";
 import { renderDebugTileOutline } from "../layer-utils.js";
 import type { RenderTileResult } from "../raster-layer.js";
 import { RasterLayer } from "../raster-layer.js";
-import type { TilesetDescriptor } from "../raster-tileset/index.js";
+import type { RasterTilesetDescriptor } from "../raster-tileset/index.js";
 import { RasterTileset2D } from "../raster-tileset/index.js";
-import type { TileMetadata } from "../raster-tileset/raster-tileset-2d.js";
+import type { RasterTileMetadata } from "../raster-tileset/raster-tileset-2d.js";
 import { TILE_SIZE, WEB_MERCATOR_TO_WORLD_SCALE } from "./constants.js";
 
 /**
@@ -85,7 +85,7 @@ export type RasterTileLayerProps<
      * Subclasses may supply this via state by overriding the protected
      * `_tilesetDescriptor()` method.
      */
-    tilesetDescriptor?: TilesetDescriptor;
+    tilesetDescriptor?: RasterTilesetDescriptor;
 
     /**
      * Load data for one tile. Runs once per (x, y, z); the resulting `DataT`
@@ -169,7 +169,7 @@ type RasterTileLayerDefaultExtraProps<DataT extends MinimalTileData> = Pick<
 
 /**
  * Base layer that renders a tiled raster source driven by a generic
- * {@link TilesetDescriptor}.
+ * {@link RasterTilesetDescriptor}.
  *
  * Usable directly (provide `tilesetDescriptor`, `getTileData`, and `renderTile`
  * as props) or as a base class (override the protected `_tilesetDescriptor`,
@@ -188,7 +188,7 @@ export class RasterTileLayer<
   static override defaultProps = defaultProps;
 
   /**
-   * The currently effective {@link TilesetDescriptor}.
+   * The currently effective {@link RasterTilesetDescriptor}.
    *
    * Subclasses override this to return a descriptor built from their own
    * async-parsed state. Returns `undefined` while the source is still
@@ -200,7 +200,7 @@ export class RasterTileLayer<
    * brings it in; for subclass use this method is overridden and the cast
    * is never reached.
    */
-  protected _tilesetDescriptor(): TilesetDescriptor | undefined {
+  protected _tilesetDescriptor(): RasterTilesetDescriptor | undefined {
     return (this.props as unknown as RasterTileLayerProps<DataT>)
       .tilesetDescriptor;
   }
@@ -249,12 +249,12 @@ export class RasterTileLayer<
     if (!descriptor) {
       return [];
     }
-    // Tiles built by RasterTileset2D are augmented with TileMetadata
+    // Tiles built by RasterTileset2D are augmented with RasterTileMetadata
     // (projectedBbox/Corners, tileWidth/Height) at construction time. The cast
     // makes that runtime augmentation visible to the typed helper.
     return renderDebugTileOutline(
       `${this.id}-${tile.id}-bounds`,
-      tile as Tile2DHeader<DataT> & TileMetadata,
+      tile as Tile2DHeader<DataT> & RasterTileMetadata,
       descriptor.projectTo4326,
     );
   }
@@ -272,7 +272,7 @@ export class RasterTileLayer<
   }
 
   private _renderTileLayer(
-    descriptor: TilesetDescriptor,
+    descriptor: RasterTilesetDescriptor,
     getTileData: NonNullable<RasterTileLayerProps<DataT>["getTileData"]>,
     renderTile: NonNullable<RasterTileLayerProps<DataT>["renderTile"]>,
   ): TileLayer {
@@ -378,11 +378,11 @@ export class RasterTileLayer<
       _offset: number;
       tile: Tile2DHeader<DataT>;
     },
-    descriptor: TilesetDescriptor,
+    descriptor: RasterTilesetDescriptor,
     renderTile: NonNullable<RasterTileLayerProps<DataT>["renderTile"]>,
   ): Layer[] {
     const { maxError, debug, debugOpacity } = this.props;
-    const tile = props.tile as Tile2DHeader<DataT> & TileMetadata;
+    const tile = props.tile as Tile2DHeader<DataT> & RasterTileMetadata;
 
     const debugLayers = debug
       ? this._renderDebug(tile, props.data ?? null)

--- a/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/affine-tileset-level.ts
@@ -1,6 +1,6 @@
 import type { Affine } from "@developmentseed/affine";
 import * as affine from "@developmentseed/affine";
-import type { TilesetLevel } from "./tileset-interface.js";
+import type { RasterTilesetLevel } from "./tileset-interface.js";
 import type { Bounds, Corners, ProjectionFunction } from "./types.js";
 
 /**
@@ -22,15 +22,15 @@ export interface AffineTilesetLevelOptions {
 }
 
 /**
- * A {@link TilesetLevel} described by a single affine transform plus tile and
+ * A {@link RasterTilesetLevel} described by a single affine transform plus tile and
  * array sizes.
  *
  * This handles axis-aligned, rotated, skewed, and non-square-pixel grids
  * uniformly. Sources that fit this shape (tiled GeoTIFF overviews, GeoZarr
  * multiscales) can construct one of these per resolution level instead of
- * implementing {@link TilesetLevel} manually.
+ * implementing {@link RasterTilesetLevel} manually.
  */
-export class AffineTilesetLevel implements TilesetLevel {
+export class AffineTilesetLevel implements RasterTilesetLevel {
   readonly tileWidth: number;
   readonly tileHeight: number;
   readonly matrixWidth: number;

--- a/packages/deck.gl-raster/src/raster-tileset/affine-tileset.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/affine-tileset.ts
@@ -1,5 +1,5 @@
 import type { AffineTilesetLevel } from "./affine-tileset-level.js";
-import type { TilesetDescriptor } from "./tileset-interface.js";
+import type { RasterTilesetDescriptor } from "./tileset-interface.js";
 import type { Bounds, ProjectionFunction } from "./types.js";
 
 /**
@@ -19,12 +19,12 @@ export interface AffineTilesetOptions {
 }
 
 /**
- * A {@link TilesetDescriptor} backed by per-level affine transforms.
+ * A {@link RasterTilesetDescriptor} backed by per-level affine transforms.
  *
  * Derives `projectedBounds` from the coarsest level's array. Everything else
  * is passed through from the constructor options.
  */
-export class AffineTileset implements TilesetDescriptor {
+export class AffineTileset implements RasterTilesetDescriptor {
   readonly levels: AffineTilesetLevel[];
   readonly projectTo3857: ProjectionFunction;
   readonly projectFrom3857: ProjectionFunction;

--- a/packages/deck.gl-raster/src/raster-tileset/index.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/index.ts
@@ -2,10 +2,13 @@ export type { AffineTilesetOptions } from "./affine-tileset.js";
 export { AffineTileset } from "./affine-tileset.js";
 export type { AffineTilesetLevelOptions } from "./affine-tileset-level.js";
 export { AffineTilesetLevel } from "./affine-tileset-level.js";
-export type { TileMetadata } from "./raster-tileset-2d.js";
+export type { RasterTileMetadata } from "./raster-tileset-2d.js";
 export { RasterTileset2D } from "./raster-tileset-2d.js";
 export { TileMatrixSetAdaptor } from "./tile-matrix-set.js";
-export type { TilesetDescriptor, TilesetLevel } from "./tileset-interface.js";
+export type {
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
+} from "./tileset-interface.js";
 export type {
   Bounds,
   CornerBounds,

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tile-traversal.ts
@@ -13,7 +13,7 @@
  * The result is a set of tiles at varying zoom levels that efficiently
  * cover the visible area with appropriate detail.
  *
- * The traversal is driven by a {@link TilesetDescriptor}, which abstracts over
+ * The traversal is driven by a {@link RasterTilesetDescriptor}, which abstracts over
  * both OGC TileMatrixSet grids and Zarr multiscale pyramids.
  */
 
@@ -29,7 +29,10 @@ import {
 import { lngLatToWorld, worldToLngLat } from "@math.gl/web-mercator";
 
 import { BoundingVolumeCache } from "./bounding-volume-cache.js";
-import type { TilesetDescriptor, TilesetLevel } from "./tileset-interface.js";
+import type {
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
+} from "./tileset-interface.js";
 import type {
   Bounds,
   Corners,
@@ -109,8 +112,8 @@ const MAX_WEB_MERCATOR_LAT = 85.05112877980659;
  *
  * This node class uses the following coordinate system:
  *
- * - x: tile column (0 to TilesetLevel.matrixWidth, left to right)
- * - y: tile row (0 to TilesetLevel.matrixHeight, top to bottom)
+ * - x: tile column (0 to RasterTilesetLevel.matrixWidth, left to right)
+ * - y: tile row (0 to RasterTilesetLevel.matrixHeight, top to bottom)
  * - z: overview level. This assumes ordering where: 0 = coarsest, higher = finer
  */
 export class RasterTileNode {
@@ -123,7 +126,7 @@ export class RasterTileNode {
   /** Zoom index assumed to be (higher = finer detail) */
   z: number;
 
-  private descriptor: TilesetDescriptor;
+  private descriptor: RasterTilesetDescriptor;
 
   /**
    * Flag indicating whether any descendant of this tile is visible.
@@ -147,7 +150,7 @@ export class RasterTileNode {
     x: number,
     y: number,
     z: number,
-    { descriptor }: { descriptor: TilesetDescriptor },
+    { descriptor }: { descriptor: RasterTilesetDescriptor },
   ) {
     this.x = x;
     this.y = y;
@@ -156,7 +159,7 @@ export class RasterTileNode {
   }
 
   /** Get the level info for this tile's z index. */
-  get level(): TilesetLevel {
+  get level(): RasterTilesetLevel {
     return this.descriptor.levels[this.z]!;
   }
 
@@ -166,7 +169,7 @@ export class RasterTileNode {
    *
    * A tileset pyramid is not guaranteed to be a quadtree — it is a stack of
    * independent grids. We find children by mapping the parent tile's CRS bounds
-   * into the child grid using {@link TilesetLevel.crsBoundsToTileRange}.
+   * into the child grid using {@link RasterTilesetLevel.crsBoundsToTileRange}.
    */
   get children(): RasterTileNode[] | null {
     if (!this._children) {
@@ -624,7 +627,7 @@ const MAX_ROOT_TILES_NO_CULL = 100;
  * Exported for unit testing.
  */
 export function createRootTiles(opts: {
-  descriptor: TilesetDescriptor;
+  descriptor: RasterTilesetDescriptor;
   viewport: Pick<Viewport, "getBounds">;
   datasetWgs84Bounds: Bounds;
 }): RasterTileNode[] {
@@ -676,13 +679,13 @@ export function createRootTiles(opts: {
 /**
  * Get tile indices visible in viewport.
  *
- * Uses frustum culling driven by a {@link TilesetDescriptor}, which abstracts
+ * Uses frustum culling driven by a {@link RasterTilesetDescriptor}, which abstracts
  * over OGC TileMatrixSet grids and Zarr multiscale pyramids.
  *
  * Overview levels follow the descriptor ordering: index 0 = coarsest, higher = finer.
  */
 export function getTileIndices(
-  descriptor: TilesetDescriptor,
+  descriptor: RasterTilesetDescriptor,
   opts: {
     viewport: Viewport;
     maxZ: number;

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
@@ -16,7 +16,7 @@ import { transformBounds } from "@developmentseed/proj";
 import type { Matrix4 } from "@math.gl/core";
 import { BoundingVolumeCache } from "./bounding-volume-cache.js";
 import { getTileIndices } from "./raster-tile-traversal.js";
-import type { TilesetDescriptor } from "./tileset-interface.js";
+import type { RasterTilesetDescriptor } from "./tileset-interface.js";
 import type {
   Bounds,
   Corners,
@@ -27,7 +27,7 @@ import type {
 } from "./types.js";
 
 /** Type returned by {@link RasterTileset2D.getTileMetadata} */
-export type TileMetadata = {
+export type RasterTileMetadata = {
   /**
    * **Axis-aligned** bounding box of the tile in **WGS84 coordinates**.
    */
@@ -114,14 +114,14 @@ export interface RasterTileset2DOptions {
  * Handles tile lifecycle, caching, and viewport-based loading.
  */
 export class RasterTileset2D extends Tileset2D {
-  private descriptor: TilesetDescriptor;
+  private descriptor: RasterTilesetDescriptor;
   private wgs84Bounds: Bounds;
   private getPixelRatio: () => number;
   private boundingVolumeCache: BoundingVolumeCache;
 
   constructor(
     opts: Tileset2DProps,
-    descriptor: TilesetDescriptor,
+    descriptor: RasterTilesetDescriptor,
     { getPixelRatio, maxBoundingVolumeCacheSize }: RasterTileset2DOptions = {},
   ) {
     super(opts);
@@ -239,7 +239,7 @@ export class RasterTileset2D extends Tileset2D {
     return index.z;
   }
 
-  override getTileMetadata(index: TileIndex): TileMetadata {
+  override getTileMetadata(index: TileIndex): RasterTileMetadata {
     const { x, y, z } = index;
     const levelDescriptor = this.descriptor.levels[z]!;
     const { tileHeight, tileWidth } = levelDescriptor;

--- a/packages/deck.gl-raster/src/raster-tileset/tile-matrix-set.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/tile-matrix-set.ts
@@ -1,14 +1,17 @@
 import * as affine from "@developmentseed/affine";
 import type { TileMatrix, TileMatrixSet } from "@developmentseed/morecantile";
 import { tileTransform, xy_bounds } from "@developmentseed/morecantile";
-import type { TilesetDescriptor, TilesetLevel } from "./tileset-interface.js";
+import type {
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
+} from "./tileset-interface.js";
 import type { Bounds, Corners, ProjectionFunction } from "./types.js";
 
 // 0.28 mm per pixel — OGC TMS 2.0 standard screen pixel size
 // https://docs.ogc.org/is/17-083r4/17-083r4.html#toc15
 const SCREEN_PIXEL_SIZE = 0.00028;
 
-class TileMatrixAdaptor implements TilesetLevel {
+class TileMatrixAdaptor implements RasterTilesetLevel {
   inner: TileMatrix;
 
   constructor(tileMatrix: TileMatrix) {
@@ -145,10 +148,10 @@ class TileMatrixAdaptor implements TilesetLevel {
 }
 
 /**
- * An adapter interface to use a TileMatrixSet as a TilesetDescriptor for raster
+ * An adapter interface to use a TileMatrixSet as a RasterTilesetDescriptor for raster
  * tile traversal.
  */
-export class TileMatrixSetAdaptor implements TilesetDescriptor {
+export class TileMatrixSetAdaptor implements RasterTilesetDescriptor {
   tms: TileMatrixSet;
   private _levels: TileMatrixAdaptor[];
   projectTo3857: ProjectionFunction;
@@ -178,7 +181,7 @@ export class TileMatrixSetAdaptor implements TilesetDescriptor {
     this.projectFrom4326 = projectFrom4326;
   }
 
-  get levels(): TilesetLevel[] {
+  get levels(): RasterTilesetLevel[] {
     return this._levels;
   }
 

--- a/packages/deck.gl-raster/src/raster-tileset/tileset-interface.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/tileset-interface.ts
@@ -6,7 +6,7 @@ import type { Bounds, Corners, ProjectionFunction } from "./types.js";
  * This interface abstracts over both TileMatrixSet levels and Zarr multiscale
  * levels, enabling a single traversal algorithm to work with both.
  */
-export interface TilesetLevel {
+export interface RasterTilesetLevel {
   /** Number of tiles across this level (columns). */
   matrixWidth: number;
 
@@ -83,9 +83,9 @@ export interface TilesetLevel {
  * Index 0 = coarsest level, higher index = finer detail (same ordering as
  * TileMatrixSet).
  */
-export interface TilesetDescriptor {
+export interface RasterTilesetDescriptor {
   /** Ordered levels from coarsest (0) to finest. */
-  levels: TilesetLevel[];
+  levels: RasterTilesetLevel[];
 
   /**
    * Projection function from the source CRS → EPSG:3857.

--- a/packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
+++ b/packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
@@ -41,9 +41,7 @@ function mockLevel(opts: {
 }
 
 /** Helper: create a mock RasterTilesetDescriptor */
-function mockDescriptor(
-  levels: RasterTilesetLevel[],
-): RasterTilesetDescriptor {
+function mockDescriptor(levels: RasterTilesetLevel[]): RasterTilesetDescriptor {
   const identity = (x: number, y: number): [number, number] => [x, y];
   return {
     levels,

--- a/packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
+++ b/packages/deck.gl-raster/tests/multi-raster-tileset/multi-tileset-descriptor.test.ts
@@ -1,23 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
-  createMultiTilesetDescriptor,
+  createMultiRasterTilesetDescriptor,
   selectSecondaryLevel,
   tilesetLevelsEqual,
 } from "../../src/multi-raster-tileset/multi-tileset-descriptor.js";
 import type {
-  TilesetDescriptor,
-  TilesetLevel,
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
 } from "../../src/raster-tileset/tileset-interface.js";
 import type { Corners } from "../../src/raster-tileset/types.js";
 
-/** Helper: create a mock TilesetLevel */
+/** Helper: create a mock RasterTilesetLevel */
 function mockLevel(opts: {
   matrixWidth: number;
   matrixHeight: number;
   tileWidth: number;
   tileHeight: number;
   metersPerPixel: number;
-}): TilesetLevel {
+}): RasterTilesetLevel {
   const identityTransform = (x: number, y: number): [number, number] => [x, y];
   return {
     ...opts,
@@ -40,8 +40,10 @@ function mockLevel(opts: {
   };
 }
 
-/** Helper: create a mock TilesetDescriptor */
-function mockDescriptor(levels: TilesetLevel[]): TilesetDescriptor {
+/** Helper: create a mock RasterTilesetDescriptor */
+function mockDescriptor(
+  levels: RasterTilesetLevel[],
+): RasterTilesetDescriptor {
   const identity = (x: number, y: number): [number, number] => [x, y];
   return {
     levels,
@@ -91,7 +93,7 @@ describe("tilesetLevelsEqual", () => {
   });
 });
 
-describe("createMultiTilesetDescriptor", () => {
+describe("createMultiRasterTilesetDescriptor", () => {
   it("selects the finest-resolution tileset as primary", () => {
     const fine = mockDescriptor([
       mockLevel({
@@ -125,7 +127,7 @@ describe("createMultiTilesetDescriptor", () => {
         metersPerPixel: 20,
       }),
     ]);
-    const multi = createMultiTilesetDescriptor(
+    const multi = createMultiRasterTilesetDescriptor(
       new Map([
         ["red", fine],
         ["swir", coarse],
@@ -155,7 +157,7 @@ describe("createMultiTilesetDescriptor", () => {
         metersPerPixel: 20,
       }),
     ]);
-    const multi = createMultiTilesetDescriptor(
+    const multi = createMultiRasterTilesetDescriptor(
       new Map([
         ["red", fine],
         ["swir", coarse],

--- a/packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts
+++ b/packages/deck.gl-raster/tests/multi-raster-tileset/secondary-tile-resolver.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { resolveSecondaryTiles } from "../../src/multi-raster-tileset/secondary-tile-resolver.js";
-import type { TilesetLevel } from "../../src/raster-tileset/tileset-interface.js";
+import type { RasterTilesetLevel } from "../../src/raster-tileset/tileset-interface.js";
 import type { Corners, Point } from "../../src/raster-tileset/types.js";
 
 /**
- * Create a mock TilesetLevel backed by a regular grid.
+ * Create a mock RasterTilesetLevel backed by a regular grid.
  * originX/originY is the top-left corner. cellSize is CRS units per pixel.
  */
 function gridLevel(opts: {
@@ -15,7 +15,7 @@ function gridLevel(opts: {
   tileHeight: number;
   matrixWidth: number;
   matrixHeight: number;
-}): TilesetLevel {
+}): RasterTilesetLevel {
   const {
     originX,
     originY,

--- a/packages/deck.gl-raster/tests/raster-tileset/bounding-volume-cache-memoization.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/bounding-volume-cache-memoization.test.ts
@@ -3,15 +3,15 @@ import { describe, expect, it } from "vitest";
 import { BoundingVolumeCache } from "../../src/raster-tileset/bounding-volume-cache.js";
 import { getTileIndices } from "../../src/raster-tileset/raster-tile-traversal.js";
 import type {
-  TilesetDescriptor,
-  TilesetLevel,
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
 } from "../../src/raster-tileset/tileset-interface.js";
 import type { Bounds, Corners } from "../../src/raster-tileset/types.js";
 
 const identity = (x: number, y: number): [number, number] => [x, y];
 
 /** Single-tile level covering [-1, -1, 1, 1] with the given metersPerPixel. */
-function makeLevel(metersPerPixel: number): TilesetLevel {
+function makeLevel(metersPerPixel: number): RasterTilesetLevel {
   const corners: Corners = {
     topLeft: [-1, 1],
     topRight: [1, 1],
@@ -42,7 +42,7 @@ function makeLevel(metersPerPixel: number): TilesetLevel {
  * assert that a second traversal does not recompute bounding volumes.
  */
 function makeCountingDescriptor(metersPerPixelByLevel: number[]): {
-  descriptor: TilesetDescriptor;
+  descriptor: RasterTilesetDescriptor;
   projectCallCount: () => number;
 } {
   let count = 0;

--- a/packages/deck.gl-raster/tests/raster-tileset/create-root-tiles.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/create-root-tiles.test.ts
@@ -1,20 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { createRootTiles } from "../../src/raster-tileset/raster-tile-traversal.js";
 import type {
-  TilesetDescriptor,
-  TilesetLevel,
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
 } from "../../src/raster-tileset/tileset-interface.js";
 import type { Bounds } from "../../src/raster-tileset/types.js";
 
 /**
- * Minimal fake `TilesetLevel`: top-left-origin EPSG:4326 grid. Only methods
+ * Minimal fake `RasterTilesetLevel`: top-left-origin EPSG:4326 grid. Only methods
  * `createRootTiles` touches are implemented.
  */
 function makeFakeLevel(opts: {
   matrixWidth: number;
   matrixHeight: number;
   tileDegrees: number;
-}): TilesetLevel {
+}): RasterTilesetLevel {
   const { matrixWidth, matrixHeight, tileDegrees } = opts;
   return {
     matrixWidth,
@@ -53,7 +53,9 @@ function makeFakeLevel(opts: {
 /** Identity projection: source CRS already is EPSG:4326. */
 const identity = (x: number, y: number): [number, number] => [x, y];
 
-function makeDescriptor(level: TilesetLevel): TilesetDescriptor {
+function makeDescriptor(
+  level: RasterTilesetLevel,
+): RasterTilesetDescriptor {
   return {
     levels: [level],
     projectTo3857: identity,
@@ -110,7 +112,7 @@ describe("createRootTiles", () => {
   it("enumerates every tile for small root matrices without projecting", () => {
     // Uncullable descriptor — projectFrom4326 throws. The small-matrix path
     // must not touch it.
-    const descriptor: TilesetDescriptor = {
+    const descriptor: RasterTilesetDescriptor = {
       levels: [
         makeFakeLevel({ matrixWidth: 3, matrixHeight: 4, tileDegrees: 90 }),
       ],

--- a/packages/deck.gl-raster/tests/raster-tileset/create-root-tiles.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/create-root-tiles.test.ts
@@ -53,9 +53,7 @@ function makeFakeLevel(opts: {
 /** Identity projection: source CRS already is EPSG:4326. */
 const identity = (x: number, y: number): [number, number] => [x, y];
 
-function makeDescriptor(
-  level: RasterTilesetLevel,
-): RasterTilesetDescriptor {
+function makeDescriptor(level: RasterTilesetLevel): RasterTilesetDescriptor {
   return {
     levels: [level],
     projectTo3857: identity,

--- a/packages/deck.gl-raster/tests/raster-tileset/lod-pixel-ratio.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/lod-pixel-ratio.test.ts
@@ -3,8 +3,8 @@ import type { _Tileset2DProps as Tileset2DProps } from "@deck.gl/geo-layers";
 import { describe, expect, it } from "vitest";
 import { RasterTileset2D } from "../../src/raster-tileset/raster-tileset-2d.js";
 import type {
-  TilesetDescriptor,
-  TilesetLevel,
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
 } from "../../src/raster-tileset/tileset-interface.js";
 import type { Corners } from "../../src/raster-tileset/types.js";
 
@@ -16,7 +16,7 @@ const identity = (x: number, y: number): [number, number] => [x, y];
  * Single-tile level covering [-1, -1, 1, 1] in source CRS, with caller-
  * specified `metersPerPixel`.
  */
-function makeLevel(metersPerPixel: number): TilesetLevel {
+function makeLevel(metersPerPixel: number): RasterTilesetLevel {
   const corners: Corners = {
     topLeft: [-1, 1],
     topRight: [1, 1],
@@ -42,7 +42,9 @@ function makeLevel(metersPerPixel: number): TilesetLevel {
   };
 }
 
-function makeDescriptor(metersPerPixelByLevel: number[]): TilesetDescriptor {
+function makeDescriptor(
+  metersPerPixelByLevel: number[],
+): RasterTilesetDescriptor {
   return {
     levels: metersPerPixelByLevel.map(makeLevel),
     projectTo3857: identity,

--- a/packages/deck.gl-raster/tests/raster-tileset/raster-tileset-2d-cache.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/raster-tileset-2d-cache.test.ts
@@ -3,14 +3,14 @@ import type { _Tileset2DProps as Tileset2DProps } from "@deck.gl/geo-layers";
 import { describe, expect, it } from "vitest";
 import { RasterTileset2D } from "../../src/raster-tileset/raster-tileset-2d.js";
 import type {
-  TilesetDescriptor,
-  TilesetLevel,
+  RasterTilesetDescriptor,
+  RasterTilesetLevel,
 } from "../../src/raster-tileset/tileset-interface.js";
 import type { Corners } from "../../src/raster-tileset/types.js";
 
 const identity = (x: number, y: number): [number, number] => [x, y];
 
-function makeLevel(metersPerPixel: number): TilesetLevel {
+function makeLevel(metersPerPixel: number): RasterTilesetLevel {
   const corners: Corners = {
     topLeft: [-1, 1],
     topRight: [1, 1],
@@ -37,7 +37,7 @@ function makeLevel(metersPerPixel: number): TilesetLevel {
 }
 
 function makeCountingDescriptor(metersPerPixelByLevel: number[]): {
-  descriptor: TilesetDescriptor;
+  descriptor: RasterTilesetDescriptor;
   projectCallCount: () => number;
 } {
   let count = 0;

--- a/packages/deck.gl-raster/tests/raster-tileset/raster-tileset-2d-tile-transform.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/raster-tileset-2d-tile-transform.test.ts
@@ -19,7 +19,7 @@ function tilesetProps(): Tileset2DProps {
 }
 
 describe("RasterTileset2D.getTileMetadata", () => {
-  it("attaches per-tile forwardTransform/inverseTransform to TileMetadata", () => {
+  it("attaches per-tile forwardTransform/inverseTransform to RasterTileMetadata", () => {
     const level = new AffineTilesetLevel({
       affine: compose(translation(100, 200), scale(10, -10)),
       arrayWidth: 8,

--- a/packages/deck.gl-zarr/src/zarr-layer.ts
+++ b/packages/deck.gl-zarr/src/zarr-layer.ts
@@ -3,8 +3,8 @@ import type {
   MinimalTileData,
   GetTileDataOptions as RasterTileGetTileDataOptions,
   RasterTileLayerProps,
+  RasterTilesetDescriptor,
   RenderTileResult,
-  TilesetDescriptor,
 } from "@developmentseed/deck.gl-raster";
 import { RasterTileLayer } from "@developmentseed/deck.gl-raster";
 import type { GeoZarrMetadata } from "@developmentseed/geozarr";
@@ -168,7 +168,7 @@ export class ZarrLayer<
     spatialDims?: [string, string];
     /** One opened array per level, finest-first (matches meta.levels order). */
     arrays?: zarr.Array<zarr.DataType, zarr.Readable>[];
-    tilesetDescriptor?: TilesetDescriptor;
+    tilesetDescriptor?: RasterTilesetDescriptor;
   };
 
   override initializeState(): void {

--- a/packages/deck.gl-zarr/src/zarr-tileset.ts
+++ b/packages/deck.gl-zarr/src/zarr-tileset.ts
@@ -1,6 +1,6 @@
 import type {
   ProjectionFunction,
-  TilesetDescriptor,
+  RasterTilesetDescriptor,
 } from "@developmentseed/deck.gl-raster";
 import {
   AffineTileset,
@@ -9,7 +9,7 @@ import {
 import type { GeoZarrMetadata } from "@developmentseed/geozarr";
 
 /**
- * Convert a `GeoZarrMetadata` object into a `TilesetDescriptor` for use with
+ * Convert a `GeoZarrMetadata` object into a `RasterTilesetDescriptor` for use with
  * `RasterTileset2D`.
  *
  * @param meta  Parsed GeoZarr metadata (from `parseGeoZarrMetadata`).
@@ -32,14 +32,14 @@ export function geoZarrToDescriptor(
     chunkSizes: Array<{ width: number; height: number }>;
     mpu: number;
   },
-): TilesetDescriptor {
+): RasterTilesetDescriptor {
   if (opts.chunkSizes.length !== meta.levels.length) {
     throw new Error(
       `chunkSizes length (${opts.chunkSizes.length}) must match meta.levels length (${meta.levels.length})`,
     );
   }
 
-  // meta.levels is finest-first; TilesetDescriptor requires coarsest-first.
+  // meta.levels is finest-first; RasterTilesetDescriptor requires coarsest-first.
   const reversedLevels = [...meta.levels].reverse();
   const reversedChunks = [...opts.chunkSizes].reverse();
 


### PR DESCRIPTION
A few renames so that use at callsites is clearer:

- `TilesetDescriptor` -> `RasterTilesetDescriptor`
- `TileMetadata` -> `RasterTileMetadata`
- `TilesetLevel` -> `RasterTilesetLevel`
- `MultiTilesetDescriptor` -> `MultiRasterTilesetDescriptor`
- `createMultiTilesetDescriptor` -> `createMultiRasterTilesetDescriptor` (perhaps this should be a class instead of an interface and a free function?)