### PR TITLE
fix: Plumb material prop to MeshTextureLayer so rasters can render unlit

### DIFF
--- a/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
+++ b/packages/deck.gl-raster/src/mesh-layer/mesh-layer.ts
@@ -175,6 +175,19 @@ export class MeshTextureLayer extends SimpleMeshLayer<
       shaderProps[m.module.name] = m.props || {};
     }
 
+    // deck.gl documents `material: false` as the way to render a mesh unlit,
+    // but in deck.gl v9 the LightingEffect forwards the raw `false` to
+    // luma.gl's ShaderInputs, which coerces falsy module props to `{}` and so
+    // silently re-applies the *default* phong material (ambient 0.35,
+    // diffuse 0.6). Translate a disabled material into the phongMaterial
+    // module's `unlit` flag ourselves so raster values render verbatim (like
+    // `BitmapLayer`). This runs after the LightingEffect's module props are
+    // applied for the frame (`Layer._drawLayer` sets effect shaderModuleProps
+    // before calling `draw`), so it reliably wins.
+    if (!this.props.material) {
+      shaderProps.phongMaterial = { unlit: true };
+    }
+
     for (const m of super.getModels()) {
       m.shaderInputs.setProps(shaderProps);
     }

--- a/packages/deck.gl-raster/src/raster-layer.ts
+++ b/packages/deck.gl-raster/src/raster-layer.ts
@@ -2,6 +2,7 @@ import type {
   CompositeLayerProps,
   DefaultProps,
   Layer,
+  Material,
   TextureSource,
   UpdateParameters,
 } from "@deck.gl/core";
