### PR TITLE
ci: Fix docs publish by skipping example dirs without a build script

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,11 @@ jobs:
         run: |
           for dir in examples/*/; do
             example=$(basename "$dir")
+            has_build=$(node -p "Boolean((require('./$dir/package.json').scripts||{}).build)")
+            if [ "$has_build" != "true" ]; then
+              echo "Skipping $example (no build script)"
+              continue
+            fi
             pkg_name=$(node -p "require('./$dir/package.json').name")
             pnpm --filter "$pkg_name" build
             mkdir -p "docs/static/examples/$example"


### PR DESCRIPTION
Previous docs publish failed because the `_shared` directory does not have a build script

https://github.com/developmentseed/deck.gl-raster/actions/runs/25923951677/job/76200031133