### PR TITLE
fix: Reduce max requests in aef mosaic example

### DIFF
--- a/examples/aef-mosaic/src/App.tsx
+++ b/examples/aef-mosaic/src/App.tsx
@@ -98,9 +98,6 @@ export default function App() {
             renderTile,
             onTileUnload: (tile) => tile.content?.texture.destroy(),
             minZoom: MIN_ZOOM,
-            // source.coop supports HTTP/2 multiplexing, so increase concurrent
-            // requests beyond browser limit of 6 per HTTP/1.1 domain
-            maxRequests: 20,
             // Tiles are heavy, so limit GPU pressure with small cache size
             maxCacheSize: 10,
             updateTriggers: {


### PR DESCRIPTION
Post #596 , we also need to fall back down to 6 requests at a time, since we're on HTTP/1.1 again