### PR TITLE
refactor: Rename `MosaicSource.key` to `MosaicSource.id`

### DIFF
--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -350,7 +350,6 @@ export default function App() {
   useEffect(() => {
     async function wrappedFetchSTACItems() {
       try {
-        // const data: STACFeatureCollection = await fetchSTACItems();
         const data = STAC_DATA as unknown as STACFeatureCollection;
         (window as any).data = data;
         setStacItems(data.features);

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-layer.ts
@@ -36,13 +36,13 @@ export type MosaicLayerProps<
      *
      * Tile cache reuse depends on stable tile IDs. By default, each source's
      * tile ID is derived from its position in this array (see
-     * `MosaicSource.key`), so:
+     * `MosaicSource.id`), so:
      *
      * - Appending items preserves all existing rendered tiles.
      * - Reordering or removing items from the middle of the array invalidates
      *   the cache slots of shifted items, causing them to re-fetch.
      *
-     * Supply an explicit `key` per source if you need cache stability across
+     * Supply an explicit `id` per source if you need cache stability across
      * arbitrary mutations of `sources`.
      */
     sources: MosaicT[];

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-tileset-2d.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-tileset-2d.ts
@@ -22,7 +22,7 @@ export type MosaicSource = {
    * spliced at runtime, so a given source keeps the same cache slot across
    * updates.
    */
-  key?: string;
+  id?: string;
   /**
    * Geographic bounds (WGS84) of the source in [minX, minY, maxX, maxY] format
    */
@@ -44,7 +44,7 @@ export type MosaicSource = {
 /** A source augmented with the `TileIndex` fields and a resolved `key`
  * (defaulting to the array position) so deck.gl typing is satisfied and the
  * cache identifier is always defined. */
-type ResolvedSource<MosaicT> = TileIndex & MosaicT & { key: string };
+type ResolvedSource<MosaicT> = TileIndex & MosaicT & { id: string };
 
 export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
   /** Closure returning the parent layer's current sources array. Re-evaluated
@@ -67,9 +67,9 @@ export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
 
   /** The Tileset2D cache key for a source. */
   override getTileId(tileIndex: TileIndex): string {
-    // `getTileIndices` always returns `ResolvedSource`s, so a `key` is
+    // `getTileIndices` always returns `ResolvedSource`s, so an `id` is
     // present on every value deck.gl will pass back here.
-    return (tileIndex as ResolvedSource<MosaicT>).key;
+    return (tileIndex as ResolvedSource<MosaicT>).id;
   }
 
   /** Must override to provide a zoom level for the tile. */
@@ -79,8 +79,8 @@ export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
 
   /** Must override because our tileIndex does not have x, y, z */
   override getTileMetadata(tileIndex: TileIndex): Record<string, any> {
-    const { key, bbox } = tileIndex as unknown as ResolvedSource<MosaicT>;
-    return { key, bbox };
+    const { id, bbox } = tileIndex as unknown as ResolvedSource<MosaicT>;
+    return { id, bbox };
   }
 
   override getParentIndex(tileIndex: TileIndex): TileIndex {
@@ -121,7 +121,7 @@ export class MosaicTileset2D<MosaicT extends MosaicSource> extends Tileset2D {
         y: 0,
         z: 0,
         ...source,
-        key: source.key ?? String(sourceIndex),
+        id: source.id ?? String(sourceIndex),
       };
     });
 

--- a/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-tileset-2d.ts
+++ b/packages/deck.gl-geotiff/src/mosaic-layer/mosaic-tileset-2d.ts
@@ -41,7 +41,7 @@ export type MosaicSource = {
  * closure returns a new array reference (compared by `===`); mutating the
  * array in place will not be detected.
  */
-/** A source augmented with the `TileIndex` fields and a resolved `key`
+/** A source augmented with the `TileIndex` fields and a resolved `id`
  * (defaulting to the array position) so deck.gl typing is satisfied and the
  * cache identifier is always defined. */
 type ResolvedSource<MosaicT> = TileIndex & MosaicT & { id: string };

--- a/packages/deck.gl-geotiff/tests/mosaic-tileset-2d.test.ts
+++ b/packages/deck.gl-geotiff/tests/mosaic-tileset-2d.test.ts
@@ -46,10 +46,10 @@ function makeTileset<T extends MosaicSource>(
   );
 }
 
-type Item = MosaicSource & { id: string };
-const A: Item = { id: "A", bbox: [0, 0, 10, 10] };
-const B: Item = { id: "B", bbox: [20, 0, 30, 10] };
-const C: Item = { id: "C", bbox: [40, 0, 50, 10] };
+type Item = MosaicSource & { name: string };
+const A: Item = { name: "A", bbox: [0, 0, 10, 10] };
+const B: Item = { name: "B", bbox: [20, 0, 30, 10] };
+const C: Item = { name: "C", bbox: [40, 0, 50, 10] };
 
 describe("MosaicTileset2D viewport filtering", () => {
   it("returns sources intersecting the viewport", () => {
@@ -58,7 +58,7 @@ describe("MosaicTileset2D viewport filtering", () => {
       viewport: makeViewport([-1, -1, 11, 11]),
     });
     expect(result).toHaveLength(1);
-    expect(result[0]?.id).toBe("A");
+    expect(result[0]?.name).toBe("A");
   });
 
   it("excludes sources outside viewport bounds", () => {
@@ -125,29 +125,29 @@ describe("MosaicTileset2D center-out ordering", () => {
   });
 });
 
-describe("MosaicTileset2D tile keys", () => {
-  it("defaults each source's tile-cache key to its array position", () => {
+describe("MosaicTileset2D tile ids", () => {
+  it("defaults each source's tile-cache id to its array position", () => {
     const tileset = makeTileset([A, B, C]);
     const result = tileset.getTileIndices({
       viewport: makeViewport([-1, -1, 51, 11]),
     });
-    const byId = new Map(result.map((s) => [s.id, s] as const));
-    expect(tileset.getTileId(byId.get("A")!)).toBe("0");
-    expect(tileset.getTileId(byId.get("B")!)).toBe("1");
-    expect(tileset.getTileId(byId.get("C")!)).toBe("2");
+    const byName = new Map(result.map((s) => [s.name, s] as const));
+    expect(tileset.getTileId(byName.get("A")!)).toBe("0");
+    expect(tileset.getTileId(byName.get("B")!)).toBe("1");
+    expect(tileset.getTileId(byName.get("C")!)).toBe("2");
   });
 
-  it("respects an explicit `key` on a source", () => {
+  it("respects an explicit `id` on a source", () => {
     const explicit: Item = {
-      id: "explicit",
+      name: "explicit",
       bbox: [0, 0, 10, 10],
-      key: "stable-id",
+      id: "stable-id",
     };
     const tileset = makeTileset([explicit]);
     const result = tileset.getTileIndices({
       viewport: makeViewport([-1, -1, 11, 11]),
     });
-    expect(result[0]).toMatchObject({ id: "explicit", key: "stable-id" });
+    expect(result[0]).toMatchObject({ name: "explicit", id: "stable-id" });
     expect(tileset.getTileId(result[0]!)).toBe("stable-id");
   });
 });


### PR DESCRIPTION
I think `id` is more in line with usual deck.gl terminology than `key`