### PR TITLE
Spike: high-zoom precision via per-tile reference point (superseded by #559)

### DIFF
--- a/dev-docs/specs/2026-05-19-high-zoom-precision-design.md
+++ b/dev-docs/specs/2026-05-19-high-zoom-precision-design.md
@@ -1,0 +1,186 @@
+# Fix high-zoom jitter from float32 mesh positions
+
+- **Date:** 2026-05-19
+- **Issues:** [#512](https://github.com/developmentseed/deck.gl-raster/issues/512)
+- **Status:** Proposed
+
+## Problem
+
+At high zoom (≳ z16) over high-resolution imagery (sub-meter NAIP, for
+example), the rendered raster jitters by sub-meter amounts during pan and
+zoom. The basemap underneath stays put; only the raster moves. Reported in
+[#512](https://github.com/developmentseed/deck.gl-raster/issues/512) with a
+NAIP mosaic reproducer.
+
+The cause is float32 quantization of mesh vertex positions. The reprojector
+emits exact output positions in EPSG:3857 meters as JS doubles
+(`packages/raster-reproject/src/delatin.ts`, `_addPoint` →
+`exactOutputPositions: number[]`). `RasterLayer._generateMesh`
+(`packages/deck.gl-raster/src/raster-layer.ts`) then writes those values into
+a `Float32Array` for the GPU. EPSG:3857 meters range up to ±2.0×10⁷ near the
+edges of the world; float32 holds ~7 significant decimal digits, so stored
+values quantize to roughly 1–2 m steps in that range. At z16 a pixel is
+~2.4 m on the ground, so the quantization is visible as jitter; at z18 a
+pixel is ~0.6 m and the jitter dominates.
+
+deck.gl's own auto-offset (`WEB_MERCATOR_AUTO_OFFSET`, kicks in at
+zoom ≥ 12 — see
+[`Viewport.projectionMode`](https://github.com/visgl/deck.gl/blob/82a028314b8b20275c8f58713e68702407f2eba4/modules/core/src/viewports/viewport.ts#L205-L212))
+does not rescue us. Auto-offset re-anchors the projection to the viewport center on the CPU
+in float64, then runs camera-relative math in float32 in the shader. That
+fixes the *camera-relative* precision, but the precision of our vertex
+attribute is already gone before the shader runs — we lost it when we
+quantized 10⁷-magnitude numbers to float32 on the CPU. Auto-offset works for
+ordinary geospatial layers because those layers store LNGLAT degrees
+(magnitudes ≲ 180), which float32 represents with sub-cm precision
+everywhere.
+
+## Goal
+
+Eliminate the float32 quantization at the vertex-attribute level for the
+tile path, so panning at z16+ over high-resolution imagery is jitter-free
+and matches the basemap.
+
+## Non-goals
+
+- The standalone `RasterLayer` (used without `RasterTileLayer`) is out of
+  scope. With the design below, its behavior is unchanged unless a caller
+  opts in by passing the new prop.
+- Globe mode is out of scope. We do not handle globe-projected raster yet
+  anywhere; revisit when we do.
+- Switching to deck.gl's `meter-offsets` coordinate system. It interprets
+  the position attribute as true ground meters relative to a lng/lat anchor
+  via `addMetersToLngLat`. Our reprojector emits EPSG:3857 meters, which
+  include the Mercator stretch `1/cos(lat)`. Using `meter-offsets`
+  unchanged would render tiles at the wrong size at high latitudes
+  (~2× too small at 60°N) and drift off the Mercator basemap. Converting
+  3857 meters → ground meters per tile is possible but adds CPU cost and
+  decouples our coordinate convention from the basemap; not worth it for
+  this fix.
+- A `fp64` / double-precision attribute path. Doubling attribute memory and
+  the shader vertex cost is unnecessary when the split-precision trick
+  below gives the same end result.
+
+## Approach
+
+Split-precision rendering, applied to the vertex attribute. Each tile picks
+a reference point in EPSG:3857 meters; mesh positions are stored as float32
+*offsets* from that reference; the reference itself is folded into the
+layer's `modelMatrix` translation, computed on the CPU in float64. This is
+the same algebraic identity deck.gl uses for auto-offset — applied one
+layer down, at the attribute, where our precision is actually being lost.
+
+For a tile reference point `ref` (in 3857 meters), the rendered position is
+
+```
+scale · (p − ref) + scale · ref + [TILE_SIZE/2, TILE_SIZE/2, 0]
+  = scale · p + [TILE_SIZE/2, TILE_SIZE/2, 0]
+```
+
+— identical to today's output. Quantization moves from `p` (magnitude
+~10⁷) to `p − ref` (magnitude bounded by the tile's half-extent — ≤ ~2×10⁷
+at z0, halving each level, ≲ 20 m by z20). The `modelMatrix` translation
+`scale · ref` is computed in JS as float64 and survives intact into the
+shader uniform; the GPU only adds a small float32 attribute to a precise
+uniform.
+
+### Reference point: tile centroid
+
+`RasterTileLayer._renderSubLayers` already has `tile.projectedCorners`
+attached by `RasterTileset2D.getTileMetadata` — the four tile corners in
+projected (EPSG:3857) coordinates, preserving any rotation. The reference
+point is the centroid of those four corners. This works for axis-aligned
+and rotated tiles alike. No new tile metadata is required.
+
+### Always-on, no zoom threshold
+
+The shift is applied unconditionally for every tile. Rationale:
+
+- Cost is negligible. One centroid (4 adds, 1 div) per tile and one float64
+  subtraction per mesh vertex during mesh generation. Mesh generation
+  already runs delatin per tile, which dominates this.
+- Never worse than today. At very low zoom the tile centroid is near the
+  origin (z0: a single tile, centroid (0,0); z1: four tiles, centroid
+  ±10⁷). Stored magnitudes are at most equal to today's. Above z2 they
+  shrink geometrically with zoom level, and precision improves
+  monotonically.
+- A threshold would add branching, a tuning parameter, and two code paths
+  to test for marginal savings.
+
+## Scope of change
+
+Two files, plus a unit test. No public API break.
+
+- `packages/deck.gl-raster/src/raster-layer.ts`
+  - Add an optional prop to `RasterLayerProps`, e.g.
+    `referencePointMeters?: [number, number] | null` (default `null`).
+  - In `_generateMesh` / `reprojectorToMesh`, subtract
+    `referencePointMeters` from each `exactOutputPositions[i*2 + 0/1]`
+    when filling the `Float32Array`. When `null`, behave exactly as today.
+  - Add `props.referencePointMeters` to the `updateState` change detection
+    so a changed reference point regenerates the mesh.
+- `packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts`
+  - In `_renderSubLayers`, in the non-globe branch, compute
+    `ref = centroid(tile.projectedCorners)` in 3857 meters.
+  - Fold the reference into the `modelMatrix` translation that's already
+    being built. The current matrix is `diag(scale, scale, 1, 1)`; the new
+    one adds translation `[scale · ref_x, scale · ref_y, 0]`. Reference
+    equality across renders must be preserved so `MeshTextureLayer`'s
+    model-rebuild gating still holds — memoize the matrix per tile, or
+    attach it to the tile metadata at creation, the same way
+    `forwardTransform` / `inverseTransform` are.
+  - Pass `referencePointMeters: ref` to the inner `RasterLayer`.
+
+### Reference-equality discipline
+
+`RasterLayer.updateState` regenerates the mesh whenever any of its
+inputs change. `RasterTileLayer._renderSubLayers` must therefore hand the
+inner `RasterLayer` a *stable* `referencePointMeters` reference across
+renders of the same tile — otherwise we'll regenerate the mesh every
+render and tank performance. The natural place to live is `RasterTileMetadata`
+on the tile object (computed once at tile creation, alongside
+`forwardTransform` / `inverseTransform`), or memoized per-tile in
+`_renderSubLayers`. Same applies to the per-tile `modelMatrix`: stable
+reference, computed once.
+
+## Verification
+
+- Unit test in `packages/deck.gl-raster/tests/raster-layer.test.ts`
+  covering `_generateMesh`:
+  - Without `referencePointMeters`, the resulting `POSITION` buffer matches
+    today's output exactly (regression guard).
+  - With a non-zero `referencePointMeters` near a sample's true 3857
+    position (~10⁷ m magnitude), reconstructing
+    `position_f32 + ref_f64` recovers the original double-precision input
+    to within float32 ULP near zero (i.e. ≤ ~10⁻⁴ m), which is ≥ 10⁴× tighter
+    than today's ~1 m quantization at the same input magnitude.
+- Manual browser check using the NAIP mosaic example (the
+  [#512](https://github.com/developmentseed/deck.gl-raster/issues/512)
+  reproducer): pan and zoom around z18 and confirm the raster no longer
+  drifts relative to the basemap.
+
+## Risks
+
+- **Stale reference equality.** If `referencePointMeters` or `modelMatrix`
+  is recreated each render, the inner `RasterLayer` regenerates its mesh
+  every frame. The change-detection in `RasterLayer.updateState` and the
+  model rebuild in `MeshTextureLayer.updateState` both rely on stable
+  references. Mitigation: store the per-tile `referencePointMeters` and
+  `modelMatrix` on the tile metadata at tile creation, the same way
+  `forwardTransform` is today, and pass those exact references in
+  `_renderSubLayers`.
+- **Picking and other downstream uses of mesh positions.** `RasterLayer`'s
+  debug overlay reads back `reprojector.exactOutputPositions` directly
+  (still in 3857 meters, unaffected). The mesh `POSITION` buffer is
+  consumed by `SimpleMeshLayer`, which only feeds it to the projection
+  shader — no app-visible position read-back. Low risk.
+- **Negligible run-time cost.** One centroid per tile, one vector subtract
+  per vertex during mesh gen. Mesh gen is already delatin-bound.
+
+## Out of scope follow-ups
+
+- Apply the same split-precision approach to the standalone `RasterLayer`
+  by either (a) auto-deriving a reference from the input positions, or
+  (b) requiring callers to pass `referencePointMeters`. Defer until a
+  user reports the same jitter outside the tile path.
+- Globe-mode precision. Revisit when globe-projected raster ships.

--- a/packages/deck.gl-raster/src/raster-layer.ts
+++ b/packages/deck.gl-raster/src/raster-layer.ts
@@ -106,6 +106,20 @@ export interface RasterLayerProps extends CompositeLayerProps {
 
   /** Opacity of the debug overlay. */
   debugOpacity?: number;
+
+  /**
+   * Reference point in projected (EPSG:3857) coordinates. When provided,
+   * mesh vertex positions are stored in the GPU buffer as float32 offsets
+   * from this point, rather than as absolute EPSG:3857 meters. Used by
+   * {@link RasterTileLayer} to preserve precision at high zoom levels.
+   *
+   * Callers passing this prop must fold the same reference point back into
+   * their `modelMatrix` translation (in float64 on the CPU) so the
+   * algebraic output is identical to the no-reference case.
+   *
+   * @default null
+   */
+  referencePointMeters?: [number, number] | null;
 }
 
 const defaultProps: DefaultProps<RasterLayerProps> = {
@@ -113,6 +127,7 @@ const defaultProps: DefaultProps<RasterLayerProps> = {
   // deck.gl (as long as async: true)
   image: { type: "image", value: null, async: true },
   renderPipeline: { type: "array", value: [], compare: true },
+  referencePointMeters: { type: "array", value: null, compare: true },
   debug: false,
   debugOpacity: 0.5,
 };
@@ -170,12 +185,19 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
       props.reprojectionFns.inverseReproject !==
         oldProps.reprojectionFns?.inverseReproject;
 
+    const refChanged =
+      (props.referencePointMeters?.[0] ?? null) !==
+        (oldProps.referencePointMeters?.[0] ?? null) ||
+      (props.referencePointMeters?.[1] ?? null) !==
+        (oldProps.referencePointMeters?.[1] ?? null);
+
     const needsMeshUpdate =
       Boolean(changeFlags.dataChanged) ||
       props.width !== oldProps.width ||
       props.height !== oldProps.height ||
       reprojectionFnsChanged ||
-      props.maxError !== oldProps.maxError;
+      props.maxError !== oldProps.maxError ||
+      refChanged;
 
     if (needsMeshUpdate) {
       this._generateMesh();
@@ -203,7 +225,10 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
       height + 1,
     );
     reprojector.run(maxError);
-    const { indices, positions, texCoords } = reprojectorToMesh(reprojector);
+    const { indices, positions, texCoords } = reprojectorToMesh(
+      reprojector,
+      this.props.referencePointMeters ?? null,
+    );
 
     this.setState({
       reprojector,
@@ -318,7 +343,10 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
   }
 }
 
-function reprojectorToMesh(reprojector: RasterReprojector): {
+function reprojectorToMesh(
+  reprojector: RasterReprojector,
+  referencePointMeters: [number, number] | null,
+): {
   indices: Uint32Array;
   positions: Float32Array;
   texCoords: Float32Array;
@@ -327,9 +355,17 @@ function reprojectorToMesh(reprojector: RasterReprojector): {
   const positions = new Float32Array(numVertices * 3);
   const texCoords = new Float32Array(reprojector.uvs);
 
+  // Subtract the reference in JS float64 BEFORE writing to Float32Array so
+  // the stored values are small offsets, not full-magnitude 3857 meters. The
+  // caller must fold the same reference into modelMatrix translation to
+  // preserve algebraic output. See
+  // dev-docs/specs/2026-05-19-high-zoom-precision-design.md.
+  const refX = referencePointMeters?.[0] ?? 0;
+  const refY = referencePointMeters?.[1] ?? 0;
+
   for (let i = 0; i < numVertices; i++) {
-    positions[i * 3] = reprojector.exactOutputPositions[i * 2]!;
-    positions[i * 3 + 1] = reprojector.exactOutputPositions[i * 2 + 1]!;
+    positions[i * 3] = reprojector.exactOutputPositions[i * 2]! - refX;
+    positions[i * 3 + 1] = reprojector.exactOutputPositions[i * 2 + 1]! - refY;
     // z (flat on the ground)
     positions[i * 3 + 2] = 0;
   }

--- a/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+++ b/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
@@ -416,19 +416,32 @@ export class RasterTileLayer<
           forwardReproject: descriptor.projectTo3857,
           inverseReproject: descriptor.projectFrom3857,
         };
-    const deckProjectionProps: Partial<LayerProps> = isGlobe
-      ? {}
-      : {
-          coordinateSystem: "cartesian",
-          coordinateOrigin: [TILE_SIZE / 2, TILE_SIZE / 2, 0],
-          // biome-ignore format: array
-          modelMatrix: [
-            WEB_MERCATOR_TO_WORLD_SCALE, 0, 0, 0,
-            0, WEB_MERCATOR_TO_WORLD_SCALE, 0, 0,
-            0, 0, 1, 0,
-            0, 0, 0, 1,
-          ],
-        };
+
+    let referencePointMeters: [number, number] | null = null;
+    let deckProjectionProps: Partial<LayerProps> = {};
+    if (!isGlobe) {
+      referencePointMeters = tile.referencePointMeters;
+      // Translation columns of the column-major modelMatrix carry the
+      // float64-precision reference point, scaled to deck.gl world units.
+      // The mesh stores positions as float32 offsets from
+      // `referencePointMeters` (see RasterLayer.referencePointMeters), so the
+      // GPU multiplies a small float32 by the scale and adds a precise
+      // float64 origin. See
+      // dev-docs/specs/2026-05-19-high-zoom-precision-design.md.
+      const tx = referencePointMeters[0] * WEB_MERCATOR_TO_WORLD_SCALE;
+      const ty = referencePointMeters[1] * WEB_MERCATOR_TO_WORLD_SCALE;
+      deckProjectionProps = {
+        coordinateSystem: "cartesian",
+        coordinateOrigin: [TILE_SIZE / 2, TILE_SIZE / 2, 0],
+        // biome-ignore format: array
+        modelMatrix: [
+          WEB_MERCATOR_TO_WORLD_SCALE, 0, 0, 0,
+          0, WEB_MERCATOR_TO_WORLD_SCALE, 0, 0,
+          0, 0, 1, 0,
+          tx, ty, 0, 1,
+        ],
+      };
+    }
 
     const rasterLayer = new RasterLayer(
       this.getSubLayerProps({
@@ -441,6 +454,7 @@ export class RasterTileLayer<
         renderPipeline,
         maxError,
         reprojectionFns,
+        referencePointMeters,
         debug,
         debugOpacity,
         ...deckProjectionProps,

--- a/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
+++ b/packages/deck.gl-raster/src/raster-tileset/raster-tileset-2d.ts
@@ -21,6 +21,7 @@ import type { RasterTilesetDescriptor } from "./tileset-interface.js";
 import type {
   Bounds,
   Corners,
+  Point,
   ProjectedBoundingBox,
   ProjectionFunction,
   TileIndex,
@@ -47,6 +48,17 @@ export type RasterTileMetadata = {
    * axis-aligned bbox.
    */
   projectedCorners: Corners;
+
+  /**
+   * Reference point in projected (EPSG:3857) coordinates, used by
+   * {@link RasterLayer} to split mesh vertex positions into a float32 offset
+   * and a float64 origin to preserve precision at high zoom. Computed once
+   * per tile as the centroid of {@link RasterTileMetadata.projectedCorners}.
+   *
+   * See `dev-docs/specs/2026-05-19-high-zoom-precision-design.md` for the
+   * reasoning.
+   */
+  referencePointMeters: Point;
 
   /**
    * Tile width in pixels.
@@ -292,6 +304,11 @@ export class RasterTileset2D extends Tileset2D {
       bottomRight,
     };
 
+    const referencePointMeters: Point = [
+      (topLeft[0] + topRight[0] + bottomLeft[0] + bottomRight[0]) / 4,
+      (topLeft[1] + topRight[1] + bottomLeft[1] + bottomRight[1]) / 4,
+    ];
+
     // Also compute axis-aligned bounding box for compatibility
     const projectedBounds: Bounds = [
       Math.min(topLeft[0], topRight[0], bottomLeft[0], bottomRight[0]),
@@ -326,6 +343,7 @@ export class RasterTileset2D extends Tileset2D {
         top: projectedBounds[3],
       },
       projectedCorners,
+      referencePointMeters,
       tileWidth,
       tileHeight,
       forwardTransform,

--- a/packages/deck.gl-raster/tests/raster-layer.test.ts
+++ b/packages/deck.gl-raster/tests/raster-layer.test.ts
@@ -84,3 +84,79 @@ describe("RasterLayer.state.mesh", () => {
     expect(layers1[0]!.props.mesh).toBe(layers2[0]!.props.mesh);
   });
 });
+
+describe("RasterLayer.referencePointMeters", () => {
+  function makeBareLayerWithRef(referencePointMeters: [number, number] | null) {
+    const layer = new RasterLayer({
+      id: "test",
+      width: 4,
+      height: 4,
+      reprojectionFns: REPROJECTION_FNS,
+      image: {} as never,
+      referencePointMeters: referencePointMeters ?? undefined,
+    });
+    const internalState: Record<string, unknown> = {};
+    Object.assign(layer as object, { state: internalState });
+    Object.assign(layer as object, {
+      setState: (updates: Record<string, unknown>) =>
+        Object.assign(internalState, updates),
+      getSubLayerProps: <T>(props: T) => props,
+    });
+    return { layer, internalState };
+  }
+
+  it("writes positions unchanged when referencePointMeters is omitted", () => {
+    const { layer: layerA, internalState: stateA } = makeBareLayerWithRef(null);
+    const { layer: layerB, internalState: stateB } = makeBareLayerWithRef(null);
+
+    (layerA as unknown as { _generateMesh: () => void })._generateMesh();
+    (layerB as unknown as { _generateMesh: () => void })._generateMesh();
+
+    const posA = (stateA.mesh as WrappedMesh).attributes.POSITION.value;
+    const posB = (stateB.mesh as WrappedMesh).attributes.POSITION.value;
+    expect(Array.from(posA)).toEqual(Array.from(posB));
+  });
+
+  it("stores Float32 offsets when referencePointMeters is provided", () => {
+    // Simulate a high-zoom tile centered at ~13M meters in 3857 (somewhere in
+    // North America). Without reference subtraction, float32 quantization at
+    // this magnitude is ~1-2 m. With subtraction, offsets are small (< 10 m)
+    // and float32 precision is ample.
+    const REF_X = 13_000_000;
+    const REF_Y = 4_500_000;
+    const SUB = 0.3; // 30 cm/pixel — typical NAIP-class resolution.
+    const fns: ReprojectionFns = {
+      forwardTransform: identity,
+      inverseTransform: identity,
+      forwardReproject: (px, py) => [REF_X + px * SUB, REF_Y + py * SUB],
+      inverseReproject: (x, y) => [(x - REF_X) / SUB, (y - REF_Y) / SUB],
+    };
+
+    const layer = new RasterLayer({
+      id: "test",
+      width: 4,
+      height: 4,
+      reprojectionFns: fns,
+      image: {} as never,
+      referencePointMeters: [REF_X, REF_Y],
+    });
+    const internalState: Record<string, unknown> = {};
+    Object.assign(layer as object, { state: internalState });
+    Object.assign(layer as object, {
+      setState: (updates: Record<string, unknown>) =>
+        Object.assign(internalState, updates),
+      getSubLayerProps: <T>(props: T) => props,
+    });
+
+    (layer as unknown as { _generateMesh: () => void })._generateMesh();
+
+    const positions = (internalState.mesh as WrappedMesh).attributes.POSITION
+      .value;
+    // Every stored x/y should be a small offset (≤ a few meters), not the
+    // absolute 13M-meter magnitude.
+    for (let i = 0; i < positions.length; i += 3) {
+      expect(Math.abs(positions[i]!)).toBeLessThan(10);
+      expect(Math.abs(positions[i + 1]!)).toBeLessThan(10);
+    }
+  });
+});

--- a/packages/deck.gl-raster/tests/raster-tileset/raster-tileset-2d-tile-transform.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tileset/raster-tileset-2d-tile-transform.test.ts
@@ -51,3 +51,32 @@ describe("RasterTileset2D.getTileMetadata", () => {
     expect(py).toBeCloseTo(0, 10);
   });
 });
+
+describe("RasterTileset2D.getTileMetadata referencePointMeters", () => {
+  it("computes the centroid of projectedCorners in projected (3857) coordinates", () => {
+    const level = new AffineTilesetLevel({
+      affine: compose(translation(100, 200), scale(10, -10)),
+      arrayWidth: 8,
+      arrayHeight: 8,
+      tileWidth: 4,
+      tileHeight: 4,
+      mpu: 1,
+    });
+    const descriptor = new AffineTileset({
+      levels: [level],
+      ...PROJECTIONS,
+    });
+    const tileset = new RasterTileset2D(tilesetProps(), descriptor);
+
+    const metadata = tileset.getTileMetadata({ x: 1, y: 1, z: 0 });
+    const { topLeft, topRight, bottomLeft, bottomRight } =
+      metadata.projectedCorners;
+    const expectedX =
+      (topLeft[0] + topRight[0] + bottomLeft[0] + bottomRight[0]) / 4;
+    const expectedY =
+      (topLeft[1] + topRight[1] + bottomLeft[1] + bottomRight[1]) / 4;
+
+    expect(metadata.referencePointMeters[0]).toBeCloseTo(expectedX, 10);
+    expect(metadata.referencePointMeters[1]).toBeCloseTo(expectedY, 10);
+  });
+});


### PR DESCRIPTION
This branch: lots of jitter, and in particular **per tile independent jitter** so we have little gaps between tiles. Jitter noticeably starts above ~z16


https://github.com/user-attachments/assets/cbcd2e56-648e-4642-a067-4fd7f828d1a2


-----


> **Closed without merging — this is a record of an approach to #512 that did not work.** The working fix is **#559**. See that PR (and `dev-docs/coordinate-systems.md` on it) for the full analysis.

## What this tried

Attack the high-zoom jitter (#512) by keeping mesh vertex magnitudes small: store each vertex as an **offset from a per-tile reference point** (the tile centroid in EPSG:3857 meters) instead of an absolute coordinate, then add the reference back via the layer transform. Iterations on this branch (and follow-on experiments in the session that produced it):

1. Offset subtraction in the mesh + per-tile reference baked into `modelMatrix.translation`.
2. Per-tile `coordinateOrigin` (let deck.gl's auto-offset subtract it).
3. Shared per-frame `coordinateOrigin = viewport.center`, per-tile shift in `modelMatrix.translation`.

## Why it didn't work

- **Tile seams.** Encoding a *shared boundary vertex* differently in adjacent tiles (e.g. `+305` in tile A, `−305` in tile B) makes the two tiles run different float32 arithmetic chains for the same physical point. The sub-pixel disagreement gets amplified by GPU rasterization coverage rounding into visible 1-px seams — which `main` does not have (it stores the same absolute value in both tiles, so they're bit-identical). The seam is structural to *any* per-tile encoding, regardless of where the reference shift lives.
- **No real precision win.** Even when numerically sub-pixel, the auto-offset origin uniform (`shaderCoordinateOrigin`) is itself float32 at ~10² world-unit magnitude, leaving a ~1 m floor — indistinguishable from `main`.

## What actually fixed it (#559)

Render the mesh in **common space** with an **identity model matrix** and **`coordinateOrigin = [0,0,0]`** (so `shaderCoordinateOrigin` is exactly `Math.fround(viewport.center)` and the camera-relative subtraction is Sterbenz-exact), plus **fp64 attribute pairs** for the vertex positions. Absolute common-space coords keep shared boundary vertices bit-identical → no seams. Full write-up in #559.

Related: #512