@@ -119,6 +120,21 @@ export interface RasterLayerProps extends CompositeLayerProps {
 
   /** Opacity of the debug overlay. */
   debugOpacity?: number;
+
+  /**
+   * Lighting material forwarded to the underlying {@link MeshTextureLayer}
+   * (a `SimpleMeshLayer` subclass). Follows deck.gl's `material` convention:
+   * pass `false` to render the raster unlit, so pixel values display verbatim
+   * even when the scene has a `LightingEffect` with ambient intensity < 1
+   * (matching `BitmapLayer` behavior).
+   *
+   * When omitted, `MeshTextureLayer`'s default material applies
+   * (`{ambient: 1, diffuse: 0, shininess: 0, specularColor: [0, 0, 0]}`),
+   * which is lighting-neutral only when the scene's ambient intensity is 1.
+   *
+   * @default undefined
+   */
+  material?: Material;
 }
 
 const defaultProps: DefaultProps<RasterLayerProps> = {
@@ -333,7 +349,7 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
 
   renderLayers() {
     const { mesh, positions64Low } = this.state;
-    const { debug, image, renderPipeline } = this.props;
+    const { debug, image, renderPipeline, material } = this.props;
 
     // mesh and positions64Low are always set together by _generateMesh.
     if (
@@ -349,6 +365,10 @@ export class RasterLayer extends CompositeLayer<RasterLayerProps> {
         id: "raster",
         image,
         renderPipeline,
+        // Forward only when set: an explicit `material: undefined` own-prop
+        // would shadow MeshTextureLayer's default material (deck.gl props are
+        // prototype-chained onto defaultProps).
+        ...(material !== undefined && { material }),
         // Single mesh rendered as one non-instanced draw.
         data: { length: 1, attributes: { positions64Low } },
         mesh,

--- a/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
+++ b/packages/deck.gl-raster/src/raster-tile-layer/raster-tile-layer.ts
@@ -3,6 +3,7 @@ import type {
   CoordinateSystem,
   DefaultProps,
   Layer,
+  Material,
 } from "@deck.gl/core";
 import { CompositeLayer } from "@deck.gl/core";
 import type {
@@ -128,6 +129,15 @@ export type RasterTileLayerProps<
      * @default 0.5
      */
     debugOpacity?: number;
+
+    /**
+     * Lighting material forwarded through {@link RasterLayer} to the
+     * underlying mesh layer. Pass `false` to render tiles unlit (pixel values
+     * verbatim, like `BitmapLayer`), e.g. when the scene uses a
+     * `LightingEffect` with ambient intensity < 1 for 3D layers.
+     * @default undefined
+     */
+    material?: Material;
 
     /**
      * AbortSignal applied to every tile fetch, composed with TileLayer's
@@ -390,7 +400,7 @@ export class RasterTileLayer<
     descriptor: RasterTilesetDescriptor,
     renderTile: NonNullable<RasterTileLayerProps<DataT>["renderTile"]>,
   ): Layer[] {
-    const { maxError, debug, debugOpacity } = this.props;
+    const { maxError, debug, debugOpacity, material } = this.props;
     const tile = props.tile as Tile2DHeader<DataT> & RasterTileMetadata;
 
     const debugLayers = debug
@@ -452,6 +462,9 @@ export class RasterTileLayer<
         ...(image !== undefined && { image }),
         renderPipeline,
         maxError,
+        // Forward only when set so RasterLayer's sublayer default handling
+        // (and MeshTextureLayer's default material) is untouched when omitted.
+        ...(material !== undefined && { material }),
         reprojectionFns,
         // Web Mercator: clamp the mesh to the valid latitude band for tiles
         // past ±85.051°. Globe renders the full mesh (it shows the poles).

--- a/packages/deck.gl-raster/tests/mesh-layer.test.ts
+++ b/packages/deck.gl-raster/tests/mesh-layer.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MeshTextureLayer } from "../src/mesh-layer/mesh-layer.js";
+
+/**
+ * Drive `draw()` directly with a stubbed model, spying on the parent
+ * (SimpleMeshLayer) draw so no GPU work happens. Captures the shader module
+ * props MeshTextureLayer sets per frame.
+ */
+function drawAndCaptureShaderProps(layerProps: Record<string, unknown>) {
+  const layer = new MeshTextureLayer({
+    id: "test",
+    image: {} as never,
+    ...layerProps,
+  });
+  const setProps = vi.fn();
+  const models = [{ shaderInputs: { setProps } }];
+  const drawSpy = vi
+    .spyOn(
+      Object.getPrototypeOf(Object.getPrototypeOf(layer)) as {
+        draw: (opts: unknown) => void;
+      },
+      "draw",
+    )
+    .mockImplementation(() => {});
+  const getModelsSpy = vi
+    .spyOn(
+      Object.getPrototypeOf(Object.getPrototypeOf(layer)) as {
+        getModels: () => unknown[];
+      },
+      "getModels",
+    )
+    .mockReturnValue(models);
+
+  try {
+    (layer as unknown as { draw: (opts: unknown) => void }).draw({});
+    expect(setProps).toHaveBeenCalledTimes(1);
+    return setProps.mock.calls[0]![0] as Record<string, unknown>;
+  } finally {
+    drawSpy.mockRestore();
+    getModelsSpy.mockRestore();
+  }
+}
+
+describe("MeshTextureLayer unlit material translation", () => {
+  it("translates material: false into phongMaterial {unlit: true} module props", () => {
+    // deck.gl v9's LightingEffect forwards the raw `false` to luma.gl, which
+    // coerces falsy module props to `{}` and re-applies the default *lit*
+    // phong material — so the layer must set the `unlit` flag itself.
+    const shaderProps = drawAndCaptureShaderProps({ material: false });
+    expect(shaderProps.phongMaterial).toEqual({ unlit: true });
+  });
+
+  it("leaves phongMaterial untouched when the default material applies", () => {
+    const shaderProps = drawAndCaptureShaderProps({});
+    expect(shaderProps).not.toHaveProperty("phongMaterial");
+  });
+
+  it("leaves phongMaterial untouched for a custom material object", () => {
+    const shaderProps = drawAndCaptureShaderProps({
+      material: { ambient: 0.5, diffuse: 0.5 },
+    });
+    expect(shaderProps).not.toHaveProperty("phongMaterial");
+  });
+});

--- a/packages/deck.gl-raster/tests/raster-layer.test.ts
+++ b/packages/deck.gl-raster/tests/raster-layer.test.ts
@@ -26,13 +26,14 @@ const REPROJECTION_FNS: ReprojectionFns = {
  * object + assign, and short-circuits `getSubLayerProps` so MeshTextureLayer
  * receives the exact prop shape we hand it.
  */
-function makeBareLayer() {
+function makeBareLayer(extraProps: Record<string, unknown> = {}) {
   const layer = new RasterLayer({
     id: "test",
     width: 4,
     height: 4,
     reprojectionFns: REPROJECTION_FNS,
     image: {} as never,
+    ...extraProps,
   });
   const internalState: Record<string, unknown> = {};
   Object.assign(layer as object, { state: internalState });
@@ -82,6 +83,42 @@ describe("RasterLayer.state.mesh", () => {
     expect(layers1[0]!.props.mesh).toBe(meshRef);
     expect(layers2[0]!.props.mesh).toBe(meshRef);
     expect(layers1[0]!.props.mesh).toBe(layers2[0]!.props.mesh);
+  });
+});
+
+describe("RasterLayer material forwarding", () => {
+  function renderMeshLayer(extraProps: Record<string, unknown> = {}) {
+    const { layer } = makeBareLayer(extraProps);
+    (layer as unknown as { _generateMesh: () => void })._generateMesh();
+    const [meshLayer] = (
+      layer as unknown as {
+        renderLayers: () => { props: Record<string, unknown> }[];
+      }
+    ).renderLayers();
+    return meshLayer!;
+  }
+
+  it("forwards material: false to MeshTextureLayer", () => {
+    const meshLayer = renderMeshLayer({ material: false });
+    expect(meshLayer.props.material).toBe(false);
+  });
+
+  it("forwards a material object to MeshTextureLayer by reference", () => {
+    const material = {
+      ambient: 0.8,
+      diffuse: 0.2,
+      shininess: 1,
+      specularColor: [0, 0, 0] as [number, number, number],
+    };
+    const meshLayer = renderMeshLayer({ material });
+    expect(meshLayer.props.material).toBe(material);
+  });
+
+  it("omits the material key when unset, preserving MeshTextureLayer's default", () => {
+    const meshLayer = renderMeshLayer();
+    // The key must be absent (not `undefined`): an explicit own-property would
+    // shadow MeshTextureLayer's prototype-chained default material.
+    expect("material" in meshLayer.props).toBe(false);
   });
 });
 

--- a/packages/deck.gl-raster/tests/raster-tile-layer/material-forwarding.test.ts
+++ b/packages/deck.gl-raster/tests/raster-tile-layer/material-forwarding.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/raster-layer.js", () => ({
+  RasterLayer: class CapturingRasterLayer {
+    public props: Record<string, unknown>;
+    constructor(props: Record<string, unknown>) {
+      this.props = props;
+    }
+  },
+}));
+
+const { RasterTileLayer } = await import(
+  "../../src/raster-tile-layer/raster-tile-layer.js"
+);
+
+const identity = (x: number, y: number): [number, number] => [x, y];
+
+/**
+ * Drive `_renderSubLayers` directly (non-globe path), bypassing deck.gl's
+ * LayerManager: stub the viewport context, short-circuit `getSubLayerProps`,
+ * and hand it a minimal tile + descriptor. The mocked RasterLayer captures
+ * the props it would have been constructed with.
+ */
+function renderRasterSubLayer(layerProps: Record<string, unknown> = {}) {
+  const layer = new RasterTileLayer({ id: "test", ...layerProps });
+  Object.assign(layer as object, {
+    context: { viewport: { resolution: undefined } },
+    getSubLayerProps: <T>(props: T) => props,
+  });
+
+  const tile = {
+    index: { x: 0, y: 0, z: 0 },
+    forwardTransform: identity,
+    inverseTransform: identity,
+    _projectPosition: identity,
+    _unprojectPosition: identity,
+    _webMercatorInitialTriangulation: undefined,
+  };
+  const subLayerInput = {
+    id: "tile-0-0-0",
+    data: { width: 4, height: 4 },
+    _offset: 0,
+    tile,
+  };
+  const descriptor = {
+    projectTo4326: identity,
+    projectFrom4326: identity,
+  };
+  const renderTile = () => ({ image: {} });
+
+  const [rasterLayer] = (
+    layer as unknown as {
+      _renderSubLayers: (
+        props: unknown,
+        descriptor: unknown,
+        renderTile: unknown,
+      ) => { props: Record<string, unknown> }[];
+    }
+  )._renderSubLayers(subLayerInput, descriptor, renderTile);
+  return rasterLayer!;
+}
+
+describe("RasterTileLayer material forwarding", () => {
+  it("forwards material: false to RasterLayer", () => {
+    const rasterLayer = renderRasterSubLayer({ material: false });
+    expect(rasterLayer.props.material).toBe(false);
+  });
+
+  it("forwards a material object to RasterLayer by reference", () => {
+    const material = {
+      ambient: 0.8,
+      diffuse: 0.2,
+      shininess: 1,
+      specularColor: [0, 0, 0] as [number, number, number],
+    };
+    const rasterLayer = renderRasterSubLayer({ material });
+    expect(rasterLayer.props.material).toBe(material);
+  });
+
+  it("omits the material key when the prop is unset", () => {
+    const rasterLayer = renderRasterSubLayer();
+    // The key must be absent (not `undefined`): an explicit own-property would
+    // shadow the sublayer's prototype-chained default material.
+    expect("material" in rasterLayer.props).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #612

## Problem

Raster imagery drawn through `MeshTextureLayer` (so `RasterLayer`, `RasterTileLayer`, and `COGLayer`) is uniformly darkened whenever the deck.gl scene has a `LightingEffect` with ambient intensity < 1 — a common setup when the same scene lights 3D extrusions. Rendered pixels come out at roughly `fileValue × ambientIntensity` (we measured 40% and 60% in two production views), while `BitmapLayer` imagery in the same scene shows true values.

The default `material: { ambient: 1.0, diffuse: 0.0, ... }` intends to neutralize lighting, but the phong ambient term is `material.ambient × ambientLight.color × ambientLight.intensity × surfaceColor` — neutral only when the scene's ambient intensity is exactly 1.0. And there is no consumer-facing escape hatch: `_subLayerProps` can't reach the mesh layer through the tile-layer indirection.

## Change

- **`RasterTileLayer` / `RasterLayer`**: new optional `material?: Material` prop (deck.gl's standard type; `false` = unlit), forwarded down the chain **only when set** (`...(material !== undefined && { material })`) so the current default behavior is untouched for existing consumers. `COGLayer` inherits the prop via `RasterTileLayer` with no deck.gl-geotiff changes.
- **`MeshTextureLayer.draw()`**: translates a falsy `material` into `phongMaterial: { unlit: true }` shader-module props.

The translation is needed because deck.gl v9 regressed `material: false`: `LightingEffect.getShaderModuleProps()` forwards the layer's raw `material` prop as the `phongMaterial` module props, and luma.gl's `ShaderInputs.setProps()` coerces falsy module props to `{}` —

```js
const moduleProps = props[moduleName] || {};
```

— which re-applies the **default lit** phong material (`ambient 0.35, diffuse 0.6`). The unlit escape hatch already exists in the shader (`if (material.unlit) return surfaceColor;` in `@luma.gl/shadertools`); it's just unreachable via `material: false` in v9. `MeshTextureLayer.draw()` already sets per-frame module props after the effect's props are applied (`Layer._drawLayer` order), so the translation deterministically wins. This also fixes `material: false` for anyone passing it directly to `MeshTextureLayer` today.

Result:

```ts
new COGLayer({ ..., material: false })  // renders pixel values verbatim, like BitmapLayer
```

We considered a raster-specific boolean (e.g. `lighting: false`) instead — happy to rename, but `material` follows the `SimpleMeshLayer` convention and gives custom-material control for free.

## Testing

- `tests/raster-layer.test.ts`: forwards `material: false` / material object to `MeshTextureLayer`; key **absent** (not `undefined`) when unset, pinning the default-preserving conditional spread.
- `tests/raster-tile-layer/material-forwarding.test.ts` (new): same assertions across `RasterTileLayer._renderSubLayers` → `RasterLayer`.
- `tests/mesh-layer.test.ts` (new): `material: false` → `setProps` called with `phongMaterial: {unlit: true}`; default and custom materials leave `phongMaterial` untouched.

`pnpm --filter @developmentseed/deck.gl-raster test` (146 passed), `pnpm lint`, `pnpm --filter @developmentseed/deck.gl-raster typecheck` all green (the `docs` workspace typecheck failure pre-exists on main — missing generated typedoc sidebar).

Verified end-to-end in our production app (AGROZOOM COG imagery over a scene lit at ambient 0.4/0.6): `material: false` renders identically to a patched unlit shader; omitting the prop reproduces today's behavior exactly.
