### PR TITLE
fix: Allow MultiCOGLayer sampler to be overridden from default `linear`

### DIFF
--- a/packages/deck.gl-geotiff/src/multi-cog-layer.ts
+++ b/packages/deck.gl-geotiff/src/multi-cog-layer.ts
@@ -48,7 +48,7 @@ import {
   metersPerUnit,
   parseWkt,
 } from "@developmentseed/proj";
-import type { Device, TextureFormat } from "@luma.gl/core";
+import type { Device, SamplerProps, TextureFormat } from "@luma.gl/core";
 import { Texture } from "@luma.gl/core";
 import proj4 from "proj4";
 import { DEFAULT_CONCURRENCY_LIMITER } from "./default-concurrency-limiter.js";
@@ -184,6 +184,17 @@ export type MultiCOGLayerProps = CompositeLayerProps &
      * @see {@link RasterModule}
      */
     renderPipeline?: RasterModule[];
+
+    /**
+     * Sampler used for each band's GPU texture.
+     *
+     * Linear blends real data with nodata/out-of-bounds fill at mask, tile,
+     * and dataset edges. Use nearest to avoid that blending, at the cost of
+     * blocky pixels when zoomed in past native resolution.
+     *
+     * @default { minFilter: "linear", magFilter: "linear" }
+     */
+    bandSampler?: SamplerProps;
 
     /**
      * EPSG code resolver used to look up projection definitions for numeric
@@ -725,7 +736,11 @@ export class MultiCOGLayer extends RasterTileLayer<
       signal,
     });
 
-    const texture = createBandTexture(device, tile.array);
+    const texture = createBandTexture(
+      device,
+      tile.array,
+      this.props.bandSampler,
+    );
     const arr = tile.array;
     const byteLength =
       arr.layout === "pixel-interleaved"
@@ -832,7 +847,11 @@ export class MultiCOGLayer extends RasterTileLayer<
       minRow: resolution.minRow,
     });
 
-    const texture = createBandTexture(device, assembled);
+    const texture = createBandTexture(
+      device,
+      assembled,
+      this.props.bandSampler,
+    );
     const assembledByteLength =
       assembled.layout === "pixel-interleaved"
         ? assembled.data.byteLength
@@ -1024,7 +1043,11 @@ function selectImage(geotiff: GeoTIFF, z: number): GeoTIFF | Overview {
  *
  * TODO: use `inferTextureFormat` from `texture.ts` for full format support.
  */
-function createBandTexture(device: Device, array: RasterArray): Texture {
+function createBandTexture(
+  device: Device,
+  array: RasterArray,
+  sampler: SamplerProps = { minFilter: "linear", magFilter: "linear" },
+): Texture {
   if (array.layout !== "pixel-interleaved") {
     throw new Error("Band-separate layout not yet supported in MultiCOGLayer");
   }
@@ -1048,7 +1071,7 @@ function createBandTexture(device: Device, array: RasterArray): Texture {
     format,
     width,
     height,
-    sampler: { minFilter: "linear", magFilter: "linear" },
+    sampler,
   });
 }
 


### PR DESCRIPTION
Related to https://github.com/developmentseed/deck.gl-raster/issues/215#issuecomment-5403656790

Can be simply used like

```tsx
new MultiCOGLayer({
  ...
  bandSampler: { minFilter: "nearest", magFilter: "nearest" },
}),
```

| Before (Linear sampler - blurred, with artifacts) | After (Nearest sampler - sharp, clean) |
|---|---|
| ![Before 1](https://github.com/user-attachments/assets/80677cc9-ec30-40f3-9709-07d261b935e5) | ![After 1](https://github.com/user-attachments/assets/9660e925-62e1-4e5b-84d5-2a49bb1f7182) |
| ![Before 2](https://github.com/user-attachments/assets/dd0a5409-be21-4205-8f91-6dd121d0cadd) | ![After 2](https://github.com/user-attachments/assets/3f3be2ee-b1b0-4b08-9d1d-bd63e7607017) |
