### PR TITLE
fix(deck.gl-geotiff): Re-register proj4 projections to survive CDN tree-shaking

### DIFF
--- a/packages/deck.gl-geotiff/package.json
+++ b/packages/deck.gl-geotiff/package.json
@@ -11,7 +11,9 @@
       "default": "./dist/index.js"
     }
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/proj4-init.js"
+  ],
   "files": [
     "dist"
   ],

--- a/packages/deck.gl-geotiff/src/index.ts
+++ b/packages/deck.gl-geotiff/src/index.ts
@@ -1,3 +1,5 @@
+import "./proj4-init.js";
+
 export type {
   COGLayerProps,
   GetTileDataOptions,

--- a/packages/deck.gl-geotiff/src/proj4-init.ts
+++ b/packages/deck.gl-geotiff/src/proj4-init.ts
@@ -1,0 +1,15 @@
+import proj4 from "proj4";
+// @ts-expect-error — proj4/projs has no published types
+import includedProjections from "proj4/projs";
+
+// Re-register proj4's built-in projection classes (utm, lcc, tmerc, …).
+//
+// proj4/lib/index.js calls includedProjections(proj4) at module init, but
+// CDN bundlers (esm.sh, jsDelivr /+esm, …) can drop that side-effect call
+// when re-bundling, leaving only merc/longlat registered and breaking any
+// non-trivial COG. See esm.sh#754. Calling it from our own entry keeps the
+// registration in code the bundler must preserve.
+//
+// This file is the only intentional side-effect in the package and is the
+// sole entry listed in `"sideEffects"` in package.json.
+(includedProjections as (p: typeof proj4) => void)(proj4);


### PR DESCRIPTION
proj4/lib/index.js calls includedProjections(proj4) at module init to register utm, lcc, tmerc, and the rest of the built-in projection classes. CDN bundlers such as esm.sh and jsDelivr /+esm drop that side-effect call when re-bundling our package, leaving only merc and longlat registered. The result is that any non-trivial COG (UTM, LCC, state-plane, NZTM2000, ...) throws "No code 'foo' found" at runtime when deck.gl-geotiff is loaded from a CDN, while npm/Vite/webpack consumers are unaffected.

Add a dedicated `proj4-init.ts` module that calls
`includedProjections(proj4)` itself, side-effect-import it from `src/index.ts` so every consumer of the package (COGLayer, MosaicLayer, MultiCOGLayer, geotiff helpers) picks it up, and narrow `"sideEffects": false` to `["./dist/proj4-init.js"]` so bundlers preserve only this file's effect and keep tree-shaking everything else.