### PR TITLE
fix: use direct s3 url for aef-mosaic example

### DIFF
--- a/examples/aef-mosaic/src/aef/constants.ts
+++ b/examples/aef-mosaic/src/aef/constants.ts
@@ -3,7 +3,10 @@
  *
  * See https://source.coop/tge-labs/aef-mosaic.
  */
-export const ZARR_URL = "https://data.source.coop/tge-labs/aef-mosaic";
+// We use the S3 URL directly to work around current source.coop bug of not sending Content-Length header
+// export const ZARR_URL = "https://data.source.coop/tge-labs/aef-mosaic";
+export const ZARR_URL =
+  "https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop/tge-labs/aef-mosaic";
 
 /** Path to the embeddings array within the root group. */
 export const VARIABLE = "embeddings";


### PR DESCRIPTION
Similar to #595 

We use the S3 URL directly to work around current source.coop bug of not sending Content-Length header

See https://github.com/manzt/zarrita.js/issues/432

cc @martham93 