### PR TITLE
feat(examples): add tile loading indicator

### DIFF
--- a/dev-docs/specs/2026-07-10-tile-loading-indicator-design.md
+++ b/dev-docs/specs/2026-07-10-tile-loading-indicator-design.md
@@ -63,10 +63,12 @@ Resetting to "done" is authoritative via the layer's `onViewportLoad`.
 - When true: a rounded pill at top-center containing a Chakra `Spinner` and the
   `label` text (default `"Loading tiles…"`).
 - Contains **no logic** — purely `loading` in, pill out.
-- Positioned inside the existing pointer-events-none
-  [`UIOverlay`](../../examples/_shared/components/ui-overlay.tsx) so it floats
-  above the map without blocking interaction. Absolute box, `top`, centered
-  horizontally via `left="50%"` + `transform`.
+- **Self-positioning**, mirroring how
+  [`ControlPanel`](../../examples/_shared/components/control-panel.tsx#L78-L90)
+  places itself: `position="absolute"`, `zIndex={1000}`,
+  `pointerEvents="none"`, centered at top via `left="50%"` + `transform`. No
+  `UIOverlay` wrapper needed — examples drop it in as a sibling of
+  `ControlPanel`.
 - Exported from `examples/_shared/index.ts` alongside the other shared
   components.
 
@@ -108,9 +110,7 @@ return (
       <DeckGlOverlay layers={[cogLayer]} interleaved />
     </MaplibreMap>
 
-    <UIOverlay>
-      <LoadingIndicator loading={loading} />
-    </UIOverlay>
+    <LoadingIndicator loading={loading} />
     {/* existing ControlPanel … */}
   </div>
 );

--- a/dev-docs/specs/2026-07-10-tile-loading-indicator-design.md
+++ b/dev-docs/specs/2026-07-10-tile-loading-indicator-design.md
@@ -1,0 +1,165 @@
+# Tile Loading Indicator for Examples
+
+- **Date:** 2026-07-10
+- **Issues:** [#599](https://github.com/developmentseed/deck.gl-raster/issues/599)
+- **Status:** Approved
+
+## Problem
+
+The example apps give no visual feedback while tiles are fetching. A user
+panning or zooming, or switching data sources, sees stale or blank tiles with no
+indication that work is in progress. Issue #599 asks for a spinner UI element
+that shows when tiles are loading.
+
+## Goals
+
+- A reusable loading indicator, centralized in `examples/_shared`, so the visual
+  is defined once.
+- Wiring that stays **visible in each example** — a reader learning from the
+  examples should be able to see exactly how loading state is derived from
+  deck.gl callbacks, not have it hidden by magic in a shared wrapper.
+- Demonstrate the pattern across the main layer types without editing all ~13
+  example apps.
+
+## Non-Goals
+
+- No changes to library packages (`deck.gl-raster`, `deck.gl-geotiff`,
+  `deck.gl-zarr`). Every layer already forwards the deck.gl `TileLayer`
+  callbacks this design relies on.
+- Not wiring every example — three representative apps only (see Scope).
+- No per-tile progress bar or percentage; a binary loading/idle indicator only.
+
+## Background: the available signal
+
+Every example layer (`COGLayer`, `MosaicLayer`, `ZarrLayer`) extends
+`RasterTileLayer`, which forwards the standard deck.gl `TileLayer` callbacks,
+including `onViewportLoad` — fired when every tile selected for the current
+viewport has resolved ("done").
+
+deck.gl provides **no matching "load started" event**. `Deck`'s `onAfterRender`
+hook exposes only `{ device, gl }`, not the layers, so polling `layer.isLoaded`
+per frame is not available through the public `MapboxOverlay` API.
+
+The "started" edge must therefore be derived from what the example already knows:
+
+- The **map moving** (`onMoveStart` on the MapLibre map) — panning/zooming
+  selects new tiles.
+- A **new load being kicked off** by the app — e.g. the user switching data
+  source.
+
+Resetting to "done" is authoritative via the layer's `onViewportLoad`.
+
+## Design
+
+### Component 1 — `LoadingIndicator` (presentational)
+
+`examples/_shared/components/loading-indicator.tsx`
+
+```tsx
+<LoadingIndicator loading={boolean} label?="Loading tiles…" />
+```
+
+- Renders nothing when `loading` is false.
+- When true: a rounded pill at top-center containing a Chakra `Spinner` and the
+  `label` text (default `"Loading tiles…"`).
+- Contains **no logic** — purely `loading` in, pill out.
+- Positioned inside the existing pointer-events-none
+  [`UIOverlay`](../../examples/_shared/components/ui-overlay.tsx) so it floats
+  above the map without blocking interaction. Absolute box, `top`, centered
+  horizontally via `left="50%"` + `transform`.
+- Exported from `examples/_shared/index.ts` alongside the other shared
+  components.
+
+### Component 2 — `useTilesLoading` (state hook)
+
+`examples/_shared/hooks/use-tiles-loading.ts`
+
+```ts
+const { loading, onViewportLoad, onLoadingStart } = useTilesLoading();
+```
+
+Returns:
+
+- `loading: boolean` — pass to `<LoadingIndicator>`.
+- `onViewportLoad: () => void` — attach to the tile layer's `onViewportLoad`
+  prop. Sets `loading` false. This is the "done" edge.
+- `onLoadingStart: () => void` — call when a new load begins (map `onMoveStart`,
+  or a source-switch handler). Sets `loading` true. This is the "started" edge.
+
+Internals (~15 lines): `useState(true)` — initialized true so the very first
+tile fetch shows the indicator before any move happens. `onLoadingStart` → set
+true; `onViewportLoad` → set false. Both callbacks are stabilized with
+`useCallback` so they are safe to pass as layer/map props.
+
+The hook's docstring documents the non-obvious point: deck.gl has no native
+"load started" event, so callers supply that edge via `onLoadingStart`
+(typically the map's `onMoveStart`).
+
+### How an example wires it
+
+```tsx
+const { loading, onViewportLoad, onLoadingStart } = useTilesLoading();
+
+const cogLayer = new COGLayer({ /* … */, onViewportLoad });
+
+return (
+  <div style={{ position: "relative", width: "100%", height: "100%" }}>
+    <MaplibreMap onMoveStart={onLoadingStart} …>
+      <DeckGlOverlay layers={[cogLayer]} interleaved />
+    </MaplibreMap>
+
+    <UIOverlay>
+      <LoadingIndicator loading={loading} />
+    </UIOverlay>
+    {/* existing ControlPanel … */}
+  </div>
+);
+```
+
+The two deck.gl/map touch-points — `onViewportLoad` on the layer, `onMoveStart`
+on the map — are visible in the example itself. The shared hook only removes the
+copy-pasted `useState` boilerplate; the mechanism a reader needs to understand
+stays in the example file.
+
+## Scope: examples to wire
+
+Three representative apps, one per primary layer type:
+
+1. **`cog-basic`** — `COGLayer` (single COG). Source-switch via the existing
+   dropdown already triggers `fitBounds` → a map move, so `onMoveStart` covers
+   it; no extra source-change wiring needed.
+2. **`naip-mosaic`** — `MosaicLayer`. Note this app already has a separate
+   `loading` state for the STAC index fetch, shown in its `ControlPanel`. The
+   new tile-loading indicator is distinct (named `tilesLoading` locally) and
+   nicely illustrates metadata-loading vs. tile-loading as two concerns.
+3. **`zarr-sentinel2-tci`** — `ZarrLayer`. The layer is created conditionally
+   (`zarrLayer ? [zarrLayer] : []`); `onViewportLoad` attaches to the layer when
+   present.
+
+Other examples can adopt the pattern later by copying these ~3 visible lines.
+
+## Error handling
+
+- `onViewportLoad` fires once the viewport's tiles have settled; a transient
+  tile fetch error does not leave the spinner hung indefinitely because
+  subsequent moves re-trigger `onLoadingStart`/`onViewportLoad`. Per-tile error
+  handling (`onTileError`) is out of scope for this indicator.
+
+## Testing / verification
+
+Examples in this repo are not unit-tested; verification is manual per the repo's
+example workflow:
+
+- `pnpm typecheck` passes for the shared package and the three wired examples.
+- `pnpm biome check` clean.
+- Manual: run each wired example, confirm the pill appears on initial load and
+  on pan/zoom into new tiles, and disappears when tiles finish.
+
+## Files
+
+- **New:** `examples/_shared/components/loading-indicator.tsx`
+- **New:** `examples/_shared/hooks/use-tiles-loading.ts`
+- **Edit:** `examples/_shared/index.ts` (export both)
+- **Edit:** `examples/cog-basic/src/App.tsx`
+- **Edit:** `examples/naip-mosaic/src/App.tsx`
+- **Edit:** `examples/zarr-sentinel2-tci/src/App.tsx`

--- a/examples/_shared/components/loading-indicator.tsx
+++ b/examples/_shared/components/loading-indicator.tsx
@@ -1,0 +1,50 @@
+import { Box, Spinner, Text } from "@chakra-ui/react";
+
+/**
+ * Props for {@link LoadingIndicator}.
+ */
+export interface LoadingIndicatorProps {
+  /** Whether tiles are currently loading. When false, nothing renders. */
+  loading: boolean;
+  /** Text shown beside the spinner. */
+  label?: string;
+}
+
+/**
+ * A top-center pill that appears while map tiles are loading.
+ *
+ * Presentational only — the caller owns the `loading` state (see
+ * `useTilesLoading`). Self-positions above the map (absolute, high z-index,
+ * pointer-events disabled) so it can be dropped in as a sibling of the map and
+ * `ControlPanel` without any wrapper.
+ */
+export function LoadingIndicator({
+  loading,
+  label = "Loading tiles…",
+}: LoadingIndicatorProps) {
+  if (!loading) {
+    return null;
+  }
+  return (
+    <Box
+      position="absolute"
+      top="4"
+      left="50%"
+      transform="translateX(-50%)"
+      display="flex"
+      alignItems="center"
+      gap="2"
+      bg="white"
+      color="gray.800"
+      borderRadius="full"
+      boxShadow="0 2px 8px rgba(0, 0, 0, 0.1)"
+      px="3"
+      py="2"
+      pointerEvents="none"
+      zIndex={1000}
+    >
+      <Spinner size="sm" color="gray.600" />
+      <Text fontSize="sm">{label}</Text>
+    </Box>
+  );
+}

--- a/examples/_shared/hooks/use-tiles-loading.ts
+++ b/examples/_shared/hooks/use-tiles-loading.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Return value of {@link useTilesLoading}.
+ */
+export interface UseTilesLoadingResult {
+  /** Whether tiles are currently loading. Pass to `<LoadingIndicator>`. */
+  loading: boolean;
+  /**
+   * Attach to the tile layer's `onViewportLoad` prop. Fires when every tile
+   * selected for the current viewport has resolved — the "done" edge.
+   */
+  onViewportLoad: () => void;
+  /**
+   * Call when a new load begins — the "started" edge. deck.gl has no native
+   * "load started" event, so the caller supplies it, typically from the map's
+   * `onMoveStart` (panning/zooming selects new tiles) or a source-switch
+   * handler.
+   */
+  onLoadingStart: () => void;
+}
+
+/**
+ * Tracks whether map tiles are currently loading, for a loading indicator.
+ *
+ * Starts in the loading state so the initial tile fetch shows the indicator
+ * before the user moves the map. `onLoadingStart` flips it back on for
+ * subsequent loads; `onViewportLoad` clears it when the viewport settles.
+ */
+export function useTilesLoading(): UseTilesLoadingResult {
+  const [loading, setLoading] = useState(true);
+
+  const onViewportLoad = useCallback(() => {
+    setLoading(false);
+  }, []);
+
+  const onLoadingStart = useCallback(() => {
+    setLoading(true);
+  }, []);
+
+  return { loading, onViewportLoad, onLoadingStart };
+}

--- a/examples/_shared/index.ts
+++ b/examples/_shared/index.ts
@@ -19,4 +19,6 @@ export { ExampleProvider } from "./components/provider.js";
 export type { RangeSliderProps } from "./components/range-slider.js";
 export { RangeSlider } from "./components/range-slider.js";
 export { UIOverlay } from "./components/ui-overlay.js";
+export type { UseTilesLoadingResult } from "./hooks/use-tiles-loading.js";
+export { useTilesLoading } from "./hooks/use-tiles-loading.js";
 export { system } from "./styles/theme.js";

--- a/examples/_shared/index.ts
+++ b/examples/_shared/index.ts
@@ -13,6 +13,8 @@ export { DocsLink, ExternalLink } from "./components/external-link.js";
 export { Field } from "./components/field.js";
 export type { HelpTooltipProps } from "./components/help-tooltip.js";
 export { HelpTooltip } from "./components/help-tooltip.js";
+export type { LoadingIndicatorProps } from "./components/loading-indicator.js";
+export { LoadingIndicator } from "./components/loading-indicator.js";
 export { ExampleProvider } from "./components/provider.js";
 export type { RangeSliderProps } from "./components/range-slider.js";
 export { RangeSlider } from "./components/range-slider.js";

--- a/examples/cog-basic/src/App.tsx
+++ b/examples/cog-basic/src/App.tsx
@@ -7,6 +7,8 @@ import {
   DeckGlOverlay,
   ExternalLink,
   Field,
+  LoadingIndicator,
+  useTilesLoading,
 } from "deck.gl-raster-examples-shared";
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { ReactNode } from "react";
@@ -97,6 +99,7 @@ export default function App() {
     debug: false,
     debugOpacity: 0.25,
   });
+  const { loading, onViewportLoad, onLoadingStart } = useTilesLoading();
 
   const selected = COG_OPTIONS[selectedIndex];
 
@@ -105,6 +108,7 @@ export default function App() {
     geotiff: selected.url,
     debug: debugState.debug,
     debugOpacity: debugState.debugOpacity,
+    onViewportLoad,
     onGeoTIFFLoad: (tiff, options) => {
       (window as unknown as { tiff: unknown }).tiff = tiff;
       const { west, south, east, north } = options.geographicBounds;
@@ -125,6 +129,7 @@ export default function App() {
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       <MaplibreMap
         ref={mapRef}
+        onMoveStart={onLoadingStart}
         initialViewState={{
           longitude: 0,
           latitude: 0,
@@ -136,6 +141,8 @@ export default function App() {
       >
         <DeckGlOverlay layers={[cogLayer]} interleaved />
       </MaplibreMap>
+
+      <LoadingIndicator loading={loading} />
 
       <ControlPanel title="COGLayer Example" sourcePath="examples/cog-basic">
         <Text mb="3" color="gray.600">

--- a/examples/naip-mosaic/src/App.tsx
+++ b/examples/naip-mosaic/src/App.tsx
@@ -15,7 +15,11 @@ import type { GeoTIFFFromUrlOptions, Overview } from "@developmentseed/geotiff";
 import { GeoTIFF } from "@developmentseed/geotiff";
 import type { Device, Texture } from "@luma.gl/core";
 import type { ShaderModule } from "@luma.gl/shadertools";
-import { DeckGlOverlay } from "deck.gl-raster-examples-shared";
+import {
+  DeckGlOverlay,
+  LoadingIndicator,
+  useTilesLoading,
+} from "deck.gl-raster-examples-shared";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { MapRef } from "react-map-gl/maplibre";
@@ -336,6 +340,11 @@ export default function App() {
   const [stacItems, setStacItems] = useState<PartialSTACItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const {
+    loading: tilesLoading,
+    onViewportLoad,
+    onLoadingStart,
+  } = useTilesLoading();
   const [renderMode, setRenderMode] = useState<RenderMode>("trueColor");
   const [ndviRange, setNdviRange] = useState<[number, number]>([-1, 1]);
   const [device, setDevice] = useState<Device | null>(null);
@@ -441,6 +450,7 @@ export default function App() {
       // COGLayer instance, and opened GeoTIFFs are already kept in the
       // module-level `geotiffCache`, so there's nothing cheap to retain here.
       maxCacheSize: 0,
+      onViewportLoad,
       // @ts-expect-error beforeId is injected by @deck.gl/mapbox; LayerProps
       // doesn't know about it.
       beforeId: "boundary_country_outline",
@@ -452,6 +462,7 @@ export default function App() {
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       <MaplibreMap
         ref={mapRef}
+        onMoveStart={onLoadingStart}
         initialViewState={{
           longitude: -104.9903,
           latitude: 39.7392,
@@ -472,6 +483,8 @@ export default function App() {
           onDeviceInitialized={setDevice}
         />
       </MaplibreMap>
+
+      <LoadingIndicator loading={tilesLoading} />
 
       <ControlPanel
         loading={loading}

--- a/examples/zarr-sentinel2-tci/src/App.tsx
+++ b/examples/zarr-sentinel2-tci/src/App.tsx
@@ -7,6 +7,8 @@ import {
   ControlPanel,
   DebugControls,
   DeckGlOverlay,
+  LoadingIndicator,
+  useTilesLoading,
 } from "deck.gl-raster-examples-shared";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useEffect, useRef, useState } from "react";
@@ -95,6 +97,7 @@ export default function App() {
     debugOpacity: 0.25,
   });
   const [node, setNode] = useState<zarr.Group<zarr.Readable> | null>(null);
+  const { loading, onViewportLoad, onLoadingStart } = useTilesLoading();
 
   // Open the store ourselves so we own version/consolidation decisions,
   // then hand the Group to the layer.
@@ -124,6 +127,7 @@ export default function App() {
         renderTile,
         debug: debugState.debug,
         debugOpacity: debugState.debugOpacity,
+        onViewportLoad,
       })
     : null;
 
@@ -131,6 +135,7 @@ export default function App() {
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       <MaplibreMap
         ref={mapRef}
+        onMoveStart={onLoadingStart}
         initialViewState={{
           longitude: -74,
           latitude: 41,
@@ -140,6 +145,8 @@ export default function App() {
       >
         <DeckGlOverlay layers={zarrLayer ? [zarrLayer] : []} interleaved />
       </MaplibreMap>
+
+      <LoadingIndicator loading={loading} />
 
       <ControlPanel
         title="ZarrLayer — Sentinel-2 TCI"


### PR DESCRIPTION
Closes #599.

Adds a UI element to the examples that shows when map tiles are loading.

## What

- **`LoadingIndicator`** (`examples/_shared/components/loading-indicator.tsx`) — a presentational top-center pill (spinner + "Loading tiles…"). Self-positions above the map like `ControlPanel`; renders nothing when not loading.
- **`useTilesLoading`** (`examples/_shared/hooks/use-tiles-loading.ts`) — a thin hook returning `{ loading, onViewportLoad, onLoadingStart }`. Starts in the loading state so the first fetch shows the indicator; `onViewportLoad` clears it ("done"), `onLoadingStart` re-arms it ("started").

deck.gl exposes `onViewportLoad` (the "done" edge) but has no native "load started" event, so each example supplies that edge via the map's `onMoveStart`. The wiring is left visible in each example so a reader can see exactly how loading state is derived from deck.gl callbacks.

## Wired into (representative of each layer type)

- `cog-basic` — `COGLayer`
- `naip-mosaic` — `MosaicLayer` (distinct from its existing STAC-index `loading` state)
- `zarr-sentinel2-tci` — `ZarrLayer`

Other examples can adopt the pattern by copying the ~3 visible lines.

## Verification

Ran `cog-basic` in headless Chrome (SwiftShader): the pill appears mid-load and disappears once the COG renders (confirming `onViewportLoad` fires and the indicator doesn't hang). Full monorepo `pnpm typecheck`, `pnpm test`, and `biome check` pass.

---
Written by Claude on behalf of @kylebarron