### PR TITLE
refactor!: Flatten `texture` exports from `geotiff/texture.js`

### DIFF
--- a/packages/deck.gl-geotiff/src/index.ts
+++ b/packages/deck.gl-geotiff/src/index.ts
@@ -5,7 +5,7 @@ export type {
 export { COGLayer } from "./cog-layer.js";
 export { DEFAULT_CONCURRENCY_LIMITER } from "./default-concurrency-limiter.js";
 export { addAlphaChannel } from "./geotiff/geotiff.js";
-export * as texture from "./geotiff/texture.js";
+export { createTextureProps, inferTextureFormat } from "./geotiff/texture.js";
 export type { MosaicLayerProps } from "./mosaic-layer/mosaic-layer.js";
 export { MosaicLayer } from "./mosaic-layer/mosaic-layer.js";
 export type { MosaicSource } from "./mosaic-layer/mosaic-tileset-2d.js";


### PR DESCRIPTION
For some reason the docs started failing, I think from this re-export.

In any case, I don't like this re-export because there are only two elements from inside it.