### PR TITLE
fix: handle `spatial:registration = node` in geozarr properties

### DIFF
--- a/packages/affine/src/affine.ts
+++ b/packages/affine/src/affine.ts
@@ -174,6 +174,19 @@ export function compose(
 }
 
 /**
+ * Convert a point/node-registered raster transform to an area/pixel-registered
+ * transform.
+ *
+ * Point-registered rasters locate integer pixel coordinates at sample points.
+ * The raster rendering path expects integer pixel coordinates to describe
+ * pixel edges, so the transform is shifted by half a pixel in source pixel
+ * space. Equivalent to `compose(affine, translation(-0.5, -0.5))`.
+ */
+export function pixelIsPointToArea(affine: Affine): Affine {
+  return compose(affine, translation(-0.5, -0.5));
+}
+
+/**
  * Compute the inverse of an Affine.
  *
  * @param affine  The affine transform to invert.

--- a/packages/affine/tests/affine.test.ts
+++ b/packages/affine/tests/affine.test.ts
@@ -5,6 +5,7 @@ import {
   compose,
   identity,
   invert,
+  pixelIsPointToArea,
   rotation,
   scale,
   translation,
@@ -72,6 +73,18 @@ describe("compose", () => {
     const t = translation(10, 20);
     const s = scale(2, 3);
     expect(compose(t, s)).not.toEqual(compose(s, t));
+  });
+});
+
+describe("pixelIsPointToArea", () => {
+  it("shifts point-registered pixels to area edges", () => {
+    const gt: Affine = [10, 0, 100, 0, -10, 200];
+    expect(pixelIsPointToArea(gt)).toEqual([10, 0, 95, 0, -10, 205]);
+  });
+
+  it("handles rotated or sheared transforms", () => {
+    const gt: Affine = [10, 2, 100, 3, -10, 200];
+    expect(pixelIsPointToArea(gt)).toEqual([10, 2, 94, 3, -10, 203.5]);
   });
 });
 

--- a/packages/deck.gl-zarr/src/zarr-tileset.ts
+++ b/packages/deck.gl-zarr/src/zarr-tileset.ts
@@ -1,8 +1,8 @@
+import { pixelIsPointToArea } from "@developmentseed/affine";
 import type {
   ProjectionFunction,
   RasterTilesetDescriptor,
 } from "@developmentseed/deck.gl-raster";
-import { pixelIsPointToArea } from "@developmentseed/affine";
 import {
   AffineTileset,
   AffineTilesetLevel,

--- a/packages/deck.gl-zarr/src/zarr-tileset.ts
+++ b/packages/deck.gl-zarr/src/zarr-tileset.ts
@@ -2,6 +2,7 @@ import type {
   ProjectionFunction,
   RasterTilesetDescriptor,
 } from "@developmentseed/deck.gl-raster";
+import { pixelIsPointToArea } from "@developmentseed/affine";
 import {
   AffineTileset,
   AffineTilesetLevel,
@@ -46,7 +47,10 @@ export function geoZarrToDescriptor(
   const levels = reversedLevels.map((level, i) => {
     const chunk = reversedChunks[i]!;
     return new AffineTilesetLevel({
-      affine: level.affine,
+      affine:
+        meta.registration === "node"
+          ? pixelIsPointToArea(level.affine)
+          : level.affine,
       arrayWidth: level.arrayWidth,
       arrayHeight: level.arrayHeight,
       tileWidth: chunk.width,

--- a/packages/deck.gl-zarr/tests/tile-transform.test.ts
+++ b/packages/deck.gl-zarr/tests/tile-transform.test.ts
@@ -19,6 +19,11 @@ const META: GeoZarrMetadata = {
   ],
 } as unknown as GeoZarrMetadata;
 
+const NODE_REGISTERED_META: GeoZarrMetadata = {
+  ...META,
+  registration: "node",
+};
+
 describe("ZarrTilesetLevel.tileTransform", () => {
   const descriptor = geoZarrToDescriptor(META, {
     projectTo4326: identityProjection,
@@ -45,5 +50,21 @@ describe("ZarrTilesetLevel.tileTransform", () => {
     const [px, py] = inverseTransform(cx, cy);
     expect(px).toBeCloseTo(2.5, 10);
     expect(py).toBeCloseTo(1.5, 10);
+  });
+
+  it("offsets node-registered rasters by half a pixel", () => {
+    const nodeDescriptor = geoZarrToDescriptor(NODE_REGISTERED_META, {
+      projectTo4326: identityProjection,
+      projectFrom4326: identityProjection,
+      projectTo3857: identityProjection,
+      projectFrom3857: identityProjection,
+      chunkSizes: [{ width: 4, height: 4 }],
+      mpu: 1,
+    });
+
+    const { forwardTransform } = nodeDescriptor.levels[0]!.tileTransform(0, 0);
+    const [x, y] = forwardTransform(0, 0);
+    expect(x).toBeCloseTo(95, 10);
+    expect(y).toBeCloseTo(205, 10);
   });
 });

--- a/packages/geotiff/src/transform.ts
+++ b/packages/geotiff/src/transform.ts
@@ -1,6 +1,6 @@
 import { RasterTypeKey } from "@cogeotiff/core";
 import type { Affine } from "@developmentseed/affine";
-import { apply, compose, invert, translation } from "@developmentseed/affine";
+import { apply, invert, pixelIsPointToArea } from "@developmentseed/affine";
 
 export function createTransform({
   modelTiepoint,
@@ -27,7 +27,7 @@ export function createTransform({
 
   // Offset transform by half pixel for point-interpreted rasters.
   if (rasterType === RasterTypeKey.PixelIsPoint) {
-    transform = compose(transform, translation(-0.5, -0.5));
+    transform = pixelIsPointToArea(transform);
   }
 
   return transform;

--- a/packages/geozarr/src/parse.ts
+++ b/packages/geozarr/src/parse.ts
@@ -112,5 +112,12 @@ export function parseGeoZarrMetadata(attrs: unknown): GeoZarrMetadata {
     ];
   }
 
-  return { levels, crs, axes, yAxisIndex, xAxisIndex };
+  return {
+    levels,
+    crs,
+    registration: spatial["spatial:registration"] ?? "pixel",
+    axes,
+    yAxisIndex,
+    xAxisIndex,
+  };
 }

--- a/packages/geozarr/src/types.ts
+++ b/packages/geozarr/src/types.ts
@@ -38,6 +38,8 @@ export interface GeoZarrMetadata {
   levels: MultiscaleLevel[];
   /** CRS extracted from the geo-proj convention. */
   crs: CRSInfo;
+  /** Pixel interpretation from the spatial convention. */
+  registration: "pixel" | "node";
   /** Axis names from the spatial convention, e.g. ["y", "x"] or ["time", "y", "x"]. */
   axes: string[];
   /** Index of the y axis in `axes`. */


### PR DESCRIPTION
Addresses #614 

This takes the logic from the GeoTiff pixel area handling, extracts it to the affine shared package, and then applies it to the Zarr handling when `spatial:registration = node` is set. Previously, the property was parsed, but not used for anything. 