### PR TITLE
docs: Add git submodule install instructions

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -2,6 +2,14 @@
 
 This is a monorepo managed with pnpm workspaces.
 
+Some packages (e.g. `morecantile`, `geozarr`) reference files from git submodules.
+Initialize them before building, otherwise `pnpm build` fails with `TS6053: File '...' not found`:
+
+```bash
+# Initialize git submodules (required for the build)
+git submodule update --init --recursive
+```
+
 ```bash
 # Install dependencies
 pnpm install

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -2,15 +2,15 @@
 
 This is a monorepo managed with pnpm workspaces.
 
+## Package setup
+
 Some packages (e.g. `morecantile`, `geozarr`) reference files from git submodules.
-Initialize them before building, otherwise `pnpm build` fails with `TS6053: File '...' not found`:
+Initialize them before building.
 
 ```bash
 # Initialize git submodules (required for the build)
 git submodule update --init --recursive
-```
 
-```bash
 # Install dependencies
 pnpm install
 
@@ -19,7 +19,11 @@ pnpm build
 
 # Watch mode for development
 pnpm build:watch
+```
 
+## Package Testing
+
+```bash
 # Run tests in all packages
 pnpm test
 

--- a/examples/cog-basic/README.md
+++ b/examples/cog-basic/README.md
@@ -19,20 +19,13 @@ The example displays 10m resolution RGB imagery of New Zealand from LINZ (Land I
 
 ## Setup
 
-1. Install dependencies from the repository root:
-   ```bash
-   pnpm install
-   ```
+1. Follow instructions for package setup in [DEVELOP.md](../../DEVELOP.md#package-setup).
 
-2. Build the packages:
-   ```bash
-   pnpm build
-   ```
+2. Run the development server:
 
-3. Run the development server:
    ```bash
    cd examples/cog-basic
    pnpm dev
    ```
 
-4. Open your browser to http://localhost:3000
+3. Open your browser to http://localhost:3000


### PR DESCRIPTION
While attempting to run the examples locally, I found a step was missing (I think?) from the setup instructions which is to install git submodules. This PR adds instructions for doing install git submodules.

I also thought it might be easier in the future to maintain all setup instructions in one place and link to that on the individual examples pages, but I can revert that change if you like have standalone READMEs for each example. (Or if you like that change I can apply it across examples)