### PR TITLE
fix: Remove NAIP Mosaic caching override

### DIFF
--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -432,7 +432,6 @@ export default function App() {
                       colormapReversed: colormapChoice.reversed,
                     }),
           signal,
-          maxCacheSize: 10,
         });
       },
       // Smaller cache for MosaicLayer cache, since it caches full COGLayer


### PR DESCRIPTION
Panning around the map a bit, it looks like this is too aggressively removing items from the cache. This will really be solved with #516